### PR TITLE
fix: use React.cloneElement vs. React.createElement to prevent extra re-rendering and remove "key" warning.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14503,6 +14503,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -16397,10 +16403,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16402,11 +16402,6 @@
         "object.getownpropertydescriptors": "^2.1.1"
       }
     },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "react-table": "^7.7.0",
     "react-transition-group": "^4.4.2",
     "tabbable": "^4.0.0",
-    "uncontrollable": "7.2.1"
+    "uncontrollable": "^7.2.1",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "react-table": "^7.7.0",
     "react-transition-group": "^4.4.2",
     "tabbable": "^4.0.0",
-    "uncontrollable": "^7.2.1",
-    "uuid": "^8.3.2"
+    "uncontrollable": "^7.2.1"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import BaseTabs from 'react-bootstrap/Tabs';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { v4 as uuidv4 } from 'uuid';
 import TabsDeprecated from './deprecated';
 import Bubble from '../Bubble';
 
@@ -10,29 +9,29 @@ const Tabs = ({
   children,
   className,
   ...props
-}) => {
-  const newChildren = [];
-  React.Children.forEach(children, (child) => {
-    if (!child) { return; }
-
-    const { title, notification, ...rest } = child.props;
-
-    const newTitle = notification ? (
-      <>
-        {title}
-        <Bubble variant="error" className="pgn__tab-notification">{notification}</Bubble>
-      </>
-    ) : title;
-    const modifiedTab = React.createElement(child.type, { ...rest, title: newTitle, key: uuidv4() });
-    newChildren.push(modifiedTab);
-  });
-
-  return (
-    <BaseTabs {...props} className={classNames(className, 'pgn__tabs')}>
-      {newChildren}
-    </BaseTabs>
-  );
-};
+}) => (
+  <BaseTabs {...props} className={classNames(className, 'pgn__tabs')}>
+    {React.Children.map(children, (child) => {
+      if (!React.isValidElement(child)) {
+        return child;
+      }
+      const { title, notification, ...rest } = child.props;
+      let newTitle;
+      if (notification) {
+        newTitle = (
+          <>
+            {title}
+            <Bubble variant="error" className="pgn__tab-notification">{notification}</Bubble>
+          </>
+        );
+      } else {
+        newTitle = title;
+      }
+      const modifiedTab = React.cloneElement(child, { ...rest, title: newTitle });
+      return modifiedTab;
+    })}
+  </BaseTabs>
+);
 
 Tabs.propTypes = {
   /** Specifies elements that is processed to create tabs. */

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import BaseTabs from 'react-bootstrap/Tabs';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
 import TabsDeprecated from './deprecated';
 import Bubble from '../Bubble';
 
@@ -10,8 +11,10 @@ const Tabs = ({
   className,
   ...props
 }) => {
-  const childrenList = [];
-  React.Children.forEach(children, child => {
+  const newChildren = [];
+  React.Children.forEach(children, (child) => {
+    if (!child) { return; }
+
     const { title, notification, ...rest } = child.props;
 
     const newTitle = notification ? (
@@ -20,13 +23,13 @@ const Tabs = ({
         <Bubble variant="error" className="pgn__tab-notification">{notification}</Bubble>
       </>
     ) : title;
-    const modifiedTab = React.createElement(child.type, { ...rest, title: newTitle });
-    childrenList.push(modifiedTab);
+    const modifiedTab = React.createElement(child.type, { ...rest, title: newTitle, key: uuidv4() });
+    newChildren.push(modifiedTab);
   });
 
   return (
     <BaseTabs {...props} className={classNames(className, 'pgn__tabs')}>
-      {childrenList.map(child => child)}
+      {newChildren}
     </BaseTabs>
   );
 };


### PR DESCRIPTION
## Description

TBD

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
