### PR TITLE
[BD-46] feat: added box-shadow toggle props

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -13,6 +13,10 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   box-shadow: $data-table-box-shadow;
   font-size: $font-size-sm;
 
+  &.hideShadow {
+    box-shadow: none;
+  }
+
   > :first-child {
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -4,6 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { useTable } from 'react-table';
 
+import classNames from 'classnames';
 import Table from './Table';
 import getVisibleColumns from './utils/getVisibleColumns';
 import { requiredWhen } from '../utils/propTypesUtils';
@@ -47,6 +48,7 @@ function DataTable({
   manualSelectColumn,
   showFiltersInSidebar,
   dataViewToggleOptions,
+  disableElevation,
   isLoading,
   children,
   ...props
@@ -127,6 +129,7 @@ function DataTable({
     showFiltersInSidebar,
     dataViewToggleOptions,
     renderRowSubComponent,
+    disableElevation,
     isLoading,
     ...selectionProps,
     ...selectionActions,
@@ -136,7 +139,10 @@ function DataTable({
   return (
     <DataTableContext.Provider value={enhancedInstance}>
       <DataTableLayout>
-        <div className="pgn__data-table-wrapper">
+        <div className={classNames('pgn__data-table-wrapper', {
+          hideShadow: !!disableElevation,
+        })}
+        >
           {children || (
           <>
             <TableControlBar />
@@ -180,6 +186,7 @@ DataTable.defaultProps = {
     defaultActiveStateValue: 'card',
     togglePlacement: 'left',
   },
+  disableElevation: false,
   renderRowSubComponent: undefined,
   isExpandable: false,
   isLoading: false,
@@ -329,6 +336,8 @@ DataTable.propTypes = {
      * actions section. Only 'left' and 'bottom' are supported */
     togglePlacement: PropTypes.string,
   }),
+  /** remove the default box shadow on the component */
+  disableElevation: PropTypes.bool,
   /** A function that will render contents of expanded row, accepts `row` as a prop. */
   renderRowSubComponent: PropTypes.func,
   /** Indicates whether table supports expandable rows. */


### PR DESCRIPTION
## Description
- added `disableElevation` props,
- added hide box-shadow style.

JIRA: [PAR-781](https://openedx.atlassian.net/browse/PAR-781)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
