### PR TITLE
fix: SCSS bug with calc

### DIFF
--- a/src/Form/_mixins.scss
+++ b/src/Form/_mixins.scss
@@ -22,9 +22,7 @@
 ) {
   .pgn__form-control-floating-label-text {
     $half-leading: calc(($line-height - 0.8) / 2);
-    $percent-height-minus-no-bottom-leading: (
-        calc(($line-height - $half-leading) / $line-height)
-      ) * 100%;
+    $percent-height-minus-no-bottom-leading: calc((($line-height - $half-leading) / $line-height) * 100%);
     transform: translateY(-$padding-y) scale(.75)  translateY(-$percent-height-minus-no-bottom-leading);
   }
 }


### PR DESCRIPTION
## Description

Fixes an issue with `latest` Paragon, post `bootstrap@latest-4` upgrade to fix the `calc` deprecation warnings, that is causing issues with consuming MFEs.

### Deploy Preview

n/a

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
