### PR TITLE
fix: Stepper errorState bug fix + documentation

### DIFF
--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -178,3 +178,100 @@ A composition of a stepper with a `FullscreenModal`.
   )
 }
 ```
+
+### Error State
+
+A composition of a stepper with the `hasError` prop. Note that the `index` prop is
+also required for steps to rerender correctly here.
+
+```jsx live
+() => {
+  const steps = ['checkbox', 'success'];
+  const [currentStep, setCurrentStep] = useState(steps[0]);
+  const [isChecked, check, uncheck, toggleChecked] = useToggle(false);
+  const [hasError, setError, removeError] = useToggle(false);
+  const [isAlertOpen, openAlert, closeAlert] = useToggle(false)
+
+  const evaluateCheckbox = () => {
+    if (isChecked) {
+      removeError();
+      setCurrentStep('success');
+    } else {
+      setError();
+    }
+  };
+
+  const resetCheckbox = () => {
+    closeAlert();
+    uncheck();
+    removeError();
+  };
+
+  return (
+    <Stepper activeKey={currentStep}>
+      <Stepper.Header />
+
+      <AlertModal
+        title="Confirm reset"
+        isOpen={isAlertOpen}
+        onClose={closeAlert}
+        footerNode={(
+          <ActionRow>
+            <Button variant="tertiary" onClick={closeAlert}>Cancel</Button>
+            <Button variant="danger" onClick={resetCheckbox}>Confirm</Button>
+          </ActionRow>
+        )}
+      >
+        <p>
+          Are you sure you wish to reset the checkbox?
+        </p>
+      </AlertModal>
+
+      <Container size="sm" className="py-5">
+        <Stepper.Step
+          eventKey="checkbox"
+          title="Check the Box"
+          index={steps.indexOf('checkbox')}
+          description={hasError ? 'Please check the box to continue.' : ''}
+          hasError={hasError}
+        >
+          <h2>Check the box</h2>
+          <Form.Checkbox checked={isChecked} onChange={toggleChecked}>
+            Check me!
+          </Form.Checkbox>
+        </Stepper.Step>
+
+        <Stepper.Step
+          eventKey="success"
+          title="Success!"
+          index={steps.indexOf('success')}
+        >
+          <h2>Success!</h2>
+          <p>You may now complete this demo.</p>
+        </Stepper.Step>
+      </Container>
+
+      <div className="py-3">
+        <Stepper.ActionRow eventKey="checkbox">
+          <Button variant="outline-primary" onClick={openAlert}>
+            Reset
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => evaluateCheckbox()}>Next</Button>
+        </Stepper.ActionRow>
+
+        <Stepper.ActionRow eventKey="success">
+          <Button
+            variant="outline-primary"
+            onClick={() => setCurrentStep('checkbox')}
+          >
+            Previous
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => alert('Completed')}>Complete</Button>
+        </Stepper.ActionRow>
+      </div>
+    </Stepper>
+  )
+}
+```

--- a/src/Stepper/StepperContext.jsx
+++ b/src/Stepper/StepperContext.jsx
@@ -6,6 +6,7 @@ export const StepperContext = React.createContext({
 });
 
 const stepsReducer = (stepsState, action) => {
+  let newStepsState = [];
   switch (action.type) {
     case 'remove':
       return stepsState.filter(step => step.eventKey !== action.eventKey);
@@ -13,14 +14,23 @@ const stepsReducer = (stepsState, action) => {
     default:
       // If is existing step
       if (stepsState.some(step => step.eventKey === action.step.eventKey)) {
-        return stepsState.map(step => {
+        newStepsState = stepsState.map(step => {
           if (step.eventKey === action.step.eventKey) {
             return action.step;
           }
           return step;
         });
+      } else {
+        newStepsState = [...stepsState, action.step];
       }
-      return [...stepsState, action.step];
+
+      // If using the index prop
+      if (stepsState.some(step => step.index)) {
+        return newStepsState.sort((a, b) => (
+          a.index > b.index ? 1 : -1
+        ));
+      }
+      return newStepsState;
   }
 };
 

--- a/src/Stepper/StepperStep.jsx
+++ b/src/Stepper/StepperStep.jsx
@@ -8,6 +8,7 @@ export default function StepperStep({
   eventKey,
   className,
   title,
+  index,
   description,
   hasError,
 }) {
@@ -16,6 +17,7 @@ export default function StepperStep({
   useEffect(() => {
     registerStep({
       title,
+      index,
       eventKey,
       description,
       hasError,
@@ -52,10 +54,16 @@ StepperStep.propTypes = {
   description: PropTypes.string,
   /** Informs user if this `Step` has errors. */
   hasError: PropTypes.bool,
+  /**
+   * Position of the `Step`, only required if adding error state
+   * or conditionally rendering steps.
+   * */
+  index: PropTypes.number,
 };
 
 StepperStep.defaultProps = {
   className: undefined,
   description: undefined,
   hasError: false,
+  index: undefined,
 };

--- a/src/Stepper/tests/Stepper.test.jsx
+++ b/src/Stepper/tests/Stepper.test.jsx
@@ -13,7 +13,7 @@ const Example = ({ activeKey, hasStepWithError, hasFourthStep }) => (
   <Stepper activeKey={activeKey}>
     <Stepper.Header />
 
-    <Stepper.Step eventKey="welcome" title="Welcome">
+    <Stepper.Step eventKey="welcome" title="Welcome" index={0}>
       <span id="welcome-content">Welcome content</span>
     </Stepper.Step>
     <Stepper.Step
@@ -21,14 +21,15 @@ const Example = ({ activeKey, hasStepWithError, hasFourthStep }) => (
       title="Cat"
       hasError={hasStepWithError}
       description={hasStepWithError ? 'Im an error description' : undefined}
+      index={1}
     >
       <span id="cats-content">Cat content</span>
     </Stepper.Step>
-    <Stepper.Step eventKey="review" title="Review">
+    <Stepper.Step eventKey="review" title="Review" index={2}>
       <span id="review-content">Review content</span>
     </Stepper.Step>
     {hasFourthStep && (
-      <Stepper.Step eventKey="extra" title="Extra">
+      <Stepper.Step eventKey="extra" title="Extra" index={3}>
         <span id="extra-content">Extra content</span>
       </Stepper.Step>
     )}
@@ -92,6 +93,9 @@ describe('Stepper', () => {
       wrapper.update();
       const oneStepWithErrors = wrapper.find(StepperHeaderStep).filterWhere((n) => n.props().hasError);
       expect(oneStepWithErrors.length).toBe(1);
+      // Ensure the step is still in the correct position
+      const allSteps = wrapper.find(StepperHeaderStep).getElements();
+      expect(allSteps[1].props.hasError).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
- https://github.com/openedx/frontend-wg/issues/51
- https://openedx.atlassian.net/browse/PAR-638

Fixes a bug where steps would be rerendered at the end of the list upon state change, regardless of original position.

This solution adds an `index` prop to `StepperStep` which, when used, allows the steps to be sorted by `index` in the header when state is updated. This is required to avoid the aforementioned bug when using error states or conditionally rendering steps.

Also adds demo for the `hasError` prop on `StepperStep`:

https://user-images.githubusercontent.com/10442143/150027282-b11a84fb-ab51-4eda-9cea-8098530a76ab.mov


