### PR TITLE
[BD-46] feat: connect SCSS grid-breakpoints in breakpoints.js file

### DIFF
--- a/scss/core/_extend.module.scss
+++ b/scss/core/_extend.module.scss
@@ -1,0 +1,22 @@
+// Grid breakpoints
+//
+// Define the minimum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
+
+$grid-breakpoints: (
+        xs: 0,
+        sm: 576px,
+        md: 768px,
+        lg: 992px,
+        xl: 1200px,
+        xxl: 1400px
+) !default;
+
+:export {
+    xs: map-get($grid-breakpoints, 'xs');
+    sm: map-get($grid-breakpoints, 'sm');
+    md: map-get($grid-breakpoints, 'md');
+    lg: map-get($grid-breakpoints, 'lg');
+    xl: map-get($grid-breakpoints, 'xl');
+    xxl: map-get($grid-breakpoints, 'xxl');
+}

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -1,3 +1,5 @@
+@import "extend.module";
+
 // Variables
 // Variables
 //
@@ -445,18 +447,7 @@ $emphasized-link-hover-darken-percentage: 15% !default;
 $paragraph-margin-bottom:   1rem !default;
 
 
-// Grid breakpoints
-//
-// Define the minimum dimensions at which your layout will change,
-// adapting to different screen sizes, for use in media queries.
-
-$grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px
-) !default;
+// Grid breakpoints order
 
 @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
 @include _assert-starts-at-zero($grid-breakpoints, "$grid-breakpoints");

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -7,26 +7,26 @@ import {
 
 const breakpoints = {
   extraSmall: {
-    maxWidth: sm,
+    maxWidth: parseFloat(sm) || 575.98,
   },
   small: {
-    minWidth: sm,
-    maxWidth: md,
+    minWidth: parseFloat(sm) || 576,
+    maxWidth: parseFloat(md) || 767.98,
   },
   medium: {
-    minWidth: md,
-    maxWidth: lg,
+    minWidth: parseFloat(md) || 768,
+    maxWidth: parseFloat(lg) || 991.98,
   },
   large: {
-    minWidth: lg,
-    maxWidth: xl,
+    minWidth: parseFloat(lg) || 992,
+    maxWidth: parseFloat(xl) || 1199.98,
   },
   extraLarge: {
-    minWidth: xl,
-    maxWidth: xxl,
+    minWidth: parseFloat(xl) || 1200,
+    maxWidth: parseFloat(xxl) || 1399.98,
   },
   extraExtraLarge: {
-    minWidth: xxl,
+    minWidth: parseFloat(xxl) || 1400,
   },
 };
 

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -1,27 +1,32 @@
 // NOTE: These are the breakpoints used in Bootstrap v4.0.0 as seen in
 // the documentation (https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)
+
+import {
+  sm, md, lg, xl, xxl,
+} from '../../scss/core/_extend.module.scss';
+
 const breakpoints = {
   extraSmall: {
-    maxWidth: 575.98,
+    maxWidth: sm,
   },
   small: {
-    minWidth: 576,
-    maxWidth: 767.98,
+    minWidth: sm,
+    maxWidth: md,
   },
   medium: {
-    minWidth: 768,
-    maxWidth: 991.98,
+    minWidth: md,
+    maxWidth: lg,
   },
   large: {
-    minWidth: 992,
-    maxWidth: 1199.98,
+    minWidth: lg,
+    maxWidth: xl,
   },
   extraLarge: {
-    minWidth: 1200,
-    maxWidth: 1399.98,
+    minWidth: xl,
+    maxWidth: xxl,
   },
   extraExtraLarge: {
-    minWidth: 1400,
+    minWidth: xxl,
   },
 };
 


### PR DESCRIPTION
- new file created `_extends.module.scss`;
- $grid-breakpoints moved to `_extends.module.scss`;
- added SCSS export to `breakpoints.js` file;
- breakpoints can now be edited from one file `_extends.module.scss`.

JIRA: [PAR-741](https://youtrack.raccoongang.com/issue/OeX_Paragon-341)