### PR TITLE
Asheehan edx/dropdown autoclose fork

### DIFF
--- a/src/Dropdown/Dropdown.test.jsx
+++ b/src/Dropdown/Dropdown.test.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import userEvent from '@testing-library/user-event';
+import Dropdown from './index';
+
+const mockOnToggle = jest.fn();
+
+const baseProps = {
+  show: false,
+  autoClose: true,
+  onToggle: mockOnToggle,
+};
+
+const outsideAutoCloseProps = {
+  autoClose: 'outside',
+};
+
+const insideAutoCloseProps = {
+  autoClose: 'inside',
+};
+
+describe('<Dropdown />', () => {
+  it('renders', () => {
+    const props = {
+      ...baseProps,
+    };
+    const wrapper = mount(<Dropdown {...props} />);
+    expect(wrapper.exists()).toEqual(true);
+  });
+  it('Dropdown functions without autoClose or show props', async () => {
+    render(
+      <Dropdown>
+        <Dropdown.Toggle id={1}>
+          Dropdown Button
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item>foobar</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+    expect(screen.queryByText('foobar')).not.toBeInTheDocument();
+    expect(screen.getByText('Dropdown Button')).toBeInTheDocument();
+
+    // Open the dropdown
+    const button = screen.getByText('Dropdown Button');
+    userEvent.click(button);
+    // Expect the dropdown item to be visible
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+
+    // Close the dropdown by clicking off the element
+    userEvent.click(document.body);
+    await waitFor(() => expect(screen.queryByText('foobar')).not.toBeVisible());
+
+    // Reopen the dropdown
+    userEvent.click(button);
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+
+    //  Close the dropdown by clicking the item
+    const dropdownItem = screen.getByText('foobar');
+    userEvent.click(dropdownItem);
+    await waitFor(() => expect(screen.queryByText('foobar')).not.toBeVisible());
+  });
+  it('Dropdown functions when autoClose is outside', async () => {
+    const props = {
+      ...outsideAutoCloseProps,
+    };
+    render(
+      <Dropdown {...props}>
+        <Dropdown.Toggle id={1}>
+          Dropdown Button
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item>foobar</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+    expect(screen.queryByText('foobar')).not.toBeInTheDocument();
+    expect(screen.getByText('Dropdown Button')).toBeInTheDocument();
+
+    // Open the dropdown
+    const button = screen.getByText('Dropdown Button');
+    userEvent.click(button);
+    // Expect the dropdown item to be visible
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+
+    // Close the dropdown by clicking off the element
+    userEvent.click(document.body);
+    await waitFor(() => expect(screen.queryByText('foobar')).not.toBeVisible());
+
+    // Reopen the dropdown
+    userEvent.click(button);
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+
+    // Assert the dropdown stays open when clicking the item
+    const dropdownItem = screen.getByText('foobar');
+    userEvent.click(dropdownItem);
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+  });
+  it('Dropdown functions when autoClose is inside', async () => {
+    const props = {
+      ...insideAutoCloseProps,
+    };
+    render(
+      <Dropdown {...props}>
+        <Dropdown.Toggle id={1}>
+          Dropdown Button
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item>foobar</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+    expect(screen.queryByText('foobar')).not.toBeInTheDocument();
+    expect(screen.getByText('Dropdown Button')).toBeInTheDocument();
+
+    // Open the dropdown
+    const button = screen.getByText('Dropdown Button');
+    userEvent.click(button);
+    // Expect the dropdown item to be visible
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+
+    // Assert the dropdown stays open when clicking outside the dropdown
+    userEvent.click(document.body);
+    await waitFor(() => expect(screen.queryByText('foobar')).toBeVisible());
+
+    // Close the dropdown by clicking the element
+    const dropdownItem = screen.getByText('foobar');
+    userEvent.click(dropdownItem);
+    await waitFor(() => expect(screen.queryByText('foobar')).not.toBeVisible());
+  });
+});

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -35,17 +35,48 @@ notes: |
 ### Advanced Usage
 
 ```jsx live
-<Dropdown>
-  <Dropdown.Toggle variant="success" id="dropdown-basic">
-    Dropdown Button
-  </Dropdown.Toggle>
-
-  <Dropdown.Menu>
-    <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
-    <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-    <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-  </Dropdown.Menu>
-</Dropdown>
+<>
+  <Dropdown onToggle={(isOpen, event, metadata) => console.log('debug', 'onToggle', { isOpen, event, metadata })} className="mb-3">
+    <Dropdown.Toggle variant="success" id="dropdown-basic-1">
+      Dropdown Button
+    </Dropdown.Toggle>
+    <Dropdown.Menu>
+      <Dropdown.Item>Action</Dropdown.Item>
+      <Dropdown.Item>Another action</Dropdown.Item>
+      <Dropdown.Item>Something else</Dropdown.Item>
+    </Dropdown.Menu>
+  </Dropdown>
+  <Dropdown autoClose={false} onToggle={(isOpen, event, metadata) => console.log('debug', 'onToggle', { isOpen, event, metadata })} className="mb-3">
+    <Dropdown.Toggle variant="success" id="dropdown-basic-2">
+      autoClose=false
+    </Dropdown.Toggle>
+    <Dropdown.Menu>
+      <Dropdown.Item>Action</Dropdown.Item>
+      <Dropdown.Item>Another action</Dropdown.Item>
+      <Dropdown.Item>Something else</Dropdown.Item>
+    </Dropdown.Menu>
+  </Dropdown>
+  <Dropdown autoClose="inside" onToggle={(isOpen, event, metadata) => console.log('debug', 'onToggle', { isOpen, event, metadata })} className="mb-3">
+    <Dropdown.Toggle variant="success" id="dropdown-basic-3">
+      autoClose=inside
+    </Dropdown.Toggle>
+    <Dropdown.Menu>
+      <Dropdown.Item>Action</Dropdown.Item>
+      <Dropdown.Item>Another action</Dropdown.Item>
+      <Dropdown.Item>Something else</Dropdown.Item>
+    </Dropdown.Menu>
+  </Dropdown>
+  <Dropdown autoClose="outside" onToggle={(isOpen, event, metadata) => console.log('debug', 'onToggle', { isOpen, event, metadata })} className="mb-3">
+    <Dropdown.Toggle variant="success" id="dropdown-basic-4">
+      autoClose=outside
+    </Dropdown.Toggle>
+    <Dropdown.Menu>
+      <Dropdown.Item>Action</Dropdown.Item>
+      <Dropdown.Item>Another action</Dropdown.Item>
+      <Dropdown.Item>Something else</Dropdown.Item>
+    </Dropdown.Menu>
+  </Dropdown>
+</>
 ```
 
 ### With IconButton

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -10,11 +10,12 @@ import { IconButton, Button } from '..';
 const Dropdown = React.forwardRef(
   // eslint-disable-next-line prefer-arrow-callback
   function Dropdown({
+    show,
     autoClose,
     onToggle,
     ...rest
   }, ref) {
-    const [show, setShow] = React.useState(false);
+    const [internalShow, setInternalShow] = React.useState(show || false);
     const isClosingPermitted = (source) => {
       console.log('debug', 'isClosingPermitted', { autoClose, source });
 

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -1,20 +1,80 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Dropdown from 'react-bootstrap/Dropdown';
+import BaseDropdown from 'react-bootstrap/Dropdown';
+import DropdownMenu from 'react-bootstrap/DropdownMenu';
+import DropdownItem from 'react-bootstrap/DropdownItem';
 import BaseDropdownToggle from 'react-bootstrap/DropdownToggle';
 import DropdownDeprecated from './deprecated';
 import { IconButton, Button } from '..';
 
-const DropdownToggle = React.forwardRef(({
-  as,
-  bsPrefix,
-  ...otherProps
-}, ref) => {
-  // hide arrow from the toggle if it is rendered as IconButton
-  // because it hinders the positioning of IconButton
-  const prefix = as === IconButton ? 'pgn__dropdown-toggle-iconbutton' : bsPrefix;
-  return <BaseDropdownToggle {...otherProps} as={as} bsPrefix={prefix} ref={ref} />;
-});
+const Dropdown = React.forwardRef(
+  // eslint-disable-next-line prefer-arrow-callback
+  function Dropdown({
+    autoClose,
+    onToggle,
+    ...rest
+  }, ref) {
+    const [show, setShow] = React.useState(false);
+    const isClosingPermitted = (source) => {
+      console.log('debug', 'isClosingPermitted', { autoClose, source });
+
+      // autoClose=false only permits close on button click
+      if (autoClose === false) {
+        return source === 'click';
+      }
+      // autoClose=inside doesn't permit close on rootClose
+      if (autoClose === 'inside') {
+        return source !== 'rootClose';
+      }
+      // autoClose=outside doesn't permit close on select
+      if (autoClose === 'outside') {
+        return source !== 'select';
+      }
+      return true;
+    };
+
+    const handleToggle = (isOpen, event, metadata) => {
+      if (isOpen) {
+        setShow(true);
+        return;
+      }
+      let { source } = { ...metadata };
+      if (event.currentTarget === document && (source !== 'keydown' || event.key === 'Escape')) {
+        source = 'rootClose';
+      }
+      if (isClosingPermitted(source)) {
+        setShow(false);
+        onToggle?.(isOpen, event, metadata);
+      }
+    };
+
+    return <BaseDropdown show={show} onToggle={handleToggle} {...rest} ref={ref} />;
+  },
+);
+
+const DropdownToggle = React.forwardRef(
+  // eslint-disable-next-line prefer-arrow-callback
+  function DropdownToggle({
+    as,
+    bsPrefix,
+    ...otherProps
+  }, ref) {
+    // hide arrow from the toggle if it is rendered as IconButton
+    // because it hinders the positioning of IconButton
+    const prefix = as === IconButton ? 'pgn__dropdown-toggle-iconbutton' : bsPrefix;
+    return <BaseDropdownToggle {...otherProps} as={as} bsPrefix={prefix} ref={ref} />;
+  },
+);
+
+Dropdown.propTypes = {
+  onToggle: PropTypes.func,
+  autoClose: PropTypes.bool,
+};
+
+Dropdown.defaultProps = {
+  onToggle: undefined,
+  autoClose: true,
+};
 
 DropdownToggle.propTypes = {
   /** Specifies the base element. */
@@ -32,6 +92,10 @@ DropdownToggle.defaultProps = {
 
 Dropdown.Deprecated = DropdownDeprecated;
 Dropdown.Toggle = DropdownToggle;
+Dropdown.Menu = DropdownMenu;
+Dropdown.Item = DropdownItem;
+Dropdown.Header = BaseDropdown.Header;
+Dropdown.Divider = BaseDropdown.Divider;
 
 export default Dropdown;
 export { DropdownToggle };

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -15,10 +15,8 @@ const Dropdown = React.forwardRef(
     onToggle,
     ...rest
   }, ref) {
-    const [internalShow, setInternalShow] = React.useState(show || false);
+    const [internalShow, setInternalShow] = React.useState(show);
     const isClosingPermitted = (source) => {
-      console.log('debug', 'isClosingPermitted', { autoClose, source });
-
       // autoClose=false only permits close on button click
       if (autoClose === false) {
         return source === 'click';
@@ -36,20 +34,21 @@ const Dropdown = React.forwardRef(
 
     const handleToggle = (isOpen, event, metadata) => {
       if (isOpen) {
-        setShow(true);
+        setInternalShow(true);
         return;
       }
       let { source } = { ...metadata };
+
       if (event.currentTarget === document && (source !== 'keydown' || event.key === 'Escape')) {
         source = 'rootClose';
       }
       if (isClosingPermitted(source)) {
-        setShow(false);
+        setInternalShow(false);
         onToggle?.(isOpen, event, metadata);
       }
     };
 
-    return <BaseDropdown show={show} onToggle={handleToggle} {...rest} ref={ref} />;
+    return <BaseDropdown show={internalShow} onToggle={handleToggle} {...rest} ref={ref} data-testid="dropdown" />;
   },
 );
 
@@ -69,12 +68,17 @@ const DropdownToggle = React.forwardRef(
 
 Dropdown.propTypes = {
   onToggle: PropTypes.func,
-  autoClose: PropTypes.bool,
+  autoClose: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+  ]),
+  show: PropTypes.bool,
 };
 
 Dropdown.defaultProps = {
   onToggle: undefined,
   autoClose: true,
+  show: false,
 };
 
 DropdownToggle.propTypes = {


### PR DESCRIPTION
## Description

* [ ] Ensure controlled usage of `Dropdown` via `show` and `onToggle` AND uncontrolled usage of `Dropdown` (no `show` or `onToggle` props provided)
  * Possibly look into using `uncontrollable` NPM package here.
* [ ] Ensure accurate `propType` definitions.
* [ ] Add tests
* [ ] Include appropriate documentation

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
