### PR TITLE
fix: add background-color and fix spacing for Card.ImageCap and Card.Header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12195,8 +12195,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.1",
-            "pacote": "^11.3.0",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
             "tar": "^6.1.0"
           }
         },

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -22,7 +22,7 @@
   .pgn__card-header-content {
     display: flex;
     flex-direction: column;
-    margin-top: map_get($spacers, 4);
+    margin-top: map_get($spacers, 4\.5);
     overflow: auto;
     text-align: start;
     width: 100%;
@@ -213,6 +213,8 @@
   border-radius: $card-logo-border-radius;
   box-shadow: $level-1-box-shadow;
   z-index: 1;
+  padding: map_get($spacers, 2);
+  background-color: $white;
 }
 
 .pgn__card {


### PR DESCRIPTION
## Description

* Increases spacing for `Card.Header` content
* Adds white background color to logo image cap
* Adds padding to match Figma spec to logo image cap

#### Before

<img width="372" alt="image" src="https://user-images.githubusercontent.com/2828721/163249353-880d1eab-c026-42e4-b238-948b9535016c.png">

#### After

<img width="369" alt="image" src="https://user-images.githubusercontent.com/2828721/163249442-7554749d-8663-4b00-ba83-feb07aac6494.png">

### Deploy Preview

https://deploy-preview-1229--paragon-openedx.netlify.app/components/card/#with-image-cap

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
