### PR TITLE
fix: no longer use math.div

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 .pgn__modal {
   background: $modal-content-bg;
   border-radius: $modal-content-inner-border-radius;
@@ -161,7 +159,7 @@
     display: block;
     height: 20px;
     position: sticky;
-    bottom: math.div(-$modal-inner-padding, 2);
+    bottom: calc($modal-inner-padding / 2 * -1);
     margin-bottom: -$modal-inner-padding;
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
@@ -238,7 +236,7 @@
     padding: calc($modal-inner-padding / 2) $modal-inner-padding;
 
     &::before {
-      top: math.div(-$modal-inner-padding, 2);
+      top: calc($modal-inner-padding / 2 * -1);
     }
   }
 }

--- a/www/src/components/Settings.jsx
+++ b/www/src/components/Settings.jsx
@@ -7,7 +7,6 @@ import {
 } from '~paragon-react';
 import { Close } from '~paragon-icons';
 
-import { FEATURES } from '../config';
 import SettingsContext from '../context/SettingsContext';
 import { THEMES } from '../../theme-config';
 

--- a/www/src/config.js
+++ b/www/src/config.js
@@ -1,6 +1,6 @@
-import hasFeatureFlagEnabled from './utils/hasFeatureFlagEnabled';
+// import hasFeatureFlagEnabled from './utils/hasFeatureFlagEnabled';
 
-export const EXAMPLE_FEATURE = 'EXAMPLE_FEATURE';
+// export const EXAMPLE_FEATURE = 'EXAMPLE_FEATURE';
 
 // Feature flags used throughout the site should be configured here.
 // You should generally allow two ways of enabling a feature flag:

--- a/www/src/pages/index.jsx
+++ b/www/src/pages/index.jsx
@@ -6,6 +6,7 @@ import SEO from '../components/SEO';
 
 const HomePage = () => (
   <Layout showMinimizedTitle hideFooterComponentMenu>
+    {/* eslint-disable-next-line react/jsx-pascal-case */}
     <SEO title="Home" />
     <div className="bg-dark text-white text-center py-5">
       <p className="x-small text-uppercase text-monospace mb-0">


### PR DESCRIPTION
## Description

Use of `math.div` appears to be causing issues for at least one consumer. This fix replaces `math.div` with an equivalent `calc`. Note because of the negative values, we are multiplying the value by -1 to force it to be negative.

### Deploy Preview

n/a

## Merge Checklist

n/a

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
