### PR TITLE
feat: adding className pass-through to .modal-dialog element

### DIFF
--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -174,7 +174,7 @@ class Modal extends React.Component {
 
   renderModal() {
     const { open } = this.state;
-    const { renderHeaderCloseButton } = this.props;
+    const { renderHeaderCloseButton, dialogClassName } = this.props;
 
     return (
       <div>
@@ -201,9 +201,12 @@ class Modal extends React.Component {
           onMouseDown={this.close}
         >
           <div
-            className={classNames({
-              'modal-dialog': open,
-            })}
+            className={classNames(
+              {
+                'modal-dialog': open,
+              },
+              dialogClassName,
+            )}
             role="dialog"
             aria-modal
             aria-labelledby={this.headerId}
@@ -280,6 +283,10 @@ Modal.propTypes = {
   }),
   /** specifies whether a close button is rendered in the modal header. It defaults to true. */
   renderHeaderCloseButton: PropTypes.bool,
+  /**
+   * Specifies optional classes to add to the element with the '.modal-dialog' class.  See Bootstrap documentation for possible classes.  Some options: modal-lg, modal-sm, modal-dialog-centered
+   */
+  dialogClassName: PropTypes.string,
 };
 
 Modal.defaultProps = {
@@ -289,6 +296,7 @@ Modal.defaultProps = {
   closeText: 'Close',
   variant: {},
   renderHeaderCloseButton: true,
+  dialogClassName: undefined,
 };
 
 


### PR DESCRIPTION
The `.modal-dialog` part of a Modal has a few optional classes you can add to it to change its styling a bit.  Most notably, this is where you use `modal-lg` and `modal-sm` to change the Modal's width.

This PR lets you use those.

I named the prop `dialogClassName` because it's only pertinent to the 'modal-dialog' element, and because that wasn't the top-most element in a modal.  Seemed wrong to call it `className` when we may want other pass-throughs as well.