### PR TITLE
[BD-46] feat: annotated progress bar

### DIFF
--- a/src/ProgressBar/ProgressBar.scss
+++ b/src/ProgressBar/ProgressBar.scss
@@ -74,6 +74,7 @@
     }
 
     .pgn__progress-info {
+        display: inline-block;
         position: relative;
     }
 

--- a/src/ProgressBar/ProgressBar.scss
+++ b/src/ProgressBar/ProgressBar.scss
@@ -7,4 +7,80 @@
 .progress-bar { 
     background-color: $progress-bar-bg;
 }
+
+.pgn__progress-annotated {
+    width: 100%;
+    position: relative;
+    overflow: visible;
+
+    .progress {
+        overflow: visible;
+        background-color: $light-300;
+        height: $annotated-progress-height;
+        border: none;
+
+        .progress-bar {
+            background-color: $annotated-progress-bar-bg;
+            overflow: visible;
+            position: relative;
+        }
+
+        .pgn__progress-tick--white::after,
+        .pgn__progress-tick--black::after {
+            content: '';
+            position: absolute;
+            height: $annotated-progress-height;
+            width: 1px;
+            right: 0;
+        }
+
+        .pgn__progress-tick--white::after {
+            background: $light-300;
+        }
+
+        .pgn__progress-tick--black::after {
+            background: $primary-500;
+        }
+
+        @each $name, $color in $progress-colors {
+            .pgn__progress-bar--#{$name} {
+                background-color: $color;
+            }
+
+            .pgn__progress-threshold-dot--#{$name} {
+                background: $color;
+                position: absolute;
+                margin-top: -($progress-threshold-circle / 2 - $annotated-progress-height / 2);
+                margin-left: -($progress-threshold-circle / 2);
+                width: $progress-threshold-circle;
+                height: $progress-threshold-circle;
+                border-radius: $progress-threshold-circle / 2;
+                z-index: 1;
+            }
+        }
+    }
+
+    .progress::before,
+    .progress::after {
+        position: absolute;
+        content: '';
+        height: $annotated-progress-height;
+        width: 1px;
+        background: $primary-500;
+    }
+
+    .progress::after {
+        right: 0;
+    }
+
+    .pgn__progress-info {
+        position: relative;
+    }
+
+    .pgn__progress-hint {
+        box-sizing: border-box;
+        padding: 0 $progress-hint-annotation-gap;
+        font-size: $small-font-size;
+    }
+}
   

--- a/src/ProgressBar/README.md
+++ b/src/ProgressBar/README.md
@@ -1,6 +1,9 @@
 ---
 title: 'Progress Bar'
 type: 'component'
+components:
+- ProgressBar
+- ProgressBarAnnotated
 categories:
 - Status & metadata
 status: 'Stable'
@@ -45,4 +48,21 @@ A bar to indicate the completed progress of a task.
   <br />
   <ProgressBar now={60} label="60%" variant="warning" />
 </div>
+```
+
+### Annotated variant
+
+```jsx live
+<>
+  <ProgressBar.Annotated
+    now={20}
+    label="20%"
+    variant="success"
+    threshold={50}
+    thresholdLabel="50%"
+    thresholdVariant="dark"
+    progressHint="Progress"
+    thresholdHint="Threshold"
+  />
+</>
 ```

--- a/src/ProgressBar/_variables.scss
+++ b/src/ProgressBar/_variables.scss
@@ -2,13 +2,23 @@
 // Progress bars
 
 $progress-height:                   1rem !default;
+$annotated-progress-height:         .3125rem !default;
 $progress-font-size:                $font-size-base * .75 !default;
 $progress-bg:                       transparent !default;
 $progress-border-radius:            0 !default;
 $progress-box-shadow:               none !default;
 $progress-bar-color:                $white !default;
 $progress-bar-bg:                   theme-color("accent-a") !default;
+$annotated-progress-bar-bg:         theme-color("dark") !default;
 $progress-bar-animation-timing:     1s linear infinite !default;
 $progress-bar-transition:           width .6s ease !default;
 $progress-bar-border-width:         1px !default;
 $progress-bar-border-color:         $gray-500 !default;
+$progress-threshold-circle:         .5625rem !default;
+$progress-hint-annotation-gap:      .5rem !default;
+$progress-colors: (
+        'dark':    $primary-500,
+        'success': $success-500,
+        'error':   $danger-500,
+        'warning': $accent-b,
+) !default;

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -111,7 +111,7 @@ ProgressBarAnnotated.propTypes = {
   /** Current value of progress. */
   now: PropTypes.number,
   /** Show label that represents visual percentage. */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /** The `ProgressBar` style variant to use. */
   variant: PropTypes.oneOf(VARIANTS),
   /** Specifies an additional `className` to add to the base element. */
@@ -121,13 +121,13 @@ ProgressBarAnnotated.propTypes = {
   /** Threshold current value. */
   threshold: PropTypes.number,
   /** Specifies label for `threshold`. */
-  thresholdLabel: PropTypes.string,
+  thresholdLabel: PropTypes.node,
   /** Variant for threshold value. */
   thresholdVariant: PropTypes.oneOf(VARIANTS),
   /** Text near the progress annotation. */
-  progressHint: PropTypes.string,
+  progressHint: PropTypes.node,
   /** Text near the threshold annotation. */
-  thresholdHint: PropTypes.string,
+  thresholdHint: PropTypes.node,
 };
 
 ProgressBarAnnotated.defaultProps = {

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -1,1 +1,147 @@
-export { default } from 'react-bootstrap/ProgressBar';
+import React, { useEffect } from 'react';
+import ProgressBarBase from 'react-bootstrap/ProgressBar';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Annotation from '../Annotation';
+import { placeInfoAtZero } from './utils';
+
+export const ANNOTATION_CLASS = 'pgn__annotation';
+const HINT_SWAP_PERCENT = 50;
+const PROGRESS_DEFAULT_VARIANT = 'warning';
+const THRESHOLD_DEFAULT_VARIANT = 'dark';
+const VARIANTS = [
+  'dark',
+  'warning',
+  'success',
+  'error',
+];
+
+const ProgressBar = (props) => <ProgressBarBase {...props} />;
+
+const ProgressBarAnnotated = ({
+  now,
+  label,
+  variant,
+  threshold,
+  thresholdLabel,
+  thresholdVariant,
+  progressHint,
+  thresholdHint,
+  ...props
+}) => {
+  const progressInfoRef = React.useRef();
+  const thresholdInfoRef = React.useRef();
+  const thresholdPercent = (threshold || 0) - (now || 0);
+  const isProgressHintAfter = now < HINT_SWAP_PERCENT;
+  const isThresholdHintAfter = threshold < HINT_SWAP_PERCENT;
+  const progressColor = VARIANTS.includes(variant) ? variant : PROGRESS_DEFAULT_VARIANT;
+  const thresholdColor = VARIANTS.includes(thresholdVariant) ? thresholdVariant : THRESHOLD_DEFAULT_VARIANT;
+
+  useEffect(() => {
+    placeInfoAtZero(progressInfoRef, isProgressHintAfter, ANNOTATION_CLASS);
+    placeInfoAtZero(thresholdInfoRef, isThresholdHintAfter, ANNOTATION_CLASS);
+  }, []);
+
+  const getHint = (text) => (
+    <span className="pgn__progress-hint">
+      {text}
+    </span>
+  );
+
+  return (
+    <div className="pgn__progress-annotated">
+      {!!label && (
+        <div
+          className="pgn__progress-info"
+          style={{ left: `${now}%` }}
+          ref={progressInfoRef}
+        >
+          {!isProgressHintAfter && getHint(progressHint)}
+          <Annotation variant={progressColor}>
+            {label}
+          </Annotation>
+          {isProgressHintAfter && getHint(progressHint)}
+        </div>
+      )}
+      <ProgressBarBase>
+        <ProgressBarBase
+          {...props}
+          now={now}
+          className={classNames(
+            `pgn__progress-bar--${progressColor}`,
+            thresholdPercent > 0 ? 'pgn__progress-tick--white' : 'pgn__progress-tick--black',
+          )}
+          srOnly
+        />
+        {!!threshold && (
+          <ProgressBarBase
+            now={thresholdPercent}
+            className={`pgn__progress-bar--${thresholdColor}`}
+            srOnly
+          />
+        )}
+        {!!threshold && (
+          <div
+            className={`pgn__progress-threshold-dot--${thresholdColor}`}
+            style={{ left: `${threshold}%` }}
+          />
+        )}
+      </ProgressBarBase>
+      {(!!threshold && !!thresholdLabel) && (
+        <div
+          className="pgn__progress-info"
+          style={{ left: `${threshold}%` }}
+          ref={thresholdInfoRef}
+        >
+          {!isThresholdHintAfter && getHint(thresholdHint)}
+          <Annotation
+            arrowPlacement="top"
+            variant={thresholdColor}
+          >
+            {thresholdLabel}
+          </Annotation>
+          {isThresholdHintAfter && getHint(thresholdHint)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+ProgressBarAnnotated.propTypes = {
+  /** Current value of progress. */
+  now: PropTypes.number,
+  /** Show label that represents visual percentage. */
+  label: PropTypes.string,
+  /** The `ProgressBar` style variant to use. */
+  variant: PropTypes.oneOf(VARIANTS),
+  /** Specifies an additional `className` to add to the base element. */
+  className: PropTypes.string,
+  /** Hide's the label visually. */
+  visuallyHidden: PropTypes.bool,
+  /** Threshold current value. */
+  threshold: PropTypes.number,
+  /** Specifies label for `threshold`. */
+  thresholdLabel: PropTypes.string,
+  /** Variant for threshold value. */
+  thresholdVariant: PropTypes.oneOf(VARIANTS),
+  /** Text near the progress annotation. */
+  progressHint: PropTypes.string,
+  /** Text near the threshold annotation. */
+  thresholdHint: PropTypes.string,
+};
+
+ProgressBarAnnotated.defaultProps = {
+  now: undefined,
+  label: undefined,
+  variant: PROGRESS_DEFAULT_VARIANT,
+  className: undefined,
+  visuallyHidden: false,
+  threshold: undefined,
+  thresholdLabel: undefined,
+  thresholdVariant: THRESHOLD_DEFAULT_VARIANT,
+  progressHint: undefined,
+  thresholdHint: undefined,
+};
+
+ProgressBar.Annotated = ProgressBarAnnotated;
+export default ProgressBar;

--- a/src/ProgressBar/tests/ProgressBar.test.jsx
+++ b/src/ProgressBar/tests/ProgressBar.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+
+import ProgressBar, { ANNOTATION_CLASS } from '../index';
+
+const ref = {
+  current: {
+    style: {
+      marginLeft: '',
+    },
+    children: [
+      {
+        className: `${ANNOTATION_CLASS} someClass`,
+        getBoundingClientRect: () => ({
+          width: 24.58123,
+        }),
+      },
+      {
+        className: 'anotherClass',
+        getBoundingClientRect: () => ({
+          width: 55.96844,
+        }),
+      },
+    ],
+  },
+};
+
+const ProgressBarElement = (props) => (
+  <ProgressBar.Annotated
+    now={20}
+    label="20%"
+    threshold={50}
+    thresholdLabel="50%"
+    {...props}
+  />
+);
+
+describe('<ProgressBar.Annotated />', () => {
+  describe('correct rendering', () => {
+    it('renders without props', () => {
+      const tree = renderer.create((
+        <ProgressBar.Annotated />
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it('renders info blocks with calculated margins', () => {
+      const useReferenceSpy = jest.spyOn(React, 'useRef').mockReturnValue(ref);
+      mount(<ProgressBarElement />);
+      expect(useReferenceSpy).toHaveBeenCalledTimes(2);
+      expect(ref.current.style.marginLeft).not.toBeFalsy();
+    });
+    it('renders correct variant for progress bar and annotation', () => {
+      const progressVariant = 'success';
+      const thresholdVariant = 'error';
+      const wrapper = mount(<ProgressBarElement variant={progressVariant} thresholdVariant={thresholdVariant} />);
+      expect(wrapper.find(`.pgn__annotation-${progressVariant}-bottom`).length).toBeGreaterThan(0);
+      expect(wrapper.find(`.pgn__progress-bar--${progressVariant}`).length).toBeGreaterThan(0);
+      expect(wrapper.find(`.pgn__annotation-${thresholdVariant}-top`).length).toBeGreaterThan(0);
+      expect(wrapper.find(`.pgn__progress-bar--${thresholdVariant}`).length).toBeGreaterThan(0);
+    });
+    it('renders default variant for progress bar and annotation', () => {
+      const wrapper = mount(<ProgressBarElement variant="wrongVariant" thresholdVariant="wrongVariant" />);
+      expect(wrapper.find('.pgn__annotation-warning-bottom').length).toBeGreaterThan(0);
+      expect(wrapper.find('.pgn__progress-bar--warning').length).toBeGreaterThan(0);
+      expect(wrapper.find('.pgn__annotation-dark-top').length).toBeGreaterThan(0);
+      expect(wrapper.find('.pgn__progress-bar--dark').length).toBeGreaterThan(0);
+    });
+    it('renders hints with text', () => {
+      const progressHint = 'first hint';
+      const thresholdHint = 'second hint';
+      const wrapper = mount(<ProgressBarElement progressHint={progressHint} thresholdHint={thresholdHint} />);
+      expect(wrapper.find('.pgn__progress-hint').length).toBeGreaterThan(0);
+      expect(wrapper.find('.pgn__progress-hint').at(0).text()).toEqual(progressHint);
+      expect(wrapper.find('.pgn__progress-hint').at(1).text()).toEqual(thresholdHint);
+    });
+    it('renders hints with text', () => {
+      const wrapper = mount(<ProgressBarElement now={30} threshold={40} />);
+      expect(wrapper.find('.pgn__progress-hint').length).toBeGreaterThan(0);
+      expect(wrapper.find('.pgn__progress-info').get(0).props.children[0]).toEqual(false);
+      expect(wrapper.find('.pgn__progress-info').get(1).props.children[0]).toEqual(false);
+      wrapper.setProps({ now: 70, threshold: 70 });
+      expect(wrapper.find('.pgn__progress-info').get(0).props.children[2]).toEqual(false);
+      expect(wrapper.find('.pgn__progress-info').get(1).props.children[2]).toEqual(false);
+    });
+  });
+});

--- a/src/ProgressBar/tests/__snapshots__/ProgressBar.test.jsx.snap
+++ b/src/ProgressBar/tests/__snapshots__/ProgressBar.test.jsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProgressBar.Annotated /> correct rendering renders without props 1`] = `
+<div
+  className="pgn__progress-annotated"
+>
+  <div
+    className="progress"
+  >
+    <div
+      aria-valuemax={100}
+      aria-valuemin={0}
+      className="pgn__progress-bar--warning pgn__progress-tick--black progress-bar"
+      role="progressbar"
+      style={
+        Object {
+          "width": "NaN%",
+        }
+      }
+      visuallyHidden={false}
+    >
+      <span
+        className="sr-only"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/ProgressBar/tests/utils.test.js
+++ b/src/ProgressBar/tests/utils.test.js
@@ -1,0 +1,80 @@
+import { placeInfoAtZero } from '../utils';
+import { ANNOTATION_CLASS } from '../index';
+
+const ref = {
+  current: {
+    style: {
+      marginLeft: '',
+    },
+    children: [
+      {
+        className: `${ANNOTATION_CLASS} someClass`,
+        getBoundingClientRect: () => ({
+          width: 24.58123,
+        }),
+      },
+      {
+        className: 'anotherClass',
+        getBoundingClientRect: () => ({
+          width: 55.96844,
+        }),
+      },
+    ],
+  },
+};
+
+describe('utils', () => {
+  describe('placeInfoAtZero', () => {
+    it('changes left margin of the ref.current.style', () => {
+      const previousValue = ref.current.style.marginLeft;
+      placeInfoAtZero(ref);
+      const changedValue = ref.current.style.marginLeft;
+      expect(previousValue).not.toEqual(changedValue);
+    });
+    it('correctly calculates left margin when ref is passed', () => {
+      placeInfoAtZero(ref);
+
+      const { children } = ref.current;
+      let marginLeft = 0.0;
+      for (let i = 0; i < children.length || 0; i++) {
+        const elementParams = children[i].getBoundingClientRect();
+        if (children[i].className.includes(ANNOTATION_CLASS)) {
+          marginLeft += elementParams.width / 2;
+        } else {
+          marginLeft += 0;
+        }
+      }
+      const expectedMarginLeft = `${-marginLeft}px`;
+      const actualMarginLeft = ref.current.style.marginLeft;
+
+      expect(actualMarginLeft).toEqual(expectedMarginLeft);
+    });
+    it('correctly calculates left margin when annotationOnly equals to true', () => {
+      placeInfoAtZero(ref, false);
+
+      const { children } = ref.current;
+      let marginLeft = 0.0;
+      for (let i = 0; i < children.length || 0; i++) {
+        const elementParams = children[i].getBoundingClientRect();
+        if (children[i].className.includes(ANNOTATION_CLASS)) {
+          marginLeft += elementParams.width / 2;
+        } else {
+          marginLeft += elementParams.width;
+        }
+      }
+      const expectedMarginLeft = `${-marginLeft}px`;
+      const actualMarginLeft = ref.current.style.marginLeft;
+
+      expect(actualMarginLeft).toEqual(expectedMarginLeft);
+    });
+    it('returns false if reference is wrong', () => {
+      const wrongRef1 = {};
+      const wrongRef2 = { current: {} };
+      expect(placeInfoAtZero(wrongRef1)).toEqual(false);
+      expect(placeInfoAtZero(wrongRef2)).toEqual(false);
+    });
+    it('returns true if reference is wrong', () => {
+      expect(placeInfoAtZero(ref)).toEqual(true);
+    });
+  });
+});

--- a/src/ProgressBar/utils.js
+++ b/src/ProgressBar/utils.js
@@ -1,0 +1,26 @@
+/**
+ * Gets the current annotation styles and calculates the left margin so
+ * that the annotation pointer indicates on zero of the ProgressBar.
+ *
+ * @param {object} ref reference to the info block
+ * @param {boolean} annotationOnly ignores width of the hint
+ * @param {string} annotationClass is used to identify the annotation element
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const placeInfoAtZero = (ref, annotationOnly = true, annotationClass = 'pgn__annotation') => {
+  if (!ref.current || !ref.current.style) { return false; }
+  const { children } = ref.current;
+  let marginLeft = 0.0;
+
+  for (let i = 0; i < children.length || 0; i++) {
+    const elementParams = children[i].getBoundingClientRect();
+    if (children[i].className.includes(annotationClass)) {
+      marginLeft += elementParams.width / 2;
+    } else {
+      marginLeft += annotationOnly ? 0.0 : elementParams.width;
+    }
+  }
+  // eslint-disable-next-line no-param-reassign
+  ref.current.style.marginLeft = `${-marginLeft}px`;
+  return true;
+};


### PR DESCRIPTION
Added `ProgressBar.Annotated` component:
- component styling
- `threshold` interaction with the `current progress`
- new properties for `threshold`
- offset calculations for the annotation
- determine whether the hint is displayed before or after the annotation

JIRA: [PAR-462](https://openedx.atlassian.net/browse/PAR-462)