### PR TITLE
fix: datetime ui cross browser issues

### DIFF
--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -231,7 +231,12 @@ $select-icon-padding: .5625rem !default;
 }
 
 .pgn__form-control-decorator-group.has-floating-label {
-  .form-control:not(.has-value) {
+
+  input[type='date']:not(:focus):not(.has-value),
+  input[type='time']:not(:focus):not(.has-value) {
+    color: transparent;
+  }
+  .form-control:not(:focus):not(.has-value) {
     &::placeholder,
     &::-webkit-datetime-edit {
       opacity: 0;


### PR DESCRIPTION
Ticket IDs: https://openedx.atlassian.net/browse/TNL-8811, https://openedx.atlassian.net/browse/TNL-8805

Description: placeholder and labels were overlapping firefox in case of date and time input fields.
helper text was not visible in chrome in the case of date and time input fields. both of these issues are resolved in this PR.
