### PR TITLE
Styling updates to pagination component for small size that uses IconButton for next and prev links

### DIFF
--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -1,6 +1,21 @@
 @import "variables";
 @import "~bootstrap/scss/pagination";
 
+.pagination-small {
+  .page-link {
+    font-size: $font-size-sm;
+  }
+  .previous-item,
+  .next-item {
+    display: flex;
+    align-items: center;
+  }
+  .btn-icon.btn-icon-sm {
+    width: 24px;
+    height: 24px;
+  }
+}
+
 .page-link {
     border-color: $pagination-border-color !important;
     border-radius: 0 !important;

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { Context as ResponsiveContext } from 'react-responsive';
 import breakpoints from '../utils/breakpoints';
 import Pagination from './index';
+import IconButton from '../IconButton/index';
 
 const baseProps = {
   paginationLabel: 'pagination navigation',
@@ -191,6 +192,15 @@ describe('<Pagination />', () => {
       const wrapper = mount(<Pagination {...props} />);
       wrapper.find('button.next').simulate('click');
       expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses IconButton component for previous and next button for small size', () => {
+      const props = {
+        ...baseProps,
+        size: 'small',
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      expect(wrapper.find(IconButton)).toHaveLength(2);
     });
   });
 

--- a/src/Pagination/README.md
+++ b/src/Pagination/README.md
@@ -96,3 +96,15 @@ Navigation between multiple pages of some set of results. Controls are provided 
   }}
 />
 ```
+
+### With small size setting
+
+```jsx live
+<Pagination
+  paginationLabel="pagination navigation"
+  pageCount={20}
+  currentPage={15}
+  onPageSelect={() => console.log('page selected')}
+  size="small"
+/>
+```

--- a/src/Pagination/_variables.scss
+++ b/src/Pagination/_variables.scss
@@ -11,7 +11,7 @@ $pagination-line-height:            1.25 !default;
 
 $pagination-color:                  $link-color !default;
 $pagination-bg:                     $white !default;
-$pagination-border-width:           $border-width !default;
+$pagination-border-width:           0 !default;
 $pagination-border-color:           theme-color("gray", "border") !default;
 
 $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -204,7 +204,7 @@ class Pagination extends React.Component {
             alt={ariaLabel}
             size="sm"
             tabIndex={isFirstPage ? '-1' : undefined}
-            inputRef={(element) => { this.previousButtonRef = element; }}
+            ref={(element) => { this.previousButtonRef = element; }}
           />
         )
           : (
@@ -266,7 +266,7 @@ class Pagination extends React.Component {
             alt={ariaLabel}
             size="sm"
             tabIndex={isLastPage ? '-1' : undefined}
-            inputRef={(element) => { this.nextButtonRef = element; }}
+            ref={(element) => { this.nextButtonRef = element; }}
           />
         )
           : (

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -7,6 +7,8 @@ import MediaQuery from 'react-responsive';
 
 import { Button } from '..';
 import Icon from '../Icon';
+import IconButton from '../IconButton';
+import { ChevronRight, ChevronLeft } from '../../icons';
 import breakpoints from '../utils/breakpoints';
 import newId from '../utils/newId';
 import { ELLIPSIS } from './constants';
@@ -135,7 +137,7 @@ class Pagination extends React.Component {
 
   renderPageOfCountButton() {
     const { currentPage } = this.state;
-    const { pageCount, buttonLabels } = this.props;
+    const { pageCount, buttonLabels, size } = this.props;
 
     const ariaLabel = `${buttonLabels.page} ${currentPage}, ${buttonLabels.currentPage}, ${buttonLabels.pageOfCount} ${pageCount}`;
 
@@ -156,7 +158,7 @@ class Pagination extends React.Component {
           className={classNames([
             'btn',
             'page-link',
-            'mx-2',
+            { 'mx-2': size !== 'small' },
             'border-0',
           ])}
           aria-label={ariaLabel}
@@ -168,7 +170,7 @@ class Pagination extends React.Component {
   }
 
   renderPreviousButton() {
-    const { buttonLabels, icons } = this.props;
+    const { buttonLabels, icons, size } = this.props;
     const { currentPage } = this.state;
     const isFirstPage = currentPage === 1;
     const previousPage = isFirstPage ? null : currentPage - 1;
@@ -182,30 +184,47 @@ class Pagination extends React.Component {
       <li
         className={classNames(
           'page-item',
+          'previous-item',
           {
             disabled: isFirstPage,
           },
         )}
       >
-        <Button.Deprecated
-          className="previous page-link"
-          aria-label={ariaLabel}
-          tabIndex={isFirstPage ? '-1' : undefined}
-          onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
-          inputRef={(element) => { this.previousButtonRef = element; }}
-          disabled={isFirstPage}
-        >
-          <div>
-            {icons.leftIcon}
-            {buttonLabels.previous}
-          </div>
-        </Button.Deprecated>
+        {size === 'small' ? (
+          <IconButton
+            iconAs={Icon}
+            src={ChevronLeft}
+            onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
+            alt={ariaLabel}
+            size="sm"
+          />
+        )
+          : (
+            <Button.Deprecated
+              className="previous page-link"
+              aria-label={ariaLabel}
+              tabIndex={isFirstPage ? '-1' : undefined}
+              onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
+              inputRef={(element) => { this.previousButtonRef = element; }}
+              disabled={isFirstPage}
+            >
+              <div>
+                {icons.leftIcon}
+                {buttonLabels.previous}
+              </div>
+            </Button.Deprecated>
+          )}
       </li>
     );
   }
 
   renderNextButton() {
-    const { buttonLabels, pageCount, icons } = this.props;
+    const {
+      buttonLabels,
+      pageCount,
+      icons,
+      size,
+    } = this.props;
     const { currentPage } = this.state;
     const isLastPage = currentPage === pageCount;
     const nextPage = isLastPage ? null : currentPage + 1;
@@ -219,24 +238,36 @@ class Pagination extends React.Component {
       <li
         className={classNames(
           'page-item',
+          'next-item',
           {
             disabled: isLastPage,
           },
         )}
       >
-        <Button.Deprecated
-          className="next page-link"
-          aria-label={ariaLabel}
-          tabIndex={isLastPage ? '-1' : undefined}
-          onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
-          inputRef={(element) => { this.nextButtonRef = element; }}
-          disabled={isLastPage}
-        >
-          <div>
-            {buttonLabels.next}
-            {icons.rightIcon}
-          </div>
-        </Button.Deprecated>
+        {size === 'small' ? (
+          <IconButton
+            iconAs={Icon}
+            src={ChevronRight}
+            onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
+            alt={ariaLabel}
+            size="sm"
+          />
+        )
+          : (
+            <Button.Deprecated
+              className="next page-link"
+              aria-label={ariaLabel}
+              tabIndex={isLastPage ? '-1' : undefined}
+              onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
+              inputRef={(element) => { this.nextButtonRef = element; }}
+              disabled={isLastPage}
+            >
+              <div>
+                {buttonLabels.next}
+                {icons.rightIcon}
+              </div>
+            </Button.Deprecated>
+          )}
       </li>
     );
   }
@@ -279,13 +310,18 @@ class Pagination extends React.Component {
   }
 
   render() {
+    const { size } = this.props;
     return (
       <nav
         aria-label={this.props.paginationLabel}
         className={this.props.className}
       >
         {this.renderScreenReaderSection()}
-        <ul className="pagination">
+        <ul className={classNames(
+          'pagination',
+          { 'pagination-small': size === 'small' },
+        )}
+        >
           {this.renderPreviousButton()}
           <MediaQuery maxWidth={breakpoints.extraSmall.maxWidth}>
             {this.renderPageOfCountButton()}
@@ -369,6 +405,11 @@ Pagination.propTypes = {
     leftIcon: PropTypes.node,
     rightIcon: PropTypes.node,
   }),
+  /**
+   * Specifies the size of pagination elements. If the 'small' size is passed,
+   * the IconButton component is used for the previous and next links.
+   */
+  size: PropTypes.oneOf(['default', 'small']),
 };
 
 Pagination.defaultProps = {
@@ -386,6 +427,7 @@ Pagination.defaultProps = {
   className: undefined,
   currentPage: 1,
   maxPagesDisplayed: 7,
+  size: 'default',
 };
 
 export default Pagination;

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -192,11 +192,19 @@ class Pagination extends React.Component {
       >
         {size === 'small' ? (
           <IconButton
+            className={classNames(
+              'mr-1',
+              {
+                disabled: isFirstPage,
+              },
+            )}
             iconAs={Icon}
             src={ChevronLeft}
             onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
             alt={ariaLabel}
             size="sm"
+            tabIndex={isFirstPage ? '-1' : undefined}
+            inputRef={(element) => { this.previousButtonRef = element; }}
           />
         )
           : (
@@ -246,11 +254,19 @@ class Pagination extends React.Component {
       >
         {size === 'small' ? (
           <IconButton
+            className={classNames(
+              'ml-1',
+              {
+                disabled: isLastPage,
+              },
+            )}
             iconAs={Icon}
             src={ChevronRight}
             onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
             alt={ariaLabel}
             size="sm"
+            tabIndex={isLastPage ? '-1' : undefined}
+            inputRef={(element) => { this.nextButtonRef = element; }}
           />
         )
           : (


### PR DESCRIPTION
## Summary of changes

This PR extends the Pagination component to accommodate the desired visual updates to it that will eventually be used on the Prospectus project

**Useful links:**

- Prospectus Jira Issue: https://openedx.atlassian.net/browse/WS-2499
- Figma mockup, Prospectus Desktop & Mobile pagination:  https://www.figma.com/file/TZfl1XuMdvWtphF1Tx0Dwo/2U-Product-Line-Integration-Exploration?node-id=1881%3A28793
- Figma mockup, Paragon Pagination spec: https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=9076%3A2630

The new `With small size setting` Pagination variation that was added to the documentation at `/components/pagination/` as part of this PR:

**desktop**
<img width="990" alt="Screen Shot 2022-01-31 at 2 58 04 PM" src="https://user-images.githubusercontent.com/13004299/151863806-4e6a978a-700a-492d-b235-6ec1e33d8396.png">

**mobile:**
<img width="466" alt="Screen Shot 2022-01-31 at 2 58 15 PM" src="https://user-images.githubusercontent.com/13004299/151863817-4a726514-18fe-4b96-b39c-11bba9f9e146.png">



