### PR TITLE
[BD-46] docs: added focus state in components

### DIFF
--- a/src/Breadcrumb/Breadcrumb.scss
+++ b/src/Breadcrumb/Breadcrumb.scss
@@ -7,34 +7,26 @@
       color: $breadcrumb-active-color;
     }
 
-        a.link-muted {
-            color: $breadcrumb-color;
-
-            &:focus {
-                position: relative;
-                outline: none;
-                box-shadow: none;
-                text-decoration: none;
-            }
-
-            &:focus::before {
-                content: '';
-                position: absolute;
-                top: -$breadcrumb-border-focus-axis-y;
-                right: -$breadcrumb-border-focus-axis-x;
-                bottom: -$breadcrumb-border-focus-axis-y;
-                left: -$breadcrumb-border-focus-axis-x;
-                border: $breadcrumb-border-focus-width solid $breadcrumb-color;
-                border-radius: $breadcrumb-focus-border-radius;
-            }
-        }
-        
-        [dir="rtl"] & {
-            margin-right: 0;
-            margin-left: $breadcrumb-margin-left;
-        }
     a.link-muted {
       color: $breadcrumb-color;
+
+      &:focus {
+        position: relative;
+        outline: none;
+        box-shadow: none;
+        text-decoration: none;
+      }
+
+      &:focus::before {
+        content: "";
+        position: absolute;
+        top: -$breadcrumb-border-focus-axis-y;
+        right: -$breadcrumb-border-focus-axis-x;
+        bottom: -$breadcrumb-border-focus-axis-y;
+        left: -$breadcrumb-border-focus-axis-x;
+        border: $breadcrumb-border-focus-width solid $breadcrumb-color;
+        border-radius: $breadcrumb-focus-border-radius;
+      }
     }
 
     [dir="rtl"] & {
@@ -55,14 +47,14 @@
         color: $breadcrumb-inverse-active;
       }
 
-            a.link-muted {
-                color: $breadcrumb-inverse-color;
+      a.link-muted {
+        color: $breadcrumb-inverse-color;
 
-                &:focus::before {
-                    border: $breadcrumb-border-focus-width solid $breadcrumb-inverse-color;
-                }
-            }
+        &:focus::before {
+          border: $breadcrumb-border-focus-width solid $breadcrumb-inverse-color;
         }
+      }
+    }
 
     .pgn__icon,
     .custom-spacer {

--- a/src/Breadcrumb/Breadcrumb.scss
+++ b/src/Breadcrumb/Breadcrumb.scss
@@ -7,6 +7,32 @@
       color: $breadcrumb-active-color;
     }
 
+        a.link-muted {
+            color: $breadcrumb-color;
+
+            &:focus {
+                position: relative;
+                outline: none;
+                box-shadow: none;
+                text-decoration: none;
+            }
+
+            &:focus::before {
+                content: '';
+                position: absolute;
+                top: -$breadcrumb-border-focus-axis-y;
+                right: -$breadcrumb-border-focus-axis-x;
+                bottom: -$breadcrumb-border-focus-axis-y;
+                left: -$breadcrumb-border-focus-axis-x;
+                border: $breadcrumb-border-focus-width solid $breadcrumb-color;
+                border-radius: $breadcrumb-focus-border-radius;
+            }
+        }
+        
+        [dir="rtl"] & {
+            margin-right: 0;
+            margin-left: $breadcrumb-margin-left;
+        }
     a.link-muted {
       color: $breadcrumb-color;
     }
@@ -29,10 +55,14 @@
         color: $breadcrumb-inverse-active;
       }
 
-      a.link-muted {
-        color: $breadcrumb-inverse-color;
-      }
-    }
+            a.link-muted {
+                color: $breadcrumb-inverse-color;
+
+                &:focus::before {
+                    border: $breadcrumb-border-focus-width solid $breadcrumb-inverse-color;
+                }
+            }
+        }
 
     .pgn__icon,
     .custom-spacer {

--- a/src/Breadcrumb/_variables.scss
+++ b/src/Breadcrumb/_variables.scss
@@ -9,6 +9,11 @@ $breadcrumb-item-padding:           .5rem !default;
 $breadcrumb-margin-bottom:          1rem !default;
 $breadcrumb-margin-left:           .5rem !default;
 
+$breadcrumb-border-focus-axis-x:    .25rem !default;
+$breadcrumb-border-focus-axis-y:    .5rem !default;
+
+$breadcrumb-border-focus-width:     .0625rem !default;
+
 $breadcrumb-bg:                     $gray-200 !default;
 $breadcrumb-divider-color:          $gray-600 !default;
 $breadcrumb-active-color:           $gray-500 !default;
@@ -19,3 +24,4 @@ $breadcrumb-inverse-color:          $white !default;
 $breadcrumb-divider:                "/" !default;
 
 $breadcrumb-border-radius:          $border-radius !default;
+$breadcrumb-focus-border-radius:          .125rem !default;

--- a/src/Chip/Chip.scss
+++ b/src/Chip/Chip.scss
@@ -6,7 +6,7 @@
 
 @mixin chip-variant(
   $background, $border, $hover-background, $hover-border, $active-background,
-  $active-border, $color, $hover-color, $active-color
+  $active-border, $color, $hover-color, $active-color, $focus-border
 ) {
   background-color: $background;
   color: $color;
@@ -25,6 +25,17 @@
     background-color: $active-background;
     color: $active-color;
     border-color: $active-border;
+  }
+
+  &:focus::before {
+    content: '';
+    position: absolute;
+    top: -$chip-position-axis;
+    right: -$chip-position-axis;
+    bottom: -$chip-position-axis;
+    left: -$chip-position-axis;
+    border: $chip-border-width solid $focus-border;
+    border-radius: $chip-focus-border-radius;
   }
 
   &:disabled {
@@ -55,6 +66,12 @@
   border-radius: $chip-border-radius;
   border: $chip-border-width solid transparent;
   margin-inline: calc($chip-margin-inline / 2);
+
+  &:focus {
+    position: relative;
+    outline: none;
+    box-shadow: none;
+  }
 
   // Empty chip collapse automatically
   &:empty {
@@ -97,6 +114,8 @@
     $active-border: get-color("border", $color, "selected");
     $active-text: get-color("text", $color, "selected");
 
+    $focus-border: get-color("border", $color, "focus");
+
     @include chip-variant(
       $background,
       $border,
@@ -106,7 +125,9 @@
       $active-border,
       $text,
       $hover-text,
-      $active-text
+      $active-text,
+      $focus-border
     );
   }
 }
+

--- a/src/Chip/Chip.scss
+++ b/src/Chip/Chip.scss
@@ -129,4 +129,3 @@ $hover-color, $active-color, $focus-border) {
     );
   }
 }
-

--- a/src/Chip/Chip.scss
+++ b/src/Chip/Chip.scss
@@ -4,10 +4,9 @@
   @return map-get($chip-theme-colors, "#{$color}-#{$element}-#{$type}");
 }
 
-@mixin chip-variant(
-  $background, $border, $hover-background, $hover-border, $active-background,
-  $active-border, $color, $hover-color, $active-color, $focus-border
-) {
+@mixin chip-variant($background, $border, $hover-background,
+$hover-border, $active-background, $active-border, $color,
+$hover-color, $active-color, $focus-border) {
   background-color: $background;
   color: $color;
   border-color: $border;
@@ -28,7 +27,7 @@
   }
 
   &:focus::before {
-    content: '';
+    content: "";
     position: absolute;
     top: -$chip-position-axis;
     right: -$chip-position-axis;

--- a/src/Chip/_variables.scss
+++ b/src/Chip/_variables.scss
@@ -33,4 +33,3 @@ $chip-theme-colors: (
   "dark-text-selected":        $white,
   "dark-border-selected":      $white,
 ) !default;
-

--- a/src/Chip/_variables.scss
+++ b/src/Chip/_variables.scss
@@ -4,6 +4,8 @@ $chip-padding-y:                    .125rem !default;
 $chip-padding-x:                    .5rem !default;
 $chip-margin-inline:                .5rem !default;
 $chip-border-radius:                .4375rem !default;
+$chip-focus-border-radius:          .5rem !default;
+$chip-position-axis:                .125rem !default;
 $chip-border-width:                 .0625rem !default;
 $chip-font-size:                    .75rem !default;
 $chip-font-weight:                  400 !default;
@@ -31,3 +33,4 @@ $chip-theme-colors: (
   "dark-text-selected":        $white,
   "dark-border-selected":      $white,
 ) !default;
+

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -396,6 +396,27 @@ select.form-control {
   }
 }
 
+.pgn__form-checkbox-input,
+.pgn__form-radio-input {
+  &:focus {
+    position: relative;
+    outline: none;
+    box-shadow: none;
+    text-decoration: none;
+    border-color: $input-focus-border-color;
+  }
+  &:focus::before {
+    content: '';
+    position: absolute;
+    top: -$form-check-position-axis;
+    right: -$form-check-position-axis;
+    bottom: -$form-check-position-axis;
+    left: -$form-check-position-axis;
+    border: $form-check-border-width solid $input-focus-border-color;
+    border-radius: $form-check-focus-border-radius;
+  }
+}
+
 .pgn__form-switch-input {
   width: $custom-switch-width;
   border-radius: $custom-switch-indicator-border-radius;
@@ -427,6 +448,13 @@ select.form-control {
 
   &:checked {
     background-image: escape-svg($custom-radio-indicator-icon-checked);
+  }
+  &:focus {
+    border-color: $black;
+
+    &::before {
+      border-radius: $custom-radio-indicator-border-radius;
+    }
   }
 }
 

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -406,7 +406,7 @@ select.form-control {
     border-color: $input-focus-border-color;
   }
   &:focus::before {
-    content: '';
+    content: "";
     position: absolute;
     top: -$form-check-position-axis;
     right: -$form-check-position-axis;
@@ -487,7 +487,6 @@ select.form-control {
       order: 1;
       margin-inline-end: $custom-control-gutter;
     }
-
     input {
       order: 2;
     }

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -405,6 +405,7 @@ select.form-control {
     text-decoration: none;
     border-color: $input-focus-border-color;
   }
+
   &:focus::before {
     content: "";
     position: absolute;
@@ -449,6 +450,7 @@ select.form-control {
   &:checked {
     background-image: escape-svg($custom-radio-indicator-icon-checked);
   }
+
   &:focus {
     border-color: $black;
 
@@ -487,6 +489,7 @@ select.form-control {
       order: 1;
       margin-inline-end: $custom-control-gutter;
     }
+
     input {
       order: 2;
     }

--- a/src/Form/_variables.scss
+++ b/src/Form/_variables.scss
@@ -64,6 +64,10 @@ $form-check-input-margin-x:             .25rem !default;
 $form-check-inline-margin-x:            .75rem !default;
 $form-check-inline-input-margin-x:      .3125rem !default;
 
+$form-check-position-axis:              .375rem !default;
+$form-check-focus-border-radius:        .0625rem !default;
+$form-check-border-width:               .125rem !default;
+
 $form-grid-gutter-width:                10px !default;
 $form-group-margin-bottom:              1rem !default;
 
@@ -87,7 +91,7 @@ $custom-control-indicator-border-color: $gray-700 !default;
 $custom-control-indicator-border-width: 2px !default;
 
 $custom-control-label-color:            null !default;
-
+$form-black: $black;
 $custom-control-indicator-disabled-bg:          $input-disabled-bg !default;
 $custom-control-label-disabled-color:           theme-color("gray", "light-text") !default;
 

--- a/src/Form/_variables.scss
+++ b/src/Form/_variables.scss
@@ -91,7 +91,6 @@ $custom-control-indicator-border-color: $gray-700 !default;
 $custom-control-indicator-border-width: 2px !default;
 
 $custom-control-label-color:            null !default;
-$form-black: $black;
 $custom-control-indicator-disabled-bg:          $input-disabled-bg !default;
 $custom-control-label-disabled-color:           theme-color("gray", "light-text") !default;
 

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -67,8 +67,9 @@
     box-shadow: none;
   }
 
-  &.btn-primary:focus:before {
+  &.btn-primary:focus::before {
     border: $pagination-focus-border-width solid $pagination-focus-color;
+
     @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
   }
 

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -94,9 +94,9 @@
     line-height: $pagination-line-height;
   }
 
-  &.active .page-link:focus {
-    background-color: $pagination-focus-color !important;
-    color: $pagination-bg !important;
+  &.active .page-link.btn-primary:not(:disabled):not(.disabled):focus {
+    background-color: $pagination-focus-color;
+    color: $pagination-bg;
   }
 }
 

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -58,6 +58,11 @@
 .page-link {
   border: none;
 
+  &.btn-primary:not(:disabled):not(.disabled):focus {
+    background-color: white;
+    color: #000;
+  }
+
   div {
     display: flex;
   }

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -59,8 +59,17 @@
   border: none;
 
   &.btn-primary:not(:disabled):not(.disabled):focus {
-    background-color: white;
-    color: #000;
+    background-color: $pagination-bg;
+    color: $black;
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+
+  &.btn-primary:focus:before {
+    border: 2px solid $primary-500;
+    @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
   }
 
   div {
@@ -83,6 +92,11 @@
   > .btn {
     transition: none;
     line-height: $pagination-line-height;
+  }
+
+  &.active .page-link:focus {
+    background-color: $primary-500 !important;
+    color: $pagination-bg !important;
   }
 }
 

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -60,7 +60,7 @@
 
   &.btn-primary:not(:disabled):not(.disabled):focus {
     background-color: $pagination-bg;
-    color: $black;
+    color: $pagination-focus-color-text;
   }
 
   &:focus {
@@ -68,7 +68,7 @@
   }
 
   &.btn-primary:focus:before {
-    border: 2px solid $primary-500;
+    border: $pagination-focus-border-width solid $pagination-focus-color;
     @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
   }
 
@@ -95,7 +95,7 @@
   }
 
   &.active .page-link:focus {
-    background-color: $primary-500 !important;
+    background-color: $pagination-focus-color !important;
     color: $pagination-bg !important;
   }
 }

--- a/src/Pagination/_variables.scss
+++ b/src/Pagination/_variables.scss
@@ -29,6 +29,9 @@ $pagination-border-color:           theme-color("gray", "border") !default;
 
 $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
 $pagination-focus-outline:          0 !default;
+$pagination-focus-border-width:     .125rem !default;
+$pagination-focus-color:     $primary-500 !default;
+$pagination-focus-color-text:       $black !default;
 
 $pagination-hover-color:            $link-hover-color !default;
 $pagination-hover-bg:               theme-color("gray", "background") !default;

--- a/src/Pagination/_variables.scss
+++ b/src/Pagination/_variables.scss
@@ -30,7 +30,7 @@ $pagination-border-color:           theme-color("gray", "border") !default;
 $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
 $pagination-focus-outline:          0 !default;
 $pagination-focus-border-width:     .125rem !default;
-$pagination-focus-color:     $primary-500 !default;
+$pagination-focus-color:            $primary-500 !default;
 $pagination-focus-color-text:       $black !default;
 
 $pagination-hover-color:            $link-hover-color !default;

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -12,6 +12,7 @@
 
   &.has-focus {
     box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
+    border: 5px double $black;
 
     .pgn__searchfield_wrapper {
       box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
@@ -73,9 +74,13 @@
     &.has-focus {
       box-shadow: none;
 
-      .btn-primary {
-        background: map-get($search-btn-variants, "light");
-      }
+            .pgn__searchfield_wrapper {
+                border: 5px double $black;
+            }
+
+            .btn-primary {
+                background: map-get($search-btn-variants, "light");
+            }
 
       .btn-brand {
         background: map-get($search-btn-variants, "dark");

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -4,6 +4,20 @@
   transition: $input-transition;
   border: $search-border-width solid $search-border-color;
 
+  .btn:focus-visible {
+    outline: none;
+    position: relative;
+    transition: $input-transition;
+
+    &::after {
+      content: "";
+      border: $search-border-focus-width double $search-border-focus-color;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
   &.disabled,
   &:disabled {
     opacity: $search-disabled-opacity;

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -10,16 +10,16 @@
     pointer-events: none;
   }
 
-    &.has-focus:not(.pgn__searchfield--external) {
-        position: relative;
+  &.has-focus:not(.pgn__searchfield--external) {
+    position: relative;
 
-        &:after {
-            content: "";
-            border: $search-border-focus-width double $search-border-focus-color;
-            position: absolute;
-            width: 100%;
-            height: 100%;
-        }
+    &::after {
+      content: "";
+      border: $search-border-focus-width double $search-border-focus-color;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
 
     .pgn__searchfield_wrapper {
       box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
@@ -81,21 +81,21 @@
     &.has-focus {
       box-shadow: none;
 
-            .pgn__searchfield_wrapper {
-                position: relative;
+      .pgn__searchfield_wrapper {
+        position: relative;
 
-                &:after {
-                    content: "";
-                    border: $search-border-focus-width double $search-border-focus-color;
-                    position: absolute;
-                    width: 100%;
-                    height: 100%;
-                }
-            }
+        &::after {
+          content: "";
+          border: $search-border-focus-width double $search-border-focus-color;
+          position: absolute;
+          width: 100%;
+          height: 100%;
+        }
+      }
 
-            .btn-primary {
-                background: map-get($search-btn-variants, "light");
-            }
+      .btn-primary {
+        background: map-get($search-btn-variants, "light");
+      }
 
       .btn-brand {
         background: map-get($search-btn-variants, "dark");

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -10,9 +10,16 @@
     pointer-events: none;
   }
 
-    &.has-focus {
-        box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
-        border: $search-border-focus-width double $search-border-focus-color;
+    &.has-focus:not(.pgn__searchfield--external) {
+        position: relative;
+
+        &:after {
+            content: "";
+            border: $search-border-focus-width double $search-border-focus-color;
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }
 
     .pgn__searchfield_wrapper {
       box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
@@ -75,7 +82,15 @@
       box-shadow: none;
 
             .pgn__searchfield_wrapper {
-                border: $search-border-focus-width double $search-border-focus-color;
+                position: relative;
+
+                &:after {
+                    content: "";
+                    border: $search-border-focus-width double $search-border-focus-color;
+                    position: absolute;
+                    width: 100%;
+                    height: 100%;
+                }
             }
 
             .btn-primary {

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -10,9 +10,9 @@
     pointer-events: none;
   }
 
-  &.has-focus {
-    box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
-    border: 5px double $black;
+    &.has-focus {
+        box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
+        border: $search-border-focus-width double $search-border-focus-color;
 
     .pgn__searchfield_wrapper {
       box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
@@ -75,7 +75,7 @@
       box-shadow: none;
 
             .pgn__searchfield_wrapper {
-                border: 5px double $black;
+                border: $search-border-focus-width double $search-border-focus-color;
             }
 
             .btn-primary {

--- a/src/SearchField/_variables.scss
+++ b/src/SearchField/_variables.scss
@@ -11,3 +11,5 @@ $search-border-width-interaction:     .125rem !default;
 $search-disabled-opacity:             .3 !default;
 $search-button-margin:                .5rem !default;
 $input-height-search:                 calc(#{$input-line-height * 1em} + #{$input-padding-y * 2}) !default;
+$search-border-focus-color:           $black !default;
+$search-border-focus-width:           .3125rem !default;


### PR DESCRIPTION
## Description

Added focus state for:
- Breadcrumbs, 
- Chip, 
- Dropdown, 
- Form.Checkbox, 
- Form.Radio, 
- Pagination, 
- SearchField components.

[JIRA](https://openedx.atlassian.net/browse/PAR-763)
[Figma](https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=14061%3A5)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
