### PR TITLE
[PAR-633] Add aria-selected to IconButtonToggle children

### DIFF
--- a/src/IconButtonToggle/IconButtonToggle.test.jsx
+++ b/src/IconButtonToggle/IconButtonToggle.test.jsx
@@ -19,7 +19,10 @@ describe('IconButtonToggle tests', () => {
         <IconButton value="abc" alt="abc" icon={iconPlane} />
       </IconButtonToggle>,
     );
-    expect(screen.getByTestId('icon-btn-val-abc')).toHaveClass('btn-icon-primary-active');
+    const btnAbc = screen.getByTestId('icon-btn-val-abc');
+
+    expect(btnAbc).toHaveClass('btn-icon-primary-active');
+    expect(btnAbc).toHaveAttribute('aria-selected', 'true');
   });
   test('switching activeValue works as expected', () => {
     const spyChanger = jest.fn();
@@ -31,11 +34,21 @@ describe('IconButtonToggle tests', () => {
     );
     const btnDef = screen.getByTestId('icon-btn-val-def');
     const btnAbc = screen.getByTestId('icon-btn-val-abc');
+
     expect(btnDef).toHaveClass('btn-icon-primary');
+    expect(btnDef).toHaveAttribute('aria-selected', 'false');
+
     expect(btnAbc).toHaveClass('btn-icon-primary-active');
+    expect(btnAbc).toHaveAttribute('aria-selected', 'true');
+
     userEvent.click(btnDef);
+
     waitFor(() => expect(btnDef).toHaveClass('btn-icon-primary-active'));
+    waitFor(() => expect(btnDef).toHaveAttribute('aria-selected', 'false'));
+
     waitFor(() => expect(btnAbc).toHaveClass('btn-icon-primary'));
+    waitFor(() => expect(btnAbc).toHaveAttribute('aria-selected', 'true'));
+
     expect(spyChanger).toHaveBeenCalledWith('def');
   });
 });

--- a/src/IconButtonToggle/index.jsx
+++ b/src/IconButtonToggle/index.jsx
@@ -13,13 +13,15 @@ import PropTypes from 'prop-types';
  */
 const IconButtonToggle = ({ activeValue, onChange, children }) => {
   const iconButtons = useMemo(
-    () => React.Children.map(children, iconButton => (
-      React.cloneElement(iconButton, {
+    () => React.Children.map(children, iconButton => {
+      const isActive = iconButton.props.value === activeValue;
+      return React.cloneElement(iconButton, {
         onClick: () => { onChange(iconButton.props.value); },
-        isActive: iconButton.props.value === activeValue,
+        isActive,
+        'aria-selected': isActive,
         'data-testid': `icon-btn-val-${iconButton.props.value}`,
-      })
-    )),
+      });
+    }),
     [children, activeValue, onChange],
   );
   return <div className="pgn__icon-button-toggle__container">{iconButtons}</div>;


### PR DESCRIPTION
Update `IconButtonToggle` children to use `aria-selected=true|false` based on the current `activeValue`.

- https://github.com/openedx/frontend-wg/issues/50
- https://openedx.atlassian.net/browse/PAR-633