### PR TITLE
[BD-46] feat: Make BulkAction buttons more configurable

### DIFF
--- a/src/DataTable/BulkActions.jsx
+++ b/src/DataTable/BulkActions.jsx
@@ -19,16 +19,7 @@ const BulkActions = ({ className }) => {
     tableInstance,
   };
 
-  if (typeof bulkActions === 'function') {
-    return <div className={classNames('pgn__bulk-actions', className)}>{bulkActions(args)}</div>;
-  }
-
-  const actions = bulkActions.map(action => {
-    if (typeof action === 'function') {
-      return action(args);
-    }
-    return action;
-  });
+  const actions = bulkActions.map(action => ({ component: action, args }));
 
   return (
     <Actions

--- a/src/DataTable/BulkActions.jsx
+++ b/src/DataTable/BulkActions.jsx
@@ -19,6 +19,10 @@ const BulkActions = ({ className }) => {
     tableInstance,
   };
 
+  if (typeof bulkActions === 'function') {
+    return <div className={classNames('pgn__bulk-actions', className)}>{bulkActions(args)}</div>;
+  }
+
   const actions = bulkActions.map(action => ({ component: action, args }));
 
   return (

--- a/src/DataTable/CollapsibleButtonGroup.jsx
+++ b/src/DataTable/CollapsibleButtonGroup.jsx
@@ -54,10 +54,11 @@ const CollapsibleButtonGroup = ({
             id="actions-dropdown"
           />
           <Dropdown.Menu alignRight>
-            {dropdownActions.map(action => React.cloneElement(
+            {dropdownActions.map((action, index) => React.cloneElement(
               action.component,
               {
-                key: action,
+                // eslint-disable-next-line react/no-array-index-key
+                key: `${action}${index}`,
                 as: Dropdown.Item,
                 ...action.args,
               },
@@ -65,10 +66,11 @@ const CollapsibleButtonGroup = ({
           </Dropdown.Menu>
         </Dropdown>
       )}
-      {visibleActions.map(action => React.cloneElement(
+      {visibleActions.map((action, index) => React.cloneElement(
         action.component,
         {
-          key: action,
+          // eslint-disable-next-line react/no-array-index-key
+          key: `${action}${index}`,
           as: action.component.props?.as || Button,
           ...action.args,
         },

--- a/src/DataTable/CollapsibleButtonGroup.jsx
+++ b/src/DataTable/CollapsibleButtonGroup.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import DataTableContext from './DataTableContext';
 import { MoreVert } from '../../icons';
 import {
-  Dropdown, useWindowSize, Icon, IconButton, breakpoints,
+  Dropdown, useWindowSize, Icon, IconButton, breakpoints, Button,
 } from '..';
 
 export const DROPDOWN_BUTTON_TEXT = 'More actions';
@@ -54,11 +54,25 @@ const CollapsibleButtonGroup = ({
             id="actions-dropdown"
           />
           <Dropdown.Menu alignRight>
-            {dropdownActions.map(action => action.component({ as: Dropdown.Item, ...action.args }))}
+            {dropdownActions.map(action => React.cloneElement(
+              action.component,
+              {
+                key: action,
+                as: Dropdown.Item,
+                ...action.args,
+              },
+            ))}
           </Dropdown.Menu>
         </Dropdown>
       )}
-      {visibleActions.map(action => action.component(action.args))}
+      {visibleActions.map(action => React.cloneElement(
+        action.component,
+        {
+          key: action,
+          as: action.component.props?.as || Button,
+          ...action.args,
+        },
+      ))}
     </div>
   );
 };

--- a/src/DataTable/CollapsibleButtonGroup.jsx
+++ b/src/DataTable/CollapsibleButtonGroup.jsx
@@ -1,11 +1,10 @@
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 import DataTableContext from './DataTableContext';
 import { MoreVert } from '../../icons';
 import {
-  Button, Dropdown, useWindowSize, Icon, IconButton, breakpoints,
+  Dropdown, useWindowSize, Icon, IconButton, breakpoints,
 } from '..';
 
 export const DROPDOWN_BUTTON_TEXT = 'More actions';
@@ -14,7 +13,6 @@ export const SMALL_SCREEN_DROPDOWN_BUTTON_TEXT = 'Actions';
 const CollapsibleButtonGroup = ({
   className,
   actions,
-  tableInstance,
 }) => {
   const {
     controlledTableSelections: [{ isEntireTableSelected }],
@@ -38,20 +36,6 @@ const CollapsibleButtonGroup = ({
     return [firstTwoActions.reverse(), extraActions];
   }, [actions, width]);
 
-  const handleClick = useCallback(
-    (action) => {
-      const args = { selectedRows };
-      if (isEntireTableSelected) {
-        args.isEntireTableSelected = isEntireTableSelected;
-      }
-      if (tableInstance) {
-        args.tableInstance = tableInstance;
-      }
-      action.handleClick(args);
-    },
-    [isEntireTableSelected, selectedRows, tableInstance],
-  );
-
   if (!isEntireTableSelected && !selectedRows) {
     return null;
   }
@@ -70,58 +54,27 @@ const CollapsibleButtonGroup = ({
             id="actions-dropdown"
           />
           <Dropdown.Menu alignRight>
-            {dropdownActions.map((action) => (
-              <Dropdown.Item
-                className={action.className}
-                key={action.buttonText}
-                onClick={() => handleClick(action)}
-                disabled={action.disabled}
-              >
-                {action.buttonText}
-              </Dropdown.Item>
-            ))}
+            {dropdownActions.map(action => action.component({ as: Dropdown.Item, ...action.args }))}
           </Dropdown.Menu>
         </Dropdown>
       )}
-      {visibleActions.map((action, idx) => {
-        let { variant } = action;
-        if (!variant) {
-          // use the variant defined on the button if it exists, if not, use these styles.
-          variant = (idx === 1 && visibleActions.length === 2) ? 'brand' : 'outline-primary';
-        }
-        return (
-          <Button
-            variant={variant}
-            className={classNames('pgn__data-table__action-btn', action.className)}
-            onClick={() => handleClick(action)}
-            key={action.buttonText}
-            disabled={action.disabled}
-          >
-            {action.buttonText}
-          </Button>
-        );
-      })}
+      {visibleActions.map(action => action.component(action.args))}
     </div>
   );
 };
 
 CollapsibleButtonGroup.defaultProps = {
   className: null,
-  tableInstance: null,
 };
 
 CollapsibleButtonGroup.propTypes = {
   /** class names for the div wrapping the button components */
   className: PropTypes.string,
-  // eslint-disable-next-line react/forbid-prop-types
   actions: PropTypes.arrayOf(PropTypes.shape({
-    className: PropTypes.string,
-    handleClick: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
-    buttonText: PropTypes.string.isRequired,
+    component: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    args: PropTypes.object,
   })).isRequired,
-  /** useTable instance */
-  tableInstance: PropTypes.shape(),
 };
 
 export default CollapsibleButtonGroup;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -28,6 +28,13 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 .pgn__table-actions {
   display: flex;
   margin-left: map_get($spacers, 2);
+
+  .btn {
+    margin-left: map_get($spacers, 1);
+    :first-child {
+      margin-left: 0;
+    }
+  }
 }
 
 .pgn__data-table-dataview-toggle {

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -237,6 +237,25 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
     Cell: DataTable.ControlledSelect,
     disableSortBy: true,
   };
+
+  const DownloadCSVAction = ({ as: Component, selectedFlatRows, ...rest }) => (
+    <Component onClick={() => console.log('Download CSV', selectedFlatRows, rest)}>
+      Download CSV
+    </Component>
+  );
+
+  const ClearAction = ({ as: Component, tableInstance, ...rest }) => (
+    <Component
+      variant="danger"
+      onClick={() => {
+        console.log('Clear Selection');
+        tableInstance.clearSelection();
+      }}
+    >
+      Clear Selection
+    </Component>
+  );
+  
   return (
     <DataTable
       isSelectable
@@ -275,27 +294,8 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
         },
       ]}
       bulkActions={[
-        ({ as, selectedFlatRows }) => React.createElement(
-          as || Button,
-          {
-            key: 'Download CSV',
-            onClick: () => console.log('Download CSV', selectedFlatRows),
-            className: as ? '' : 'ml-2',
-          },
-          'Download CSV',
-        ),
-        ({ as, selectedFlatRows, tableInstance }) => React.createElement(
-          as || Button,
-          {
-            key: 'Clear Selection',
-            onClick: () => {
-              console.log('Clear Selection');
-              tableInstance.clearSelection();
-            },
-            className: as ? '' : 'ml-2',
-          },
-          'Clear Selection',
-        )
+        <DownloadCSVAction />,
+        <ClearAction />,
       ]}
     />
   );
@@ -646,37 +646,31 @@ You can pass a function to render custom components for bulk actions and table a
 
 ```jsx live
 () => {
-  const TableAction = (props) => React.createElement(
-    props.as || Button,
-    {
-      key: 'Table Action',
-      onClick: () => console.log('Table Action', props.selectedFlatRows),
-      className: props.as ? "" : "ml-2",
-    },
-    'Table Action'
+  const TableAction = ({ as: Component, ...rest }) => (
+    // Here is access to the tableInstance
+    // Pass `as` like in the example bellow for the proper display in the toggled variant
+    <Component onClick={() => console.log('TableAction', rest)}>
+      Enroll
+    </Component>
   );
   
-  const AssignAction = (props) => React.createElement(
+  const EnrollAction = ({ as: Component, selectedFlatRows, ...rest }) => (
     // Here is access to the selectedFlatRows, isEntireTableSelected, tableInstance
-    // Pass `as` like in the example bellow for the proper display in the toggled variant
-    props.as || Button,
-    {
-      key: 'Assign',
-      onClick: () => console.log('Assign', props.selectedFlatRows),
-      className: props.as ? "" : "ml-2",
-    },
-    'Assign'
+    <Component variant="danger" onClick={() => console.log('Enroll', selectedFlatRows, rest)}>
+      Enroll ({selectedFlatRows.length})
+    </Component>
   );
 
-  const EnrollAction = (props) => React.createElement(
-    props.as || Button,
-    {
-      key: 'Enroll',
-      variant: 'danger',
-      onClick: () => console.log('Enroll', props.selectedFlatRows),
-      className: props.as ? '' : 'ml-2',
-    },
-    'Enroll'
+  const AssignAction = ({ as: Component, selectedFlatRows, ...rest }) => (
+    <Component onClick={() => console.log('Assign', selectedFlatRows, rest)}>
+      Assign ({selectedFlatRows.length})
+    </Component>
+  );
+  
+  const ExtraAction = ({ text, as: Component, selectedFlatRows, ...rest }) => (
+    <Component onClick={() => console.log(`Extra Action ${text}`, selectedFlatRows, rest)}>
+      {`Extra Action ${text}`}
+    </Component>
   );
   
   return (
@@ -684,29 +678,14 @@ You can pass a function to render custom components for bulk actions and table a
       isSelectable
       itemCount={7}
       tableActions={[
-        TableAction,
+        <TableAction />,
       ]}
       bulkActions={[
-        AssignAction,
-        EnrollAction,
-        ({ as, selectedFlatRows }) => React.createElement(
-          as || Button,
-          {
-            key: 'Extra action 1',
-            onClick: () => console.log('Extra action 1', selectedFlatRows),
-            className: as ? "" : "ml-2",
-          },
-          'Extra action 1'
-        ),
-        ({ as, selectedFlatRows }) => React.createElement(
-          as || Button,
-          {
-            key: 'Extra action 2',
-            onClick: () => console.log('Extra action 2', selectedFlatRows),
-            className: as ? "" : "ml-2",
-          },
-          'Extra action 2'
-        )
+        <EnrollAction />,
+        // Default value for `as` property is `Button`
+        <AssignAction as={Button} />,
+        <ExtraAction text="1" />,
+        <ExtraAction text="2" />,
       ]}
       additionalColumns={[
         {
@@ -785,37 +764,31 @@ You can pass a function to render custom components for bulk actions and table a
 () => {
   const [currentView, setCurrentView] = useState('card');
 
-  const TableAction = (props) => React.createElement(
-    props.as || Button,
-    {
-      key: 'Table Action',
-      onClick: () => console.log('Table Action', props.selectedFlatRows),
-      className: props.as ? "" : "ml-2",
-    },
-    'Table Action'
-  );
-
-  const AssignAction = (props) => React.createElement(
-    // Here is access to the selectedFlatRows, isEntireTableSelected, tableInstance
+  const TableAction = ({ as: Component, ...rest }) => (
+    // Here is access to the tableInstance
     // Pass `as` like in the example bellow for the proper display in the toggled variant
-    props.as || Button,
-    {
-      key: 'Assign',
-      onClick: () => console.log('Assign', props.selectedFlatRows),
-      className: props.as ? "" : "ml-2",
-    },
-    'Assign'
+    <Component onClick={() => console.log('TableAction', rest)}>
+      Enroll
+    </Component>
   );
 
-  const EnrollAction = (props) => React.createElement(
-    props.as || Button,
-    {
-      key: 'Enroll',
-      variant: 'danger',
-      onClick: () => console.log('Enroll', props.selectedFlatRows),
-      className: props.as ? '' : 'ml-2',
-    },
-    'Enroll'
+  const EnrollAction = ({ as: Component, selectedFlatRows, ...rest }) => (
+    // Here is access to the selectedFlatRows, isEntireTableSelected, tableInstance
+    <Component variant="danger" onClick={() => console.log('Enroll', selectedFlatRows, rest)}>
+      Enroll ({selectedFlatRows.length})
+    </Component>
+  );
+
+  const AssignAction = ({ as: Component, selectedFlatRows, ...rest }) => (
+    <Component onClick={() => console.log('Assign', selectedFlatRows, rest)}>
+      Assign ({selectedFlatRows.length})
+    </Component>
+  );
+
+  const ExtraAction = ({ text, as: Component, selectedFlatRows, ...rest }) => (
+    <Component onClick={() => console.log(`Extra Action ${text}`, selectedFlatRows, rest)}>
+      {`Extra Action ${text}`}
+    </Component>
   );
 
   return (<DataTable
@@ -827,29 +800,14 @@ You can pass a function to render custom components for bulk actions and table a
             isSelectable
             itemCount={7}
             tableActions={[
-              TableAction,
+              <TableAction />,
             ]}
             bulkActions={[
-              AssignAction,
-              EnrollAction,
-              ({ as, selectedFlatRows }) => React.createElement(
-                as || Button,
-                {
-                  key: 'Extra action 1',
-                  onClick: () => console.log('Extra action 1', selectedFlatRows),
-                  className: as ? "" : "ml-2",
-                },
-                'Extra action 1'
-              ),
-              ({ as, selectedFlatRows }) => React.createElement(
-                as || Button,
-                {
-                  key: 'Extra action 2',
-                  onClick: () => console.log('Extra action 2', selectedFlatRows),
-                  className: as ? "" : "ml-2",
-                },
-                'Extra action 2'
-              )
+              <EnrollAction />,
+              // Default value for `as` property is `Button`
+              <AssignAction as={Button} />,
+              <ExtraAction text="1" />,
+              <ExtraAction text="2" />,
             ]}
             additionalColumns={[
               {
@@ -933,209 +891,225 @@ The CardView takes a ``CardComponent`` that is personalized to the table in ques
 a responsive grid of cards.
 
 ```jsx live
-<DataTable
-  isFilterable
-  defaultColumnValues={{ Filter: TextFilter }}
-  isPaginated
-  isSortable
-  initialState={{
-    pageSize: 3,
-    pageIndex: 0
-  }}
-  itemCount={20}
-  fetchData={(data) => console.log(`This function will be called with the value: ${JSON.stringify(data)}}`)}
-  data={[
-  {
-    'id': '2baf70d1-42bb-4437-b551-e5fed5a87abe',
-    'title': 'Castle in the Sky',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Isao Takahata',
-    'release_date': '1986',
-    'rt_score': '95',
-  },
-  {
-    'id': '12cfb892-aac0-4c5b-94af-521852e46d6a',
-    'title': 'Grave of the Fireflies',
-    'director': 'Isao Takahata',
-    'producer': 'Toru Hara',
-    'release_date': '1988',
-    'rt_score': '97',
-  },
-  {
-    'id': '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
-    'title': 'My Neighbor Totoro',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Hayao Miyazaki',
-    'release_date': '1988',
-    'rt_score': '93',
-  },
-  {
-    'id': 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
-    'title': 'Kiki\'s Delivery Service',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Hayao Miyazaki',
-    'release_date': '1989',
-    'rt_score': '96',
-  },
-  {
-    'id': '4e236f34-b981-41c3-8c65-f8c9000b94e7',
-    'title': 'Only Yesterday',
-    'director': 'Isao Takahata',
-    'producer': 'Toshio Suzuki',
-    'release_date': '1991',
-    'rt_score': '100',
-  },
-  {
-    'id': 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
-    'title': 'Porco Rosso',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '1992',
-    'rt_score': '94',
-  },
-  {
-    'id': '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
-    'title': 'Pom Poko',
-    'director': 'Isao Takahata',
-    'producer': 'Toshio Suzuki',
-    'release_date': '1994',
-    'rt_score': '78',
-  },
-  {
-    'id': 'ff24da26-a969-4f0e-ba1e-a122ead6c6e3',
-    'title': 'Whisper of the Heart',
-    'director': 'Yoshifumi Kondō',
-    'producer': 'Toshio Suzuki',
-    'release_date': '1995',
-    'rt_score': '91',
-  },
-  {
-    'id': '0440483e-ca0e-4120-8c50-4c8cd9b965d6',
-    'title': 'Princess Mononoke',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '1997',
-    'rt_score': '92',
-  },
-  {
-    'id': '45204234-adfd-45cb-a505-a8e7a676b114',
-    'title': 'My Neighbors the Yamadas',
-    'director': 'Isao Takahata',
-    'producer': 'Toshio Suzuki',
-    'release_date': '1999',
-    'rt_score': '75',
-  },
-  {
-    'id': 'dc2e6bd1-8156-4886-adff-b39e6043af0c',
-    'title': 'Spirited Away',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2001',
-    'rt_score': '97',
-  },
-  {
-    'id': '90b72513-afd4-4570-84de-a56c312fdf81',
-    'title': 'The Cat Returns',
-    'director': 'Hiroyuki Morita',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2002',
-    'rt_score': '89',
-  },
-  {
-    'id': 'cd3d059c-09f4-4ff3-8d63-bc765a5184fa',
-    'title': 'Howl\'s Moving Castle',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2004',
-    'rt_score': '87',
-  },
-  {
-    'id': '112c1e67-726f-40b1-ac17-6974127bb9b9',
-    'title': 'Tales from Earthsea',
-    'director': 'Gorō Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2006',
-    'rt_score': '41',
-  },
-  {
-    'id': '758bf02e-3122-46e0-884e-67cf83df1786',
-    'title': 'Ponyo',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2008',
-    'rt_score': '92',
-  },
-  {
-    'id': '2de9426b-914a-4a06-a3a0-5e6d9d3886f6',
-    'title': 'Arrietty',
-    'director': 'Hiromasa Yonebayashi',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2010',
-    'rt_score': '95',
-  },
-  {
-    'id': '45db04e4-304a-4933-9823-33f389e8d74d',
-    'title': 'From Up on Poppy Hill',
-    'director': 'Gorō Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2011',
-    'rt_score': '83',
-  },
-  {
-    'id': '67405111-37a5-438f-81cc-4666af60c800',
-    'title': 'The Wind Rises',
-    'director': 'Hayao Miyazaki',
-    'producer': 'Toshio Suzuki',
-    'release_date': '2013',
-    'rt_score': '89',
-  },
-  {
-    'id': '578ae244-7750-4d9f-867b-f3cd3d6fecf4',
-    'title': 'The Tale of the Princess Kaguya',
-    'director': 'Isao Takahata',
-    'producer': 'Yoshiaki Nishimura',
-    'release_date': '2013',
-    'rt_score': '100',
-  },
-  {
-    'id': '5fdfb320-2a02-49a7-94ff-5ca418cae602',
-    'title': 'When Marnie Was There',
-    'director': 'Hiromasa Yonebayashi',
-    'producer': 'Yoshiaki Nishimura',
-    'release_date': '2014',
-    'rt_score': '92',
-  }
-]}
-  columns={[
-    {
-      Header: 'Title',
-      accessor: 'title',
+() => {
+  const DownloadCSVAction = ({ as: Component, selectedFlatRows, ...rest }) => (
+    <Component onClick={() => console.log('Download CSV', selectedFlatRows, rest)}>
+      Download CSV
+    </Component>
+  );
 
-    },
-    {
-      Header: 'Director',
-      accessor: 'director',
-    },
-    {
-      Header: 'Release date',
-      accessor: 'release_date',
-    },
-  ]}
-  bulkActions={[
-    ({ as, selectedFlatRows }) => React.createElement(
-      as || Button,
-      {
-        onClick: () => console.log('Download CSV', selectedFlatRows),
-        className: as ? "" : "ml-2",
-      },
-      'Download CSV'
-    )
-  ]}
->
-  <TableControlBar />
-  <CardView CardComponent={MiyazakiCard} />
-  <TableFooter />
-</DataTable>
+  const ClearAction = ({ as: Component, tableInstance, ...rest }) => (
+    <Component
+      variant="danger"
+      onClick={() => {
+        console.log('Clear Selection');
+        tableInstance.clearSelection();
+      }}
+    >
+      Clear Selection
+    </Component>
+  );
+  
+  return (
+    <DataTable
+      isFilterable
+      defaultColumnValues={{ Filter: TextFilter }}
+      isPaginated
+      isSortable
+      initialState={{
+        pageSize: 3,
+        pageIndex: 0
+      }}
+      itemCount={20}
+      fetchData={(data) => console.log(`This function will be called with the value: ${JSON.stringify(data)}}`)}
+      data={[
+        {
+          'id': '2baf70d1-42bb-4437-b551-e5fed5a87abe',
+          'title': 'Castle in the Sky',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Isao Takahata',
+          'release_date': '1986',
+          'rt_score': '95',
+        },
+        {
+          'id': '12cfb892-aac0-4c5b-94af-521852e46d6a',
+          'title': 'Grave of the Fireflies',
+          'director': 'Isao Takahata',
+          'producer': 'Toru Hara',
+          'release_date': '1988',
+          'rt_score': '97',
+        },
+        {
+          'id': '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
+          'title': 'My Neighbor Totoro',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Hayao Miyazaki',
+          'release_date': '1988',
+          'rt_score': '93',
+        },
+        {
+          'id': 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
+          'title': 'Kiki\'s Delivery Service',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Hayao Miyazaki',
+          'release_date': '1989',
+          'rt_score': '96',
+        },
+        {
+          'id': '4e236f34-b981-41c3-8c65-f8c9000b94e7',
+          'title': 'Only Yesterday',
+          'director': 'Isao Takahata',
+          'producer': 'Toshio Suzuki',
+          'release_date': '1991',
+          'rt_score': '100',
+        },
+        {
+          'id': 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
+          'title': 'Porco Rosso',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '1992',
+          'rt_score': '94',
+        },
+        {
+          'id': '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
+          'title': 'Pom Poko',
+          'director': 'Isao Takahata',
+          'producer': 'Toshio Suzuki',
+          'release_date': '1994',
+          'rt_score': '78',
+        },
+        {
+          'id': 'ff24da26-a969-4f0e-ba1e-a122ead6c6e3',
+          'title': 'Whisper of the Heart',
+          'director': 'Yoshifumi Kondō',
+          'producer': 'Toshio Suzuki',
+          'release_date': '1995',
+          'rt_score': '91',
+        },
+        {
+          'id': '0440483e-ca0e-4120-8c50-4c8cd9b965d6',
+          'title': 'Princess Mononoke',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '1997',
+          'rt_score': '92',
+        },
+        {
+          'id': '45204234-adfd-45cb-a505-a8e7a676b114',
+          'title': 'My Neighbors the Yamadas',
+          'director': 'Isao Takahata',
+          'producer': 'Toshio Suzuki',
+          'release_date': '1999',
+          'rt_score': '75',
+        },
+        {
+          'id': 'dc2e6bd1-8156-4886-adff-b39e6043af0c',
+          'title': 'Spirited Away',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2001',
+          'rt_score': '97',
+        },
+        {
+          'id': '90b72513-afd4-4570-84de-a56c312fdf81',
+          'title': 'The Cat Returns',
+          'director': 'Hiroyuki Morita',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2002',
+          'rt_score': '89',
+        },
+        {
+          'id': 'cd3d059c-09f4-4ff3-8d63-bc765a5184fa',
+          'title': 'Howl\'s Moving Castle',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2004',
+          'rt_score': '87',
+        },
+        {
+          'id': '112c1e67-726f-40b1-ac17-6974127bb9b9',
+          'title': 'Tales from Earthsea',
+          'director': 'Gorō Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2006',
+          'rt_score': '41',
+        },
+        {
+          'id': '758bf02e-3122-46e0-884e-67cf83df1786',
+          'title': 'Ponyo',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2008',
+          'rt_score': '92',
+        },
+        {
+          'id': '2de9426b-914a-4a06-a3a0-5e6d9d3886f6',
+          'title': 'Arrietty',
+          'director': 'Hiromasa Yonebayashi',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2010',
+          'rt_score': '95',
+        },
+        {
+          'id': '45db04e4-304a-4933-9823-33f389e8d74d',
+          'title': 'From Up on Poppy Hill',
+          'director': 'Gorō Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2011',
+          'rt_score': '83',
+        },
+        {
+          'id': '67405111-37a5-438f-81cc-4666af60c800',
+          'title': 'The Wind Rises',
+          'director': 'Hayao Miyazaki',
+          'producer': 'Toshio Suzuki',
+          'release_date': '2013',
+          'rt_score': '89',
+        },
+        {
+          'id': '578ae244-7750-4d9f-867b-f3cd3d6fecf4',
+          'title': 'The Tale of the Princess Kaguya',
+          'director': 'Isao Takahata',
+          'producer': 'Yoshiaki Nishimura',
+          'release_date': '2013',
+          'rt_score': '100',
+        },
+        {
+          'id': '5fdfb320-2a02-49a7-94ff-5ca418cae602',
+          'title': 'When Marnie Was There',
+          'director': 'Hiromasa Yonebayashi',
+          'producer': 'Yoshiaki Nishimura',
+          'release_date': '2014',
+          'rt_score': '92',
+        }
+      ]}
+      columns={[
+        {
+          Header: 'Title',
+          accessor: 'title',
+
+        },
+        {
+          Header: 'Director',
+          accessor: 'director',
+        },
+        {
+          Header: 'Release date',
+          accessor: 'release_date',
+        },
+      ]}
+      bulkActions={[
+        <DownloadCSVAction />,
+        <ClearAction />,
+      ]}
+    >
+      <TableControlBar />
+      <CardView CardComponent={MiyazakiCard} />
+      <TableFooter />
+    </DataTable>
+  );
+};
 ```
 
 ## Sidebar Filter

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -309,7 +309,7 @@ Card view is default when ``isDataViewToggleEnabled`` is true
 See ``dataViewToggleOptions`` props documentation for all supported props
 
 ```jsx live
-function() {
+() => {
   const [currentView, setCurrentView] = useState('card');
   const togglePlacement = 'left'; // 'bottom' is the only other supported value
   return (
@@ -394,7 +394,7 @@ function() {
 ### With a default active state specified
 
 ```jsx live
-function() {
+() => {
   const defaultVal = "list";
   const [currentView, setCurrentView] = useState(defaultVal);
   return (
@@ -782,8 +782,41 @@ You can pass a function to render custom components for bulk actions and table a
 
 
 ```jsx live
-function() {
-    const [currentView, setCurrentView] = useState('card');
+() => {
+  const [currentView, setCurrentView] = useState('card');
+
+  const TableAction = (props) => React.createElement(
+    props.as || Button,
+    {
+      key: 'Table Action',
+      onClick: () => console.log('Table Action', props.selectedFlatRows),
+      className: props.as ? "" : "ml-2",
+    },
+    'Table Action'
+  );
+
+  const AssignAction = (props) => React.createElement(
+    // Here is access to the selectedFlatRows, isEntireTableSelected, tableInstance
+    // Pass `as` like in the example bellow for the proper display in the toggled variant
+    props.as || Button,
+    {
+      key: 'Assign',
+      onClick: () => console.log('Assign', props.selectedFlatRows),
+      className: props.as ? "" : "ml-2",
+    },
+    'Assign'
+  );
+
+  const EnrollAction = (props) => React.createElement(
+    props.as || Button,
+    {
+      key: 'Enroll',
+      variant: 'danger',
+      onClick: () => console.log('Enroll', props.selectedFlatRows),
+      className: props.as ? '' : 'ml-2',
+    },
+    'Enroll'
+  );
 
   return (<DataTable
             dataViewToggleOptions={{
@@ -794,32 +827,30 @@ function() {
             isSelectable
             itemCount={7}
             tableActions={[
-                {
-                  buttonText: 'Table Action',
-                  handleClick: (data) => console.log('Table Action', data),
-                },
+              TableAction,
             ]}
             bulkActions={[
-                // Function defined button
-                ({selectedFlatRows})=>{
-                  return {
-                    buttonText: `Enroll (${selectedFlatRows.length})`,
-                    handleClick: () => console.log('Enroll', selectedFlatRows),
-                  }
-                },
+              AssignAction,
+              EnrollAction,
+              ({ as, selectedFlatRows }) => React.createElement(
+                as || Button,
                 {
-                  buttonText: 'Assign',
-                  handleClick: (data) => console.log('Assign', data),
+                  key: 'Extra action 1',
+                  onClick: () => console.log('Extra action 1', selectedFlatRows),
+                  className: as ? "" : "ml-2",
                 },
+                'Extra action 1'
+              ),
+              ({ as, selectedFlatRows }) => React.createElement(
+                as || Button,
                 {
-                  buttonText: 'Extra action 1',
-                  handleClick: (data) => console.log('Extra action 1', data),
+                  key: 'Extra action 2',
+                  onClick: () => console.log('Extra action 2', selectedFlatRows),
+                  className: as ? "" : "ml-2",
                 },
-                {
-                  buttonText: 'Extra action 2',
-                  handleClick: (data) => console.log('Extra action 2', data),
-                },
-              ]}
+                'Extra action 2'
+              )
+            ]}
             additionalColumns={[
               {
                 id: 'action',

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -275,20 +275,27 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
         },
       ]}
       bulkActions={[
-        {
-          buttonText: 'Download CSV',
-          handleClick: (data) => console.log('Download CSV', data),
-        },
-        // custom button function that utilizes clearSelection function provided by the table instance
-        ({tableInstance})=>{
-          return {
-            buttonText: `Clear Selection`,
-            handleClick: () => {
-              console.log('Clear selection');
-              tableInstance.clearSelection()
+        ({ as, selectedFlatRows }) => React.createElement(
+          as || Button,
+          {
+            key: 'Download CSV',
+            onClick: () => console.log('Download CSV', selectedFlatRows),
+            className: as ? '' : 'ml-2',
+          },
+          'Download CSV',
+        ),
+        ({ as, selectedFlatRows, tableInstance }) => React.createElement(
+          as || Button,
+          {
+            key: 'Clear Selection',
+            onClick: () => {
+              console.log('Clear Selection');
+              tableInstance.clearSelection();
             },
-          }
-        },
+            className: as ? '' : 'ml-2',
+          },
+          'Clear Selection',
+        )
       ]}
     />
   );
@@ -638,102 +645,137 @@ You can pass a function to render custom components for bulk actions and table a
 
 
 ```jsx live
-  <DataTable
-    isSelectable
-    itemCount={7}
-    tableActions={[
+() => {
+  const TableAction = (props) => React.createElement(
+    props.as || Button,
+    {
+      key: 'Table Action',
+      onClick: () => console.log('Table Action', props.selectedFlatRows),
+      className: props.as ? "" : "ml-2",
+    },
+    'Table Action'
+  );
+  
+  const AssignAction = (props) => React.createElement(
+    // Here is access to the selectedFlatRows, isEntireTableSelected, tableInstance
+    // Pass `as` like in the example bellow for the proper display in the toggled variant
+    props.as || Button,
+    {
+      key: 'Assign',
+      onClick: () => console.log('Assign', props.selectedFlatRows),
+      className: props.as ? "" : "ml-2",
+    },
+    'Assign'
+  );
+
+  const EnrollAction = (props) => React.createElement(
+    props.as || Button,
+    {
+      key: 'Enroll',
+      variant: 'danger',
+      onClick: () => console.log('Enroll', props.selectedFlatRows),
+      className: props.as ? '' : 'ml-2',
+    },
+    'Enroll'
+  );
+  
+  return (
+    <DataTable
+      isSelectable
+      itemCount={7}
+      tableActions={[
+        TableAction,
+      ]}
+      bulkActions={[
+        AssignAction,
+        EnrollAction,
+        ({ as, selectedFlatRows }) => React.createElement(
+          as || Button,
+          {
+            key: 'Extra action 1',
+            onClick: () => console.log('Extra action 1', selectedFlatRows),
+            className: as ? "" : "ml-2",
+          },
+          'Extra action 1'
+        ),
+        ({ as, selectedFlatRows }) => React.createElement(
+          as || Button,
+          {
+            key: 'Extra action 2',
+            onClick: () => console.log('Extra action 2', selectedFlatRows),
+            className: as ? "" : "ml-2",
+          },
+          'Extra action 2'
+        )
+      ]}
+      additionalColumns={[
         {
-          buttonText: 'Table Action',
-          handleClick: (data) => console.log('Table Action', data),
-        },
-    ]}
-    bulkActions={[
-        // Function defined button
-        ({selectedFlatRows})=>{
-          return {
-            buttonText: `Enroll (${selectedFlatRows.length})`,
-            handleClick: () => console.log('Enroll', selectedFlatRows),
-          }
+          id: 'action',
+          Header: 'Action',
+          Cell: ({ row }) => <Button variant="link" onClick={() => console.log(`Assigning ${row.values.name}`)}>Assign</Button>,
+        }
+      ]}
+      data={[
+        {
+          name: 'Lil Bub',
+          color: 'brown tabby',
+          famous_for: 'weird tongue',
         },
         {
-          buttonText: 'Assign',
-          handleClick: (data) => console.log('Assign', data),
+          name: 'Grumpy Cat',
+          color: 'siamese',
+          famous_for: 'serving moods',
         },
         {
-          buttonText: 'Extra action 1',
-          handleClick: (data) => console.log('Extra action 1', data),
+          name: 'Smoothie',
+          color: 'orange tabby',
+          famous_for: 'modeling',
         },
         {
-          buttonText: 'Extra action 2',
-          handleClick: (data) => console.log('Extra action 2', data),
+          name: 'Maru',
+          color: 'brown tabby',
+          famous_for: 'being a lovable oaf',
+        },
+        {
+          name: 'Keyboard Cat',
+          color: 'orange tabby',
+          famous_for: 'piano virtuoso',
+        },
+        {
+          name: 'Long Cat',
+          color: 'russian white',
+          famous_for:
+            'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+        },
+        {
+          name: 'Zeno',
+          color: 'brown tabby',
+          famous_for: 'getting halfway there'
         },
       ]}
-    additionalColumns={[
-      {
-        id: 'action',
-        Header: 'Action',
-        Cell: ({ row }) => <Button variant="link" onClick={() => console.log(`Assigning ${row.values.name}`)}>Assign</Button>,
-      }
-    ]}
-    data={[
-      {
-        name: 'Lil Bub',
-        color: 'brown tabby',
-        famous_for: 'weird tongue',
-      },
-      {
-        name: 'Grumpy Cat',
-        color: 'siamese',
-        famous_for: 'serving moods',
-      },
-      {
-        name: 'Smoothie',
-        color: 'orange tabby',
-        famous_for: 'modeling',
-      },
-      {
-        name: 'Maru',
-        color: 'brown tabby',
-        famous_for: 'being a lovable oaf',
-      },
-      {
-        name: 'Keyboard Cat',
-        color: 'orange tabby',
-        famous_for: 'piano virtuoso',
-      },
-      {
-        name: 'Long Cat',
-        color: 'russian white',
-        famous_for:
-          'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
-      },
-      {
-        name: 'Zeno',
-        color: 'brown tabby',
-        famous_for: 'getting halfway there'
-      },
-    ]}
-    columns={[
-      {
-        Header: 'Name',
-        accessor: 'name',
-
-      },
-      {
-        Header: 'Famous For',
-        accessor: 'famous_for',
-      },
-      {
-        Header: 'Coat Color',
-        accessor: 'color',
-      },
-    ]}
-  >
-    <DataTable.TableControlBar />
-    <DataTable.Table />
-    <DataTable.EmptyTable content="No results found" />
-    <DataTable.TableFooter />
-  </DataTable>
+      columns={[
+        {
+          Header: 'Name',
+          accessor: 'name',
+        },
+        {
+          Header: 'Famous For',
+          accessor: 'famous_for',
+        },
+        {
+          Header: 'Coat Color',
+          accessor: 'color',
+        },
+      ]}
+    >
+      <DataTable.TableControlBar />
+      <DataTable.Table />
+      <DataTable.EmptyTable content="No results found" />
+      <DataTable.TableFooter />
+    </DataTable>
+  )
+}
+  
 ```
 
 #### Actions with Data view toggle enabled
@@ -1049,10 +1091,14 @@ a responsive grid of cards.
     },
   ]}
   bulkActions={[
-    {
-      buttonText: 'Download CSV',
-      handleClick: (data) => console.log('Download CSV ', data),
-    },
+    ({ as, selectedFlatRows }) => React.createElement(
+      as || Button,
+      {
+        onClick: () => console.log('Download CSV', selectedFlatRows),
+        className: as ? "" : "ml-2",
+      },
+      'Download CSV'
+    )
   ]}
 >
   <TableControlBar />

--- a/src/DataTable/TableActions.jsx
+++ b/src/DataTable/TableActions.jsx
@@ -13,13 +13,16 @@ const TableActions = ({ className }) => {
     tableInstance,
   };
 
+  if (typeof tableActions === 'function') {
+    return <div className={classNames('pgn__table-actions', className)}>{tableActions(tableInstance)}</div>;
+  }
+
   const actions = tableActions.map(action => ({ component: action, args }));
 
   return (
     <Actions
       className={classNames('pgn__table-actions', className)}
       actions={actions}
-      tableInstance={tableInstance}
     />
   );
 };

--- a/src/DataTable/TableActions.jsx
+++ b/src/DataTable/TableActions.jsx
@@ -9,16 +9,11 @@ const TableActions = ({ className }) => {
   const tableInstance = useContext(DataTableContext);
   const { tableActions } = tableInstance;
 
-  if (typeof tableActions === 'function') {
-    return <div className={classNames('pgn__table-actions', className)}>{tableActions(tableInstance)}</div>;
-  }
+  const args = {
+    tableInstance,
+  };
 
-  const actions = tableActions.map(action => {
-    if (typeof action === 'function') {
-      return action(tableInstance);
-    }
-    return action;
-  });
+  const actions = tableActions.map(action => ({ component: action, args }));
 
   return (
     <Actions

--- a/src/DataTable/tests/ActionDisplay.test.jsx
+++ b/src/DataTable/tests/ActionDisplay.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
+import { Button } from '../..';
 import ActionDisplay from '../ActionDisplay';
 import DataTableContext from '../DataTableContext';
 import BulkActions from '../BulkActions';
@@ -19,17 +20,25 @@ const instance = {
   ],
 };
 
-const firstAction = {
-  buttonText: 'Primary action',
-  handleClick: () => {},
-  className: 'class1',
-};
+const firstAction = ({ as }) => React.createElement(
+  as || Button,
+  {
+    key: 'First Action',
+    onClick: () => {},
+    className: 'class1',
+  },
+  'First Action',
+);
 
-const secondAction = {
-  buttonText: 'Secondary action',
-  handleClick: () => {},
-  className: 'class2',
-};
+const secondAction = ({ as }) => React.createElement(
+  as || Button,
+  {
+    key: 'Second Action',
+    onClick: () => {},
+    className: 'class2',
+  },
+  'Second Action',
+);
 
 // eslint-disable-next-line react/prop-types
 const ActionDisplayWrapper = ({ value = instance, props = {} }) => (
@@ -40,6 +49,17 @@ describe('<ActionDisplay />', () => {
   it('renders null if there are no actions', () => {
     const wrapper = mount(<ActionDisplayWrapper />);
     expect(wrapper.find(ActionDisplay).text()).toEqual('');
+  });
+  it('renders null if there are no rows', () => {
+    const wrapper = mount(
+      <ActionDisplayWrapper
+        value={{
+          ...instance, rows: null, tableActions: [firstAction], bulkActions: [secondAction],
+        }}
+      />,
+    );
+    const button = wrapper.find(Button);
+    expect(button.length).toEqual(0);
   });
   it('displays bulk actions when rows are selected', () => {
     const wrapper = mount(

--- a/src/DataTable/tests/ActionDisplay.test.jsx
+++ b/src/DataTable/tests/ActionDisplay.test.jsx
@@ -20,24 +20,18 @@ const instance = {
   ],
 };
 
-const firstAction = ({ as }) => React.createElement(
-  as || Button,
-  {
-    key: 'First Action',
-    onClick: () => {},
-    className: 'class1',
-  },
-  'First Action',
+// eslint-disable-next-line react/prop-types
+const FirstAction = ({ as: Component }) => (
+  <Component className="class1">
+    First Action
+  </Component>
 );
 
-const secondAction = ({ as }) => React.createElement(
-  as || Button,
-  {
-    key: 'Second Action',
-    onClick: () => {},
-    className: 'class2',
-  },
-  'Second Action',
+// eslint-disable-next-line react/prop-types
+const SecondAction = ({ as: Component }) => (
+  <Component className="class2">
+    Second Action
+  </Component>
 );
 
 // eslint-disable-next-line react/prop-types
@@ -54,7 +48,7 @@ describe('<ActionDisplay />', () => {
     const wrapper = mount(
       <ActionDisplayWrapper
         value={{
-          ...instance, rows: null, tableActions: [firstAction], bulkActions: [secondAction],
+          ...instance, rows: null, tableActions: [<FirstAction />], bulkActions: [<SecondAction />],
         }}
       />,
     );
@@ -64,7 +58,7 @@ describe('<ActionDisplay />', () => {
   it('displays bulk actions when rows are selected', () => {
     const wrapper = mount(
       <ActionDisplayWrapper
-        value={{ ...instance, bulkActions: [firstAction, secondAction], selectedFlatRows: [{}, {}] }}
+        value={{ ...instance, bulkActions: [<FirstAction />, <SecondAction />], selectedFlatRows: [{}, {}] }}
       />,
     );
     expect(wrapper.find(BulkActions)).toHaveLength(1);
@@ -72,7 +66,7 @@ describe('<ActionDisplay />', () => {
   it('does not display bulk actions when no rows are selected (no table actions)', () => {
     const wrapper = mount(
       <ActionDisplayWrapper
-        value={{ ...instance, bulkActions: [firstAction, secondAction], selectedFlatRows: [] }}
+        value={{ ...instance, bulkActions: [<FirstAction />, <SecondAction />], selectedFlatRows: [] }}
       />,
     );
     expect(wrapper.find(ActionDisplay).text()).toEqual('');
@@ -80,7 +74,7 @@ describe('<ActionDisplay />', () => {
   it('displays tableActions', () => {
     const wrapper = mount(
       <ActionDisplayWrapper
-        value={{ ...instance, tableActions: [firstAction, secondAction], selectedFlatRows: [] }}
+        value={{ ...instance, tableActions: [<FirstAction />, <SecondAction />], selectedFlatRows: [] }}
       />,
     );
     expect(wrapper.find(TableActions)).toHaveLength(1);
@@ -90,8 +84,8 @@ describe('<ActionDisplay />', () => {
       <ActionDisplayWrapper
         value={{
           ...instance,
-          bulkActions: [firstAction],
-          tableActions: [secondAction],
+          bulkActions: [<FirstAction />],
+          tableActions: [<SecondAction />],
           selectedFlatRows: [],
         }}
       />,
@@ -102,7 +96,7 @@ describe('<ActionDisplay />', () => {
     // This is an edge case
     const wrapper = mount(
       <ActionDisplayWrapper
-        value={{ ...instance, tableActions: [firstAction, secondAction], selectedFlatRows: [{}, {}] }}
+        value={{ ...instance, tableActions: [<FirstAction />, <SecondAction />], selectedFlatRows: [{}, {}] }}
       />,
     );
     expect(wrapper.find(TableActions)).toHaveLength(1);
@@ -112,8 +106,8 @@ describe('<ActionDisplay />', () => {
       <ActionDisplayWrapper
         value={{
           ...instance,
-          bulkActions: [firstAction],
-          tableActions: [secondAction],
+          bulkActions: [<FirstAction />],
+          tableActions: [<SecondAction />],
           selectedFlatRows: [{}, {}],
         }}
       />,

--- a/src/DataTable/tests/BulkActions.test.jsx
+++ b/src/DataTable/tests/BulkActions.test.jsx
@@ -20,8 +20,8 @@ const FirstAction = ({ as: Component, onClick, className }) => (
 );
 
 // eslint-disable-next-line react/prop-types
-const SecondAction = ({ as: Component }) => (
-  <Component variant="outline-primary" className="class2">
+const SecondAction = ({ as: Component, onClick, className }) => (
+  <Component variant="outline-primary" className={classNames('class2', className)} onClick={onClick}>
     Second Action
   </Component>
 );
@@ -140,7 +140,7 @@ describe('<BulkActions />', () => {
       const onClickSpy = jest.fn();
       const wrapper = mount(
         <BulkActionsWrapper
-          value={{ ...instance, bulkActions: [<FirstAction />, <FirstAction onClick={onClickSpy} />] }}
+          value={{ ...instance, bulkActions: [<FirstAction />, <SecondAction onClick={onClickSpy} />] }}
         />,
       );
       const button = wrapper.find(Button).at(0);

--- a/src/DataTable/tests/TableActions.test.jsx
+++ b/src/DataTable/tests/TableActions.test.jsx
@@ -20,8 +20,8 @@ const FirstAction = ({ as: Component, onClick, className }) => (
 );
 
 // eslint-disable-next-line react/prop-types
-const SecondAction = ({ as: Component }) => (
-  <Component variant="outline-primary" className="class2">
+const SecondAction = ({ as: Component, onClick, className }) => (
+  <Component variant="outline-primary" className={classNames('class2', className)} onClick={onClick}>
     Second Action
   </Component>
 );
@@ -111,7 +111,7 @@ describe('<TableActions />', () => {
     });
     it('performs the second button action on click', () => {
       const onClickSpy = jest.fn();
-      const tableInstance = { ...instance, tableActions: [<FirstAction />, <FirstAction onClick={onClickSpy} />] };
+      const tableInstance = { ...instance, tableActions: [<FirstAction />, <SecondAction onClick={onClickSpy} />] };
       const wrapper = mount(<TableActionsWrapper value={tableInstance} />);
       const button = wrapper.find(Button).at(0);
       button.simulate('click');

--- a/src/DataTable/tests/TableActions.test.jsx
+++ b/src/DataTable/tests/TableActions.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import classNames from 'classnames';
 
 import TableActions from '../TableActions';
 import { DROPDOWN_BUTTON_TEXT, SMALL_SCREEN_DROPDOWN_BUTTON_TEXT } from '../CollapsibleButtonGroup';
@@ -11,32 +12,32 @@ import DataTableContext from '../DataTableContext';
 jest.mock('../../hooks/useWindowSize');
 useWindowSize.mockReturnValue({ width: 800 });
 
-const firstAction = ({ as }) => React.createElement(
-  as || Button,
-  {
-    key: 'First Action',
-    onClick: () => {},
-    className: 'class1',
-  },
-  'First Action',
+// eslint-disable-next-line react/prop-types
+const FirstAction = ({ as: Component, onClick, className }) => (
+  <Component variant="brand" className={classNames('class1', className)} onClick={onClick}>
+    First Action
+  </Component>
 );
 
-const secondAction = ({ as }) => React.createElement(
-  as || Button,
-  {
-    key: 'Second Action',
-    onClick: () => {},
-    className: 'class2',
-    variant: 'brand',
-  },
-  'Second Action',
+// eslint-disable-next-line react/prop-types
+const SecondAction = ({ as: Component }) => (
+  <Component variant="outline-primary" className="class2">
+    Second Action
+  </Component>
+);
+
+// eslint-disable-next-line react/prop-types
+const ExtraAction = ({ text, as: Component }) => (
+  <Component>
+    {`Extra Action ${text}`}
+  </Component>
 );
 
 const selectedFlatRows = [{ id: 1 }, { id: 2 }];
 
 const twoActions = [
-  firstAction,
-  secondAction,
+  <FirstAction />,
+  <SecondAction />,
 ];
 
 const instance = {
@@ -50,21 +51,9 @@ const instance = {
   ],
   tableActions: [
     ...twoActions,
-    ({ as }) => React.createElement(
-      as || Button,
-      { key: 'action1' },
-      'Extra 1',
-    ),
-    ({ as }) => React.createElement(
-      as || Button,
-      { key: 'action2' },
-      'Extra 2',
-    ),
-    ({ as }) => React.createElement(
-      as || Button,
-      { key: 'action3' },
-      'Extra 3',
-    ),
+    <ExtraAction text="1" />,
+    <ExtraAction text="2" />,
+    <ExtraAction text="3" />,
   ],
 };
 
@@ -73,51 +62,18 @@ const TableActionsWrapper = ({ value = instance }) => (
   <DataTableContext.Provider value={value}><TableActions /></DataTableContext.Provider>);
 
 describe('<TableActions />', () => {
+  describe('with functional rendering', () => {
+    it('renders the function', () => {
+      const myFunction = () => <Button>Some Button</Button>;
+      const wrapper = mount(<TableActionsWrapper value={{ ...instance, tableActions: myFunction }} />);
+      const button = wrapper.find(Button);
+      expect(button.length).toEqual(1);
+    });
+  });
   describe('with one action', () => {
-    it('displays the primary action with the user\'s variant', () => {
-      const variant = 'my-variant';
-      const action = ({ as }) => React.createElement(
-        as || Button,
-        { variant, key: 'action1' },
-        'Extra 1',
-      );
-      const wrapper = mount(
-        <TableActionsWrapper value={{ ...instance, tableActions: [action] }} />,
-      );
-      const button = wrapper.find(Button);
-      expect(button.props().variant).toEqual(variant);
-    });
-    it('passes button classnames', () => {
-      const customClass = 'class1';
-      const action = ({ as }) => React.createElement(
-        as || Button,
-        { className: customClass, key: 'action1' },
-        'Extra 1',
-      );
-      const wrapper = mount(<TableActionsWrapper value={{ ...instance, tableActions: [action] }} />);
-      const button = wrapper.find(Button);
-      expect(button.props().className).toContain(customClass);
-    });
-    it('disables the button', () => {
-      const action = ({ as }) => React.createElement(
-        as || Button,
-        { disabled: true, key: 'action1' },
-        'Extra 1',
-      );
-      const wrapper = mount(
-        <TableActionsWrapper value={{ ...instance, tableActions: [action] }} />,
-      );
-      const button = wrapper.find(Button);
-      expect(button.props().disabled).toEqual(true);
-    });
     it('performs the button action on click', () => {
       const onClickSpy = jest.fn();
-      const action = ({ as }) => React.createElement(
-        as || Button,
-        { onClick: onClickSpy, key: 'action1' },
-        'Extra 1',
-      );
-      const tableInstance = { ...instance, tableActions: [action] };
+      const tableInstance = { ...instance, tableActions: [<FirstAction onClick={onClickSpy} />] };
       const wrapper = mount(
         <TableActionsWrapper value={tableInstance} />,
       );
@@ -132,27 +88,22 @@ describe('<TableActions />', () => {
     it('displays the user\'s first button as an brand button', () => {
       const buttons = wrapper.find(Button);
       expect(buttons.length).toEqual(2);
-      expect(buttons.get(0).props.variant).toEqual('brand');
+      expect(buttons.get(0).props.variant).toEqual('outline-primary');
     });
     it('displays the user\'s second button as an outline button', () => {
       const buttons = wrapper.find(Button);
-      expect(buttons.get(1).props.variant).toEqual('primary');
+      expect(buttons.get(1).props.variant).toEqual('brand');
     });
     it('reverses the button order so that the primary button is on the right', () => {
       const buttons = wrapper.find(Button);
-      expect(buttons.get(1).props.variant).toEqual('primary');
-      expect(buttons.get(0).props.variant).toEqual('brand');
+      expect(buttons.get(1).props.variant).toEqual('brand');
+      expect(buttons.get(0).props.variant).toEqual('outline-primary');
     });
   });
   describe('two actions on click', () => {
     it('performs the primary button action on click', () => {
       const onClickSpy = jest.fn();
-      const action = ({ as }) => React.createElement(
-        as || Button,
-        { onClick: onClickSpy, key: 'action1' },
-        'Extra 1',
-      );
-      const tableInstance = { ...instance, tableActions: [action, secondAction] };
+      const tableInstance = { ...instance, tableActions: [<FirstAction onClick={onClickSpy} />, <SecondAction />] };
       const wrapper = mount(<TableActionsWrapper value={tableInstance} />);
       const button = wrapper.find(Button).at(1);
       button.simulate('click');
@@ -160,12 +111,7 @@ describe('<TableActions />', () => {
     });
     it('performs the second button action on click', () => {
       const onClickSpy = jest.fn();
-      const action = ({ as }) => React.createElement(
-        as || Button,
-        { onClick: onClickSpy },
-        'Extra 1',
-      );
-      const tableInstance = { ...instance, tableActions: [firstAction, action] };
+      const tableInstance = { ...instance, tableActions: [<FirstAction />, <FirstAction onClick={onClickSpy} />] };
       const wrapper = mount(<TableActionsWrapper value={tableInstance} />);
       const button = wrapper.find(Button).at(0);
       button.simulate('click');
@@ -177,29 +123,23 @@ describe('<TableActions />', () => {
       const wrapper = mount(<TableActionsWrapper />);
       const buttons = wrapper.find(Button);
       expect(buttons.length).toEqual(2);
-      expect(buttons.get(1).props.variant).toEqual('primary');
+      expect(buttons.get(1).props.variant).toEqual('brand');
     });
     it('displays the user\'s second button as an outline button', () => {
       const wrapper = mount(<TableActionsWrapper />);
       const buttons = wrapper.find(Button);
-      expect(buttons.get(0).props.variant).toEqual('brand');
+      expect(buttons.get(0).props.variant).toEqual('outline-primary');
     });
     describe('dropdown', () => {
       const onClickSpy = jest.fn();
       const itemClassName = 'itemClickTest';
-      const itemText = 'Yet another action';
       let tableInstance;
       let wrapper;
       let dropdownButton;
       beforeEach(() => {
-        const action = ({ as }) => React.createElement(
-          as || Button,
-          { onClick: onClickSpy, className: itemClassName, key: 'action0' },
-          itemText,
-        );
         tableInstance = {
           ...instance,
-          tableActions: [...instance.tableActions, action],
+          tableActions: [...instance.tableActions, <FirstAction onClick={onClickSpy} className={itemClassName} />],
         };
         wrapper = mount(
           <TableActionsWrapper value={tableInstance} />,
@@ -222,10 +162,6 @@ describe('<TableActions />', () => {
         wrapper.find(`a.${itemClassName}`).simulate('click');
         expect(onClickSpy).toHaveBeenCalledTimes(1);
       });
-      it('displays the action text', () => {
-        const item = wrapper.find(`a.${itemClassName}`);
-        expect(item.text()).toEqual(itemText);
-      });
       it('passes the class names to the dropdown item', () => {
         const item = wrapper.find(`a.${itemClassName}`);
         expect(item.length).toEqual(1);
@@ -233,7 +169,7 @@ describe('<TableActions />', () => {
     });
   });
   describe('small screen', () => {
-    const actions = [[[firstAction]], [[firstAction, secondAction]], [instance.tableActions]];
+    const actions = [[[<FirstAction />]], [[<FirstAction />, <SecondAction />]], [instance.tableActions]];
     test.each(actions)('puts all actions in a dropdown %#', (testActions) => {
       useWindowSize.mockReturnValue({ width: 500 });
       const wrapper = mount(<TableActionsWrapper value={{ ...instance, tableActions: testActions }} />);


### PR DESCRIPTION
Modifications to the `BulkActions` and `TableActions` as they are based on the same `CollapsibleButtonGroup`:
- `DataTable` accepts functional components for the `bulkActions` and `tableActions` props instead of objects
- The idea is to pass `as || anyComponent` to the `React.creatElement` so the `CollapsibleButtonGroup` can manage toggled and not toggled display of the buttons by itself

JIRA: [PAR-273](https://openedx.atlassian.net/browse/PAR-273)