### PR TITLE
build: use shared browserslist config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,6 +1212,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
+    },
     "@edx/eslint-config": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.0.0",
+    "@edx/browserslist-config": "1.0.0",
     "@edx/eslint-config": "^1.1.6",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
@@ -126,8 +127,7 @@
     ]
   },
   "browserslist": [
-    "last 2 versions",
-    "not ie < 11"
+    "extends @edx/browserslist-config"
   ],
   "husky": {
     "hooks": {


### PR DESCRIPTION
* Removes custom `browserslist` configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).

This change reduces the resultant asset bundle size.