### PR TITLE
fix: rename box-shadow-control SCSS mixin to pgn-box-shadow

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -512,7 +512,7 @@ $level-3-box-shadow:          0 0 .625rem rgba(0, 0, 0, 0.15), 0 0 1rem rgba(0, 
 $level-4-box-shadow:          0 .625rem 1.25rem rgba(0, 0, 0, 0.15), 0 .5rem 1.25rem rgba(0, 0, 0, 0.15) !default;
 $level-5-box-shadow:          0 1.25px 2.5rem rgba(0, 0, 0, 0.15), 0 .5rem 2.5rem rgba(0, 0, 0, 0.15) !default;
 
-@mixin box-shadow-control ($level, $side) {
+@mixin pgn-box-shadow ($level, $side) {
   @if $side == 'down' {
     @if $level == 1 {
       box-shadow: 0 .0625rem .125rem rgba(0, 0, 0, .15), 0 .0625rem .25rem rgba(0, 0, 0, .15);

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -16,7 +16,7 @@
   margin-bottom: $alert-margin-bottom;
   border: $alert-border-width solid transparent;
   @include border-radius($alert-border-radius);
-  @include box-shadow-control(1, 'down');
+  @include pgn-box-shadow(1, 'down');
 
   .alert-message-content > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Description

This is a new SCSS mixin, which gives consumers the ability to add elevation (i.e., elevation) based on the pre-defined elevation levels in addition to a direction/side (e.g., top, right, centered).

### Deploy Preview

n/a (SCSS change only. There probably should be an `Elevation` foundations page in the documentation website. Taking an action item to file this ticket).

![image](https://user-images.githubusercontent.com/2828721/160619867-2c70bf4f-5ed3-491f-b413-d0800f63d107.png)


## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
