### PR TITLE
build: remove PULL_REQUEST config and update cron schedule

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -2,7 +2,7 @@ name: Analyze Dependents
 
 on:
   schedule:
-  - cron: "0 0 * * *" # daily
+  - cron: "0 14 * * *" # daily at 10am EST (Github Actions works with UTC)
 
 jobs:
   # clones known dependent Git repositories from Open edX
@@ -260,4 +260,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.EDX_NETLIFY_PAT }}
         MERGE_METHOD: squash
-        PULL_REQUEST: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
On the first scheduled run of the analyze-dependents.yml Github Action workflow, an error occurred when attempting to automerge the generated PR:

![image](https://user-images.githubusercontent.com/2828721/138103653-dccf64ca-ae6e-4063-9a21-af7d5d389d3c.png)

After some [searching](https://githubmemory.com/repo/pascalgn/automerge-action/issues/161), it seems the fix may be to remove the `PULL_REQUEST` configuration 🤞 

Also updates the cron schedule to run at 10am EST instead of at 8pm.