### PR TITLE
feat!: update svgo config to 2.x version

### DIFF
--- a/icons/.svgrrc.js
+++ b/icons/.svgrrc.js
@@ -15,8 +15,15 @@ module.exports = {
     return exportEntries.join('\n')
   },
   svgoConfig: {
-    plugins: {
-      removeViewBox: false,
-    },
+    plugins: [
+      {
+        name: 'preset-default',
+        params: {
+          overrides: {
+            removeViewBox: false,
+          },
+        },
+      },
+    ],
   },
 };


### PR DESCRIPTION
This requires consumers to have updated to frontend-build 9.0.7
or greater (or otherwise be using svgo 2.x). The config changes
are not backwards-compatible.

Without this change, you may see errors like:
```
ERROR in ./node_modules/@edx/paragon/icons/svg/flag.svg
Module build failed (from ./node_modules/@svgr/webpack/dist/index.js):
Error: Invalid plugins list. Provided 'plugins' in config should be an array.
```