### PR TITLE
fix: remove leading and trailing spaces on StatefulButton label

### DIFF
--- a/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
+++ b/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
@@ -14,9 +14,7 @@ exports[`StatefulButton renders basic usage 1`] = `
       className="d-flex align-items-center justify-content-center"
     >
       <span>
-         
         Saved
-         
       </span>
     </span>
   </button>
@@ -56,9 +54,7 @@ exports[`StatefulButton renders basic usage 1`] = `
         </span>
       </span>
       <span>
-         
         Saving
-         
       </span>
     </span>
   </button>
@@ -98,9 +94,7 @@ exports[`StatefulButton renders basic usage 1`] = `
         </span>
       </span>
       <span>
-         
         Saved
-         
       </span>
     </span>
   </button>
@@ -130,9 +124,7 @@ Array [
         />
       </span>
       <span>
-         
         Download
-         
       </span>
     </span>
   </button>,
@@ -157,9 +149,7 @@ Array [
         />
       </span>
       <span>
-         
         Downloading
-         
       </span>
     </span>
   </button>,
@@ -184,9 +174,7 @@ Array [
         />
       </span>
       <span>
-         
         Downloaded
-         
       </span>
     </span>
   </button>,
@@ -216,9 +204,7 @@ Array [
         />
       </span>
       <span>
-         
         Save (no changes)
-         
       </span>
     </span>
   </button>,
@@ -243,9 +229,7 @@ Array [
         />
       </span>
       <span>
-         
         Save Changes
-         
       </span>
     </span>
   </button>,

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -96,7 +96,7 @@ function StatefulButton({
     >
       <span className="d-flex align-items-center justify-content-center">
         {icon && <span className={classNames({ 'pgn__stateful-btn-icon': !!label })}>{icon}</span>}
-        {label ? <span> {label} </span> : <span className="sr-only"> {state} </span>}
+        {label ? <span>{label}</span> : <span className="sr-only">{state}</span>}
       </span>
     </Button>
   );


### PR DESCRIPTION
When upgrading `@edx/paragon` in an MFE, it was noticed that a leading/trailing space was added to `StatefulButton` labels. This PR removes those spaces as they're not needed and causes tests to fail in consuming MFEs.