### PR TITLE
feat: Add className prop to Toast

### DIFF
--- a/src/Toast/index.jsx
+++ b/src/Toast/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import BaseToast from 'react-bootstrap/Toast';
@@ -7,21 +8,21 @@ import { Button, IconButton, Icon } from '..';
 import { Close } from '../../icons';
 
 function Toast({
-  action, children, closeLabel, delay, onClose, show,
+  action, children, className, closeLabel, onClose, show, ...rest
 }) {
   const [autoHide, setAutoHide] = useState(true);
   return (
     <ToastContainer>
       <BaseToast
         autohide={autoHide}
-        className="toast"
-        delay={delay}
+        className={classNames('pgn__toast', className)}
         onClose={onClose}
         onBlur={() => setAutoHide(true)}
         onFocus={() => setAutoHide(false)}
         onMouseOut={() => setAutoHide(true)}
         onMouseOver={() => setAutoHide(false)}
         show={show}
+        {...rest}
       >
         <div
           className="toast-header"
@@ -33,7 +34,7 @@ function Toast({
               alt={closeLabel}
               className="align-self-start"
               src={Close}
-              onClick={() => (onClose())}
+              onClick={onClose}
               variant="primary"
               invertColors
             />
@@ -57,6 +58,7 @@ function Toast({
 
 Toast.defaultProps = {
   action: null,
+  className: undefined,
   closeLabel: 'Close',
   delay: 5000,
 };
@@ -90,6 +92,8 @@ Toast.propTypes = {
   closeLabel: PropTypes.string,
   /** Time in milliseconds for which the `Toast` will display. */
   delay: PropTypes.number,
+  /** Class names for the `BaseToast` component */
+  className: PropTypes.string,
 };
 
 export default Toast;


### PR DESCRIPTION
## Description
The issue is related to https://openedx.atlassian.net/browse/VAN-906 where two toasts are appearing (one for the component that renders when desktop view is on and other for Mobile view)

The classes added to parent components in prospectus that dynamically show and hide the content `d-block d-md-none` and `d-none d-md-block` don't work on any children Toast elements. Adding a `div` with these classes around `Toast` also doesn't work. 

Solution:
Added a span around `BaseToast` which takes className as props. This doesn't change the appearance of Toast. 


### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
