### PR TITLE
feat: create card header

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ const MyComponent = ({ children, className }) => {
 
 MyComponent.propTypes = {
   className: PropTypes.string.isRequired,
+  children: Proptypes.node.isRequired,
 }
 
 export default MyComponent;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -8,3 +8,48 @@
     flex: 1 0 auto;
   }
 }
+
+.pgn__card-header {
+  padding: 0 $card-spacer-x;
+  display: flex;
+  justify-content: space-between;
+
+  .pgn__card-header-content {
+    display: flex;
+    flex-direction: column;
+    margin-top: map_get($spacers, 4);
+    overflow: auto;
+  } 
+
+  .pgn__card-header-title {
+    color: $black;
+    font-weight: $font-weight-bold;
+  }
+  .pgn__card-header-title-sm {
+    @extend .pgn__card-header-title;
+    font-size: $h4-font-size;
+  }
+  .pgn__card-header-title-md {
+    @extend .pgn__card-header-title;
+    font-size: $h3-font-size;
+  }
+
+  .pgn__card-header-subtitle {
+    color: $gray-700;
+    margin-top: map_get($spacers, 1);
+  }
+  .pgn__card-header-subtitle-sm {
+    @extend .pgn__card-header-subtitle;
+    font-size: $h5-font-size;
+  }
+  .pgn__card-header-subtitle-md {
+    @extend .pgn__card-header-subtitle;
+    font-size: $h4-font-size;
+  }
+
+  .pgn__card-header-actions {
+    margin-top: $spacer;
+    margin-left: $spacer;
+    flex-shrink: 0;
+  }
+}

--- a/src/Card/CardHeader.jsx
+++ b/src/Card/CardHeader.jsx
@@ -1,0 +1,66 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const CardHeader = React.forwardRef(({
+  actions,
+  className,
+  size,
+  subtitle,
+  title,
+}, ref) => {
+  const cloneActions = useCallback(
+    (Action) => {
+      if (React.isValidElement(Action)) {
+        const { children } = Action.props;
+        const addtlActionProps = {
+          size,
+          children: Array.isArray(children) ? children.map(cloneActions) : cloneActions(children),
+        };
+        return React.cloneElement(Action, addtlActionProps);
+      }
+
+      return Action;
+    },
+    [size],
+  );
+
+  return (
+    <div className={classNames('pgn__card-header', className)} ref={ref}>
+      <div className="pgn__card-header-content">
+        {title && <div className={`pgn__card-header-title-${size}`}>{title}</div>}
+        {subtitle && <div className={`pgn__card-header-subtitle-${size}`}>{subtitle}</div>}
+      </div>
+      {actions
+        && (
+        <div className="pgn__card-header-actions">
+          {size !== 'md' ? cloneActions(actions) : actions}
+        </div>
+        )}
+    </div>
+  );
+});
+
+CardHeader.propTypes = {
+  /** Optional node to render on the top right of the card header,
+   *  i.e. ActionRow or a DropdownMenu.
+   * */
+  actions: PropTypes.node,
+  /** The class name for the CardHeader component */
+  className: PropTypes.string,
+  /** The title for the CardHeader component */
+  title: PropTypes.node.isRequired,
+  /** The size of the CardHeader component */
+  size: PropTypes.oneOf(['sm', 'md']),
+  /** The subtitle of the CardHeader component */
+  subtitle: PropTypes.node,
+};
+
+CardHeader.defaultProps = {
+  actions: null,
+  className: null,
+  size: 'md',
+  subtitle: null,
+};
+
+export default CardHeader;

--- a/src/Card/CardHeader.test.jsx
+++ b/src/Card/CardHeader.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Button from '../Button';
+import CardHeader from './CardHeader';
+
+describe('<CardHeader />', () => {
+  it('renders with title prop', () => {
+    const tree = renderer.create((
+      <CardHeader title="Title" />
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with title and subtitle prop', () => {
+    const tree = renderer.create((
+      <CardHeader title="Title" subtitle="Subtitle" />
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with actions', () => {
+    const tree = renderer.create((
+      <CardHeader
+        title="Title"
+        subtitle="Subtitle"
+        actions={
+          <Button>Action</Button>
+      }
+      />
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -3,6 +3,7 @@ title: 'Card'
 type: 'component'
 components:
 - Card
+- CardHeader
 - CardGrid
 categories:
 - Content
@@ -36,6 +37,93 @@ notes: |
 </Card>
 ```
 
+### Header
+You may add a header by adding a ``Card.Header`` component.
+This header displays a title, subtitle, and may contain actions.
+
+```jsx live
+<div>
+  <Card>
+    <Card.Header 
+      title="Title"
+    />
+  </Card>
+  <Card className="mt-1">
+    <Card.Header 
+      title="Title"
+      subtitle="Subtitle"
+    />
+  </Card>
+</div>
+```
+
+#### Actions
+The CardHeader supports custom actions via the the actions prop and renders them on the top right of the header.
+
+```jsx live
+<div>
+  <Card>
+    <Card.Header
+      title="Title"
+      subtitle="Subtitle"
+      actions={
+        <ActionRow>
+          <Button>Action</Button>
+        </ActionRow>
+      } 
+    />
+  </Card>
+  <Card className="mt-1">
+    <Card.Header
+      title="Title"
+      subtitle="Subtitle"
+      actions={
+        <>
+          <ExtraSmall>
+            <IconButton
+              icon={FontAwesome.faBars}
+              alt="Menu"
+              onClick={() => console.log("You clicked the menu button")}
+              variant="primary"
+            />
+          </ExtraSmall>
+          <LargerThanExtraSmall>
+            <ActionRow>
+              <Button>Action 1</Button>
+              <Button variant="secondary">Action 2</Button>
+              <IconButton
+                icon={FontAwesome.faBars}
+                alt="Menu"
+                onClick={() => console.log("You clicked the menu button")}
+                variant="primary"
+              />
+            </ActionRow>
+          </LargerThanExtraSmall>
+        </>
+      } 
+    />
+  </Card>
+</div>
+```
+
+#### Sizes
+The CardHeader supports two size variants, ``"sm"`` and ``"md"``. 
+Add ``size="sm"`` for smaller header content and actions.
+
+```jsx live
+<Card>
+  <Card.Header
+    title="Title"
+    subtitle="Subtitle"
+    actions={
+      <ActionRow>
+        <Button>Action</Button>
+      </ActionRow>
+    }
+    size="sm"
+  />
+</Card>
+```
 ### CardGrid
 
 This component displays a collection of Cards as a grid (with customizable responsive behavior), where

--- a/src/Card/__snapshots__/CardHeader.test.jsx.snap
+++ b/src/Card/__snapshots__/CardHeader.test.jsx.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CardHeader /> renders with actions 1`] = `
+<div
+  className="pgn__card-header"
+>
+  <div
+    className="pgn__card-header-content"
+  >
+    <div
+      className="pgn__card-header-title-md"
+    >
+      Title
+    </div>
+    <div
+      className="pgn__card-header-subtitle-md"
+    >
+      Subtitle
+    </div>
+  </div>
+  <div
+    className="pgn__card-header-actions"
+  >
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="button"
+    >
+      Action
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<CardHeader /> renders with title and subtitle prop 1`] = `
+<div
+  className="pgn__card-header"
+>
+  <div
+    className="pgn__card-header-content"
+  >
+    <div
+      className="pgn__card-header-title-md"
+    >
+      Title
+    </div>
+    <div
+      className="pgn__card-header-subtitle-md"
+    >
+      Subtitle
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CardHeader /> renders with title prop 1`] = `
+<div
+  className="pgn__card-header"
+>
+  <div
+    className="pgn__card-header-content"
+  >
+    <div
+      className="pgn__card-header-title-md"
+    >
+      Title
+    </div>
+  </div>
+</div>
+`;

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -1,7 +1,12 @@
-export { default } from 'react-bootstrap/Card';
+import Card from 'react-bootstrap/Card';
+import CardHeader from './CardHeader';
+
 export { default as CardColumns } from 'react-bootstrap/CardColumns';
 export { default as CardDeck } from 'react-bootstrap/CardDeck';
 export { default as CardImg } from 'react-bootstrap/CardImg';
 export { default as CardGroup } from 'react-bootstrap/CardGroup';
 
 export { default as CardGrid } from './CardGrid';
+
+Card.Header = CardHeader;
+export default Card;


### PR DESCRIPTION
https://deploy-preview-834--paragon-edx.netlify.app/components/card/
https://deploy-preview-834--paragon-edx.netlify.app/components/card/

We could overwrite Card.Header on the Card export. Left it alone for now in case Card.Header is being used already.