### PR TITLE
fix: update display heading mobile sizes

### DIFF
--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -4,7 +4,10 @@
   .display-1,
   .display-2,
   .display-3,
-  .display-4,
+  .display-4 {
+    font-size: $display-mobile-size;
+    line-height: $display-mobile-line-height;
+  }
   h1, .h1 {
     font-size: $h1-mobile-font-size;
   }

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -672,12 +672,15 @@ $display2-size:               4.875rem !default;
 $display3-size:               5.625rem !default;
 $display4-size:               7.5rem !default;
 
+$display-mobile-size:         3.25rem !default;
+
 $display1-weight:             700 !default;
 $display2-weight:             700 !default;
 $display3-weight:             700 !default;
 $display4-weight:             700 !default;
 
 $display-line-height:         1.0 !default;
+$display-mobile-line-height:  3.5rem !default;
 
 $lead-font-size:              $font-size-base * 1.25 !default;
 $lead-font-weight:            null !default;


### PR DESCRIPTION
## Description

Increase display headings to 52px font size / 56px line height for mobile, so that they no longer lose hierarchy next to mobile H1.

![Screen Shot 2022-04-22 at 3 32 09 PM](https://user-images.githubusercontent.com/10442143/164790994-780318cc-dffb-4a1c-a72b-94cddf9fa02b.png)


Related ticket with more context: https://openedx.atlassian.net/browse/WS-2763

### Deploy Preview

https://deploy-preview-1251--paragon-openedx.netlify.app/foundations/typography

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
