### PR TITLE
[BD-46] fix: update styles for ImageCap component

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -164,7 +164,7 @@
       border-top-left-radius: $card-image-border-radius;
       border-bottom-left-radius: $card-image-border-radius;
       border-top-right-radius: 0;
-      max-width: stretch;
+      max-width: inherit;
       width: auto;
       object-fit: cover;
     }


### PR DESCRIPTION
fix max-width style for ImageCap which caused images to overflow other content

example:
![image](https://user-images.githubusercontent.com/52399399/151814310-6f59a838-6045-4ef8-8cff-78d6c4b37715.png)
