### PR TITLE
fix: address Pagination prop type warning and resolve eslint errors in `www`

### DIFF
--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -241,6 +241,7 @@ class Pagination extends React.Component {
                 onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
                 ref={(element) => { this.previousButtonRef = element; }}
                 disabled={isFirstPage}
+                alt="Go to previous page"
               />
             )
         }
@@ -298,6 +299,7 @@ class Pagination extends React.Component {
                 onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
                 ref={(element) => { this.nextButtonRef = element; }}
                 disabled={isLastPage}
+                alt="Go to next page"
               />
             )
         }

--- a/www/src/pages/404.jsx
+++ b/www/src/pages/404.jsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
+import React from 'react';
 
 import Layout from '../components/PageLayout';
 import SEO from '../components/SEO';
 
 const NotFoundPage = () => (
   <Layout>
+    {/* eslint-disable-next-line react/jsx-pascal-case */}
     <SEO title="404: Not found" />
     <h1>404: Not Found</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>

--- a/www/src/pages/foundations/colors.jsx
+++ b/www/src/pages/foundations/colors.jsx
@@ -103,10 +103,9 @@ export default function ColorsPage({ data }) {
   return (
     <Layout>
       <Container size="md" className="py-5">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <SEO title="Colors" />
-
         <h1>Colors</h1>
-
         <div className="d-flex flex-wrap">
           {colors
             .slice(0, 3)

--- a/www/src/pages/foundations/spacing.jsx
+++ b/www/src/pages/foundations/spacing.jsx
@@ -53,9 +53,9 @@ export default function SpacingPage() {
   return (
     <Layout>
       <Container size="md" className="py-5">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <SEO title="Spacing" />
         <h1>Spacing</h1>
-
         <h3>Margin</h3>
         <p>
           Margin utilities are structured as{' '}

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -41,10 +41,9 @@ export default function TypographyPage() {
   return (
     <Layout>
       <Container size="xl" className="py-5">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <SEO title="Typography" />
-
         <h1>Typography</h1>
-
         <table className="w-100 table pgn-doc__status-table">
           <tbody>
             <tr>

--- a/www/src/pages/insights.jsx
+++ b/www/src/pages/insights.jsx
@@ -175,6 +175,7 @@ export default function InsightsPage() {
   return (
     <Layout>
       <Container size="md" className="py-5">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <SEO title="Usage Insights" />
         <header className="mb-5">
           <h1>Usage Insights</h1>

--- a/www/src/pages/status.jsx
+++ b/www/src/pages/status.jsx
@@ -9,8 +9,8 @@ export default function StatusPage() {
   return (
     <Layout>
       <Container size="md" className="py-5">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <SEO title="Status" />
-
         <h1>Library Status</h1>
 
         <h3>Components Status</h3>

--- a/www/src/templates/component-page-template.jsx
+++ b/www/src/templates/component-page-template.jsx
@@ -40,6 +40,7 @@ export default function PageTemplate({
 
   return (
     <Layout>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title={mdx.frontmatter.title} />
       <Container size="md" className="py-5">
         {isDeprecated && (

--- a/www/src/templates/default-mdx-page-template.jsx
+++ b/www/src/templates/default-mdx-page-template.jsx
@@ -17,6 +17,7 @@ const shortcodes = {
 export default function PageTemplate({ children, pageContext }) {
   return (
     <Layout>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title={pageContext?.frontmatter?.title} />
       <Container size="md" className="py-5">
         <MDXProvider components={shortcodes}>{children}</MDXProvider>


### PR DESCRIPTION
While upgrading Paragon, it was observed there's a prop type warning when using `DataTable`'s pagination, where `alt` prop is not passed to the `IconButton` components. This PR ensures we pass `alt` prop to `IconButton` components in `Pagination`.

It also disables an eslint rule when using the `SEO` component due to the component name.