### PR TITLE
fix: show correct mobile typography on docs site

### DIFF
--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -29,6 +29,10 @@
   @include mobile-type;
 }
 
+.mobile-type {
+  @include mobile-type;
+}
+
 .heading-label {
   text-transform: uppercase;
   font-family: $font-family-monospace;

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -111,12 +111,11 @@ export default function TypographyPage() {
               </td>
             </tr>
             <tr>
-              <td colSpan="2">
+              <td colSpan="3">
                 <MeasuredItem {...measuredTypeProps}>
                   <p className="m-0">Body</p>
                 </MeasuredItem>
               </td>
-              <td />
             </tr>
             <tr>
               <td colSpan="2">


### PR DESCRIPTION
Adds `.mobile-type` classname such that the mobile heading/display sizes visually match their specified sizes.

![image](https://user-images.githubusercontent.com/2828721/137408573-4ca5294b-8726-4317-b96c-3f3ada627e91.png)

https://deploy-preview-832--paragon-edx.netlify.app/foundations/typography
https://deploy-preview-832--paragon-openedx.netlify.app/foundations/typography
