### PR TITLE
Adds showDismissButton prop to ProductTour checkpoints

### DIFF
--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -122,6 +122,7 @@ Checkpoint.defaultProps = {
   endButtonText: null,
   placement: 'top',
   title: null,
+  showDismissButton: undefined,
 };
 
 Checkpoint.propTypes = {
@@ -155,6 +156,8 @@ Checkpoint.propTypes = {
   title: PropTypes.node,
   /** The total number of Checkpoints in a tour */
   totalCheckpoints: PropTypes.number.isRequired,
+  /** Enforces visibility of the dismiss button under all circumstances */
+  showDismissButton: PropTypes.bool,
 };
 
 export default Checkpoint;

--- a/src/ProductTour/Checkpoint.test.jsx
+++ b/src/ProductTour/Checkpoint.test.jsx
@@ -135,4 +135,30 @@ describe('Checkpoint', () => {
       expect(breadcrumbs.length).toEqual(0);
     });
   });
+
+  describe('only one Checkpoint in Tour and showDismissButton set to true', () => {
+    it('it renders dismiss button and end button', () => {
+      render(
+        <>
+          <div id="#target-element" />
+          <Checkpoint
+            advanceButtonText="Next"
+            body="Lorem ipsum checkpoint body"
+            dismissButtonText="Dismiss"
+            endButtonText="End"
+            index={0}
+            onAdvance={handleAdvance}
+            onDismiss={handleDismiss}
+            onEnd={handleEnd}
+            target="#target-element"
+            title="Checkpoint title"
+            totalCheckpoints={1}
+            showDismissButton
+          />
+        </>,
+      );
+      expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
+    });
+  });
 });

--- a/src/ProductTour/CheckpointActionRow.jsx
+++ b/src/ProductTour/CheckpointActionRow.jsx
@@ -10,9 +10,10 @@ const CheckpointActionRow = React.forwardRef(({
   onAdvance,
   onDismiss,
   onEnd,
+  showDismissButton,
 }, ref) => (
   <div className="pgn__checkpoint-action-row" ref={ref}>
-    {!isLastCheckpoint && (
+    {(showDismissButton === undefined ? !isLastCheckpoint : showDismissButton) && (
       <Button
         variant="tertiary"
         className="pgn__checkpoint-button_dismiss"
@@ -40,6 +41,7 @@ CheckpointActionRow.defaultProps = {
   onAdvance: () => {},
   onDismiss: () => {},
   onEnd: () => {},
+  showDismissButton: undefined,
 };
 
 CheckpointActionRow.propTypes = {
@@ -57,6 +59,8 @@ CheckpointActionRow.propTypes = {
   onDismiss: PropTypes.func,
   /** A function that runs when triggering the `onClick` event of the advance button if isLastCheckpoint is true. */
   onEnd: PropTypes.func,
+  /** Enforces visibility of the dismiss button under all circumstances */
+  showDismissButton: PropTypes.bool,
 };
 
 export default CheckpointActionRow;

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -104,6 +104,7 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
       target={currentCheckpointData.target}
       title={currentCheckpointData.title}
       totalCheckpoints={prunedCheckpoints.length}
+      showDismissButton={currentCheckpointData.showDismissButton}
       ref={ref}
     />
   );
@@ -121,6 +122,7 @@ ProductTour.defaultProps = {
       onDismiss: () => {},
       placement: 'top',
       title: '',
+      showDismissButton: undefined,
     },
     dismissButtonText: '',
     endButtonText: '',
@@ -163,6 +165,8 @@ ProductTour.propTypes = {
       target: PropTypes.string.isRequired,
       /** The text displayed in the title of the Checkpoint */
       title: PropTypes.node,
+      /** Enforces visibility of the dismiss button under all circumstances */
+      showDismissButton: PropTypes.bool,
     })),
     /** The text displayed on the button used to dismiss the tour. */
     dismissButtonText: PropTypes.node,


### PR DESCRIPTION
The `showDismissButton` prop in ProductTour checkpoints enforces visibility of the dismiss button under all circumstances. This change is required for [ENT-5184](https://openedx.atlassian.net/browse/ENT-5184).