### PR TITLE
fix: import from default export on breakpoint module

### DIFF
--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -3,7 +3,9 @@
 
 import breakpointSizes from '../../scss/core/_extend.module.scss';
 
-const { sm, md, lg, xl, xxl } = breakpointSizes;
+const {
+  sm, md, lg, xl, xxl,
+} = breakpointSizes;
 
 const breakpoints = {
   extraSmall: {

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -1,9 +1,9 @@
 // NOTE: These are the breakpoints used in Bootstrap v4.0.0 as seen in
 // the documentation (https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)
 
-import {
-  sm, md, lg, xl, xxl,
-} from '../../scss/core/_extend.module.scss';
+import breakpointSizes from '../../scss/core/_extend.module.scss';
+
+const { sm, md, lg, xl, xxl } = breakpointSizes;
 
 const breakpoints = {
   extraSmall: {


### PR DESCRIPTION
## Description

Use default export during import of SCSS-defined `grid-breakpoint` values. This resolves an error on the consuming end in an MFE that was complaining that named exports `sm`, `md`, `lg`, etc. were not available.