### PR TITLE
fix: remove aria-label from span and move alt text to icon

### DIFF
--- a/src/Hyperlink/Hyperlink.scss
+++ b/src/Hyperlink/Hyperlink.scss
@@ -1,0 +1,5 @@
+.pgn__hyperlink__external-icon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: map_get($spacers, 2);
+}

--- a/src/Hyperlink/Hyperlink.test.jsx
+++ b/src/Hyperlink/Hyperlink.test.jsx
@@ -38,7 +38,7 @@ describe('correct rendering', () => {
   it('renders external Hyperlink', () => {
     const wrapper = mount(<Hyperlink {...externalLinkProps} />);
 
-    expect(wrapper.find('span')).toHaveLength(2);
+    expect(wrapper.find('span')).toHaveLength(3);
 
     const icon = wrapper.find('span').at(1);
     const iconImage = icon.find('svg').at(0);

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -43,12 +43,14 @@ const Hyperlink = React.forwardRef((props, ref) => {
     if (showLaunchIcon) {
       externalLinkIcon = (
         <span
-          // TODO: do not use css utility classes in components as they use !important, which hinders theming.
-          className="d-inline-block align-middle ml-2"
-          aria-label={externalLinkAlternativeText}
+          className="pgn__hyperlink__external-icon"
           title={externalLinkTitle}
         >
-          <Icon src={Launch} style={{ height: '1em', width: '1em' }} />
+          <Icon
+            src={Launch}
+            screenReaderText={externalLinkAlternativeText}
+            style={{ height: '1em', width: '1em' }}
+          />
         </span>
       );
     }

--- a/src/index.scss
+++ b/src/index.scss
@@ -14,6 +14,7 @@
 @import './Dropdown/Dropdown.scss';
 @import './Fieldset/Fieldset.scss';
 @import './Form/Form.scss';
+@import './Hyperlink//Hyperlink.scss';
 @import './Icon/Icon.scss';
 @import './Image/Image.scss';
 @import './Media/Media.scss';


### PR DESCRIPTION
See the following Lighthouse a11y error regarding `Hyperlink` with external URLs:

![image](https://user-images.githubusercontent.com/2828721/152600445-88114e20-6dd1-441c-8b94-e14716b85f0d.png)

This PR fixes the a11y error by removing `aria-label` from the `span` and instead simply passing its contents to the `screenReaderText` prop of `Icon` instead which has the same result.