### PR TITLE
[BD-46] feat: add insights tabs routing

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -72,6 +72,13 @@ const plugins = [
       ],
     },
   },
+  {
+    resolve: 'gatsby-plugin-page-creator',
+    options: {
+      path: `${__dirname}/src/pages`,
+      ignore: ['insights.jsx'],
+    },
+  },
 ];
 
 if (process.env && process.env.SEGMENT_KEY) {

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -10,6 +10,7 @@ const { createFilePath } = require(`gatsby-source-filesystem`)
 const sass = require('sass')
 const css = require('css')
 const fs = require(`fs`)
+const { INSIGHTS_PAGES } = require('./src/config');
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
@@ -113,6 +114,15 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       context: { id: node.id, components: node.frontmatter.components || [], cssVariables },
     })
   })
+
+  INSIGHTS_PAGES.forEach(({ path, tab }) => {
+    createPage({
+      path,
+      component: require.resolve('./src/pages/insights.jsx'),
+      context: { tab },
+    });
+  })
+
 }
 
 function createCssUtilityClassNodes({

--- a/www/src/config.js
+++ b/www/src/config.js
@@ -17,3 +17,29 @@
 // export const FEATURES = {
 //   EXAMPLE_FEATURE: process.env.EXAMPLE_FEATURE || hasFeatureFlagEnabled(EXAMPLE_FEATURE),
 // };
+
+const INSIGHTS_TABS = Object.freeze({
+  SUMMARY: 'Summary',
+  PROJECTS: 'Projects',
+  COMPONENTS: 'Components',
+});
+
+const INSIGHTS_PAGES = [
+  {
+    tab: INSIGHTS_TABS.SUMMARY,
+    path: '/insights',
+  },
+  {
+    tab: INSIGHTS_TABS.PROJECTS,
+    path: '/insights/projects',
+  },
+  {
+    tab: INSIGHTS_TABS.COMPONENTS,
+    path: '/insights/components',
+  },
+];
+
+module.exports = {
+  INSIGHTS_TABS,
+  INSIGHTS_PAGES,
+};

--- a/www/src/pages/insights.jsx
+++ b/www/src/pages/insights.jsx
@@ -14,6 +14,7 @@ import ProjectUsageExamples from '../components/insights/ProjectUsageExamples';
 import ComponentUsageExamples from '../components/insights/ComponentUsageExamples';
 import getGithubProjectUrl from '../utils/getGithubProjectUrl';
 import dependentProjectsAnalysis from '../../../dependent-usage.json';
+import { INSIGHTS_TABS, INSIGHTS_PAGES } from '../config';
 
 const {
   lastModified: analysisLastUpdated,
@@ -173,22 +174,11 @@ const ComponentsUsage = () => (
   </div>
 );
 
-export default function InsightsPage() {
-  const tabs = ['/insights', '/insights/?tab=projects', '/insights/?tab=components'];
-
+export default function InsightsPage({ pageContext: { tab } }) {
   const handleOnSelect = (value) => {
-    switch (value) {
-      case tabs[0]:
-        global.analytics.track('Usage Insights', { tab: 'Summary' });
-        break;
-      case tabs[1]:
-        global.analytics.track('Usage Insights', { tab: 'Projects' });
-        break;
-      case tabs[2]:
-        global.analytics.track('Usage Insights', { tab: 'Components' });
-        break;
-      default:
-        break;
+    if (value !== tab) {
+      global.analytics.track('Usage Insights', { tab: value });
+      navigate(INSIGHTS_PAGES.find(item => item.tab === value).path);
     }
   };
 
@@ -202,17 +192,17 @@ export default function InsightsPage() {
           <p>Last updated: {new Date(analysisLastUpdated).toLocaleDateString()}</p>
         </header>
         <Tabs
-          defaultKey={tabs[0]}
+          activeKey={tab}
           id="uncontrolled-tab-example"
           onSelect={handleOnSelect}
         >
-          <Tab eventKey={tabs[0]} title="Summary">
+          <Tab eventKey={INSIGHTS_TABS.SUMMARY} title="Summary">
             <SummaryUsage />
           </Tab>
-          <Tab eventKey={tabs[1]} title="Projects">
+          <Tab eventKey={INSIGHTS_TABS.PROJECTS} title="Projects">
             <ProjectsUsage />
           </Tab>
-          <Tab eventKey={tabs[2]} title="Components">
+          <Tab eventKey={INSIGHTS_TABS.COMPONENTS} title="Components">
             <ComponentsUsage />
           </Tab>
         </Tabs>
@@ -222,8 +212,7 @@ export default function InsightsPage() {
 }
 
 InsightsPage.propTypes = {
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
-    search: PropTypes.string,
+  pageContext: PropTypes.shape({
+    tab: PropTypes.oneOf(Object.values(INSIGHTS_TABS)),
   }).isRequired,
 };

--- a/www/src/pages/insights.jsx
+++ b/www/src/pages/insights.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { navigate } from 'gatsby';
+import PropTypes from 'prop-types';
 import {
   DataTable,
   Tabs,
@@ -218,3 +220,10 @@ export default function InsightsPage() {
     </Layout>
   );
 }
+
+InsightsPage.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    search: PropTypes.string,
+  }).isRequired,
+};


### PR DESCRIPTION
Insights routing update:
- tabs on the `insights` pages is linked with corresponding routes
- used search params for route changing
- added support for back button behavior

JIRA: [PAR-724](https://openedx.atlassian.net/browse/PAR-724)