### PR TITLE
fix: remove aria label not needed

### DIFF
--- a/src/Breadcrumb/index.jsx
+++ b/src/Breadcrumb/index.jsx
@@ -26,7 +26,7 @@ const Breadcrumbs = ({
               )}
           </React.Fragment>
         ))}
-              {activeLabel && <li className="list-inline-item active" key="active" aria-current="page">{activeLabel}</li>}
+        {activeLabel && <li className="list-inline-item active" key="active" aria-current="page">{activeLabel}</li>}
       </ol>
     </nav>
   );


### PR DESCRIPTION
There is a `<li>` in the breadcrumbs which looks like this in the DOM:

`<li class="list-inline-item" role="presentation" aria-label="spacer"></li>`

The problem here is that role="presentation" means "screen readers should ignore this", which is counter to the purpose of an aria-label. Can consider removing the aria-label.