### PR TITLE
[BD-46] fix: prevent stretching in Stack

### DIFF
--- a/src/Stack/README.md
+++ b/src/Stack/README.md
@@ -17,7 +17,7 @@ Shorthand helpers that build on top of our flexbox utilities to make component l
 
 ### Vertical direction
 
-Stacks are vertical by default and stacked items are full-width by default. Watch this pull request to see more details about the [auto stretching behaviour](https://github.com/openedx/paragon/pull/1188).
+Stacks are vertical by default and stacked items are full-width by default. Watch this pull request to see more details about the [auto stretching behavior](https://github.com/openedx/paragon/pull/1188).
 
 ```jsx live
 <Stack gap={3}>

--- a/src/Stack/README.md
+++ b/src/Stack/README.md
@@ -17,11 +17,13 @@ Shorthand helpers that build on top of our flexbox utilities to make component l
 
 ### Vertical direction
 
+Stacks are vertical by default and stacked items are full-width by default. Watch this pull request to see more details about the [auto stretching behaviour](https://github.com/openedx/paragon/pull/1188).
+
 ```jsx live
 <Stack gap={3}>
-  <div className="border p-2">first block</div>
-  <div className="border p-2">second block</div>
-  <div className="border p-2">third block</div>
+  <Button>first button</Button>
+  <Button>second button</Button>
+  <Button>third button</Button>
 </Stack>
 ```
 

--- a/src/Stack/Stack.scss
+++ b/src/Stack/Stack.scss
@@ -2,7 +2,7 @@
 
 .pgn__vstack,
 .pgn__hstack {
-  display: inline-flex;
+  display: flex;
   align-self: stretch;
   gap: $stack-gap;
 

--- a/src/Stack/Stack.scss
+++ b/src/Stack/Stack.scss
@@ -2,7 +2,7 @@
 
 .pgn__vstack,
 .pgn__hstack {
-  display: flex;
+  display: inline-flex;
   align-self: stretch;
   gap: $stack-gap;
 


### PR DESCRIPTION
Fix auto stretching for the `Stack` component in the vertical mode

JIRA: [PAR-760](https://openedx.atlassian.net/browse/PAR-760)