### PR TITLE
[BD-46] feat: escape press, backdrop click for Sheet

### DIFF
--- a/src/Sheet/README.md
+++ b/src/Sheet/README.md
@@ -35,8 +35,8 @@ notes: |
           <Dropdown.Item eventKey={position}>{position}</Dropdown.Item>
         ))}
       </DropdownButton><br />
-      <Button onClick={() => setShow(!show)}>
-        {show ? "Hide" : "Show"} the Sheet
+      <Button onClick={() => setShow(true)}>
+        Show the Sheet
       </Button>{' '}
       <Button onClick={() => setBlocking(!blocking)}>
         {blocking ? "Disable": "Enable"} blocking content
@@ -50,6 +50,7 @@ notes: |
         show={show}
         blocking={blocking}
         variant={dark ? 'dark' : 'light'}
+        onClose={() => setShow(false)}
       >
         This is a Sheet component <br />
         <Button

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { fireEvent, render } from '@testing-library/react';
 import Sheet, { POSITIONS, VARIANTS } from './index';
 
 /* eslint-disable react/prop-types */
@@ -49,34 +48,6 @@ describe('<Sheet />', () => {
     it('returns empty render if show is false', () => {
       expect(renderJSON(<Sheet show={false} />)).toEqual(null);
       expect(renderJSON(<Sheet />)).not.toEqual(null);
-    });
-  });
-  describe('correct interactions', () => {
-    it('closes on Escape if not blocking', () => {
-      const func = jest.fn();
-      render(
-        <div id="test">
-          <Sheet show onClose={func} />
-        </div>,
-      );
-      fireEvent.keyDown(document.getElementById('test'), {
-        key: 'Escape',
-        code: 'Escape',
-        keyCode: 27,
-        charCode: 27,
-      });
-      expect(func).toHaveBeenCalledTimes(1);
-    });
-    it('closes on backdrop click if not blocking', () => {
-      const func = jest.fn();
-      render(
-        <div>
-          <div id="backdrop" />
-          <Sheet show onClose={func} />
-        </div>,
-      );
-      fireEvent.mouseDown(document.getElementById('backdrop'));
-      expect(func).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { fireEvent, render } from '@testing-library/react';
 import Sheet, { POSITIONS, VARIANTS } from './index';
 
 /* eslint-disable react/prop-types */
@@ -44,9 +45,38 @@ describe('<Sheet />', () => {
       ).toMatchSnapshot();
     });
   });
-
-  it('returns empty render iff show is false', () => {
-    expect(renderJSON(<Sheet show={false} />)).toEqual(null);
-    expect(renderJSON(<Sheet />)).not.toEqual(null);
+  describe('correct rendering', () => {
+    it('returns empty render if show is false', () => {
+      expect(renderJSON(<Sheet show={false} />)).toEqual(null);
+      expect(renderJSON(<Sheet />)).not.toEqual(null);
+    });
+  });
+  describe('correct interactions', () => {
+    it('closes on Escape if not blocking', () => {
+      const func = jest.fn();
+      render(
+        <div id="test">
+          <Sheet show onClose={func} />
+        </div>,
+      );
+      fireEvent.keyDown(document.getElementById('test'), {
+        key: 'Escape',
+        code: 'Escape',
+        keyCode: 27,
+        charCode: 27,
+      });
+      expect(func).toHaveBeenCalledTimes(1);
+    });
+    it('closes on backdrop click if not blocking', () => {
+      const func = jest.fn();
+      render(
+        <div>
+          <div id="backdrop" />
+          <Sheet show onClose={func} />
+        </div>,
+      );
+      fireEvent.mouseDown(document.getElementById('backdrop'));
+      expect(func).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -6,7 +6,17 @@ exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
     className="pgn__sheet-skrim"
     role="presentation"
   />
-  <focus-on>
+  <focus-on
+    onClickOutside={[Function]}
+    onEscapeKey={[Function]}
+    shards={
+      Array [
+        Object {
+          "current": null,
+        },
+      ]
+    }
+  >
     <div
       aria-atomic="true"
       aria-live="polite"
@@ -27,7 +37,17 @@ exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
     className="pgn__sheet-skrim hidden"
     role="presentation"
   />
-  <focus-on>
+  <focus-on
+    onClickOutside={[Function]}
+    onEscapeKey={[Function]}
+    shards={
+      Array [
+        Object {
+          "current": null,
+        },
+      ]
+    }
+  >
     <div
       aria-atomic="true"
       aria-live="polite"
@@ -48,7 +68,17 @@ exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
     className="pgn__sheet-skrim hidden"
     role="presentation"
   />
-  <focus-on>
+  <focus-on
+    onClickOutside={[Function]}
+    onEscapeKey={[Function]}
+    shards={
+      Array [
+        Object {
+          "current": null,
+        },
+      ]
+    }
+  >
     <div
       aria-atomic="true"
       aria-live="polite"

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -6,9 +6,7 @@ exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
     className="pgn__sheet-skrim"
     role="presentation"
   />
-  <focus-on
-    enabled={true}
-  >
+  <focus-on>
     <div
       aria-atomic="true"
       aria-live="polite"
@@ -29,9 +27,7 @@ exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
     className="pgn__sheet-skrim hidden"
     role="presentation"
   />
-  <focus-on
-    enabled={false}
-  >
+  <focus-on>
     <div
       aria-atomic="true"
       aria-live="polite"
@@ -52,9 +48,7 @@ exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
     className="pgn__sheet-skrim hidden"
     role="presentation"
   />
-  <focus-on
-    enabled={false}
-  >
+  <focus-on>
     <div
       aria-atomic="true"
       aria-live="polite"

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -29,7 +29,6 @@ class Sheet extends React.Component {
     const { children, position, variant } = this.props;
     return (
       <div
-        ref={this.wrapperRef}
         className={classNames(
           'pgn__sheet-component',
           `pgn__sheet__${variant}`,
@@ -67,6 +66,7 @@ class Sheet extends React.Component {
         <FocusOn
           onClickOutside={blocking ? () => {} : onClose}
           onEscapeKey={blocking ? () => {} : onClose}
+          shards={[this.wrapperRef]}
         >
           {this.renderSheet()}
         </FocusOn>

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -23,30 +23,6 @@ class Sheet extends React.Component {
 
     this.wrapperRef = React.createRef();
     this.renderSheet = this.renderSheet.bind(this);
-    this.handleEscape = this.handleEscape.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
-  }
-
-  componentDidMount() {
-    document.addEventListener('keydown', this.handleEscape);
-    document.addEventListener('mousedown', this.handleClickOutside);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleEscape);
-    document.removeEventListener('mousedown', this.handleClickOutside);
-  }
-
-  handleEscape(e) {
-    if (e.key === 'Escape' && !this.props.blocking) {
-      this.props.onClose();
-    }
-  }
-
-  handleClickOutside(e) {
-    if (this.wrapperRef?.current && !this.wrapperRef.current.contains(e.target) && !this.props.blocking) {
-      this.props.onClose();
-    }
   }
 
   renderSheet() {
@@ -74,6 +50,7 @@ class Sheet extends React.Component {
     const {
       blocking,
       show,
+      onClose,
     } = this.props;
     if (!show) {
       return null;
@@ -87,7 +64,10 @@ class Sheet extends React.Component {
           )}
           role="presentation"
         />
-        <FocusOn>
+        <FocusOn
+          onClickOutside={blocking ? () => {} : onClose}
+          onEscapeKey={blocking ? () => {} : onClose}
+        >
           {this.renderSheet()}
         </FocusOn>
       </SheetContainer>

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -20,13 +20,40 @@ export const VARIANTS = {
 class Sheet extends React.Component {
   constructor(props) {
     super(props);
+
+    this.wrapperRef = React.createRef();
     this.renderSheet = this.renderSheet.bind(this);
+    this.handleEscape = this.handleEscape.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleEscape);
+    document.addEventListener('mousedown', this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleEscape);
+    document.removeEventListener('mousedown', this.handleClickOutside);
+  }
+
+  handleEscape(e) {
+    if (e.key === 'Escape' && !this.props.blocking) {
+      this.props.onClose();
+    }
+  }
+
+  handleClickOutside(e) {
+    if (this.wrapperRef?.current && !this.wrapperRef.current.contains(e.target) && !this.props.blocking) {
+      this.props.onClose();
+    }
   }
 
   renderSheet() {
     const { children, position, variant } = this.props;
     return (
       <div
+        ref={this.wrapperRef}
         className={classNames(
           'pgn__sheet-component',
           `pgn__sheet__${variant}`,
@@ -60,7 +87,7 @@ class Sheet extends React.Component {
           )}
           role="presentation"
         />
-        <FocusOn enabled={this.props.blocking}>
+        <FocusOn>
           {this.renderSheet()}
         </FocusOn>
       </SheetContainer>
@@ -82,6 +109,8 @@ Sheet.propTypes = {
   ]),
   /** Boolean used to control whether the Sheet shows. */
   show: PropTypes.bool,
+  /** Specifies function that controls `show` value. */
+  onClose: PropTypes.func,
   /** a string designating which version of the sheet to show (light vs dark) */
   variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark]),
 };
@@ -91,6 +120,7 @@ Sheet.defaultProps = {
   children: undefined,
   position: POSITIONS.bottom,
   show: true,
+  onClose: () => {},
   variant: VARIANTS.light,
 };
 


### PR DESCRIPTION
Add processing of `Escape` press and backdrop click
- on `Escape` sheet is closed. New requirement - pass new `onClose` prop that will be called on `Escape`.
- on backdrop click. The same requirement as for `Escape`
- along with this task also [PAR-783](https://openedx.atlassian.net/browse/PAR-783) is completed. Backdrop click on the button that toggles `Sheet` has led to 2 actions at the same time - close on the backdrop event and open again on the button click. Changing `<FocusOn enabled={this.props.blocking} />` to `<FocusOn />` from `react-focus-on` always put focus inside the `Sheet` so that backdrop click can't trigger any event from outside of the `Sheet`.
- added tests for new functionality

JIRA: [PAR-784](https://openedx.atlassian.net/browse/PAR-784), [PAR-783](https://openedx.atlassian.net/browse/PAR-783)