### PR TITLE
[BD-46] fix: accessor requirements update

### DIFF
--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -193,7 +193,7 @@ DataTable.propTypes = {
     /** String used to access the correct cell data for this column */
     accessor: requiredWhenNot(PropTypes.string, 'Cell'),
     /** Specifies a function that receives `row` as argument and returns cell content */
-    Cell: PropTypes.func,
+    Cell: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
     /** Specifies filter component */
     Filter: PropTypes.func,
     /** Specifies filter type */

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -6,7 +6,7 @@ import { useTable } from 'react-table';
 
 import Table from './Table';
 import getVisibleColumns from './utils/getVisibleColumns';
-import { requiredWhen } from '../utils/propTypesUtils';
+import { requiredWhen, requiredWhenNot } from '../utils/propTypesUtils';
 import getTableArgs from './utils/getTableArgs';
 import TableControlBar from './TableControlBar';
 import EmptyTableContent from './EmptyTable';
@@ -191,7 +191,18 @@ DataTable.propTypes = {
     /** User visible column name */
     Header: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
     /** String used to access the correct cell data for this column */
-    accessor: PropTypes.string,
+    accessor: requiredWhenNot(PropTypes.string, 'Cell'),
+    /** Specifies a function that receives `row` as argument and returns cell content */
+    Cell: PropTypes.func,
+    /** Specifies filter component. */
+    Filter: PropTypes.func,
+    /** Specifies filter type. */
+    filter: PropTypes.string,
+    filterChoices: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string,
+      number: PropTypes.number,
+      value: PropTypes.string,
+    })),
   })).isRequired,
   /** Data to be displayed in the table */
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -194,10 +194,11 @@ DataTable.propTypes = {
     accessor: requiredWhenNot(PropTypes.string, 'Cell'),
     /** Specifies a function that receives `row` as argument and returns cell content */
     Cell: PropTypes.func,
-    /** Specifies filter component. */
+    /** Specifies filter component */
     Filter: PropTypes.func,
-    /** Specifies filter type. */
+    /** Specifies filter type */
     filter: PropTypes.string,
+    /** Specifies filter choices */
     filterChoices: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string,
       number: PropTypes.number,


### PR DESCRIPTION
`columns` prop types update:
- added `Cell`
- `accessor` is required when not `Cell`
- along with that I found 3 more filters fields that can be passed. I defined them and added description

JIRA: [PAR-699](https://openedx.atlassian.net/browse/PAR-699)