### PR TITLE
build: rename analysis output file to dependent-usage.json

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -1,6 +1,8 @@
 name: Analyze Dependents
 
-on: [pull_request]
+on:
+  schedule:
+  - cron: "0 0 * * *" # daily
 
 jobs:
   # clones known dependent Git repositories from Open edX


### PR DESCRIPTION
Follow-up from https://github.com/edx/paragon/pull/841 to rename the dependent usage analysis output file to dependent-usage.json to overwrite the original file so that the `-v2` name is no longer necessary.