### PR TITLE
[BD-46] Improve tree-shaking detectability

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
According to [Bundlephobia](https://bundlephobia.com/package/@edx/paragon@19.10.1) Paragon does not support tree-shaking, even though local tests say otherwise. One possible reason is that package.json has no `module` entry, as can be seen from these two issues ([first](https://github.com/pastelsky/bundlephobia/issues/377), [second](https://github.com/pastelsky/bundlephobia/issues/457)).

By adding `module` entry we might be able to help services such as Bundlephobia to detect tree-shakability more easily.

JIRA: [PAR-746](https://openedx.atlassian.net/browse/PAR-746)