### PR TITLE
fix: text wrapping issue for Toast

### DIFF
--- a/src/Toast/_Toast.scss
+++ b/src/Toast/_Toast.scss
@@ -28,7 +28,7 @@
     p {
       font-size: $small-font-size;
       margin: 0;
-      max-width: 320px;
+      padding-right: .75rem;
     }
     & + .btn {
       margin-top: 1rem;


### PR DESCRIPTION
On mobile screen the text is not wrapping correctly. 

|Before|After|
|-------|-----|
<img width="547" alt="Screenshot 2022-02-09 at 1 45 14 PM" src="https://user-images.githubusercontent.com/40633976/153178094-8b72222f-140b-479f-a602-3954c4f29320.png">|<img width="547" alt="Screenshot 2022-02-09 at 1 44 27 PM" src="https://user-images.githubusercontent.com/40633976/153178079-ac86afe4-a4ee-4f6c-b906-3e9d4dc5ac50.png">|

Ticket: https://openedx.atlassian.net/browse/VAN-847