### PR TITLE
[BD-46] feat: eslint config upgrade, refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
         "@babel/preset-env": "^7.16.8",
         "@babel/preset-react": "^7.16.7",
-        "@edx/eslint-config": "^2.0.0",
+        "@edx/eslint-config": "^3.0.0",
         "@semantic-release/changelog": "^5.0.1",
         "@semantic-release/git": "^9.0.1",
         "@testing-library/jest-dom": "^5.16.3",
@@ -1837,9 +1837,9 @@
       }
     },
     "node_modules/@edx/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-JfbN9kTs6qWNzNL0+GTbifHktXXpe6oPXXEy7jA6FykzD51FcGBPIp88v3AtHgfaoMnD95He3SATdeNCRIjcqQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-3vMX3/vqYxpJK/XKGRjWlsvcIkOQYMxJ1uXcVl70HiQda31xWW4qpg2OTevEdnYo5vThSBVMFe7lRmMpMNDR7Q==",
       "dev": true,
       "peerDependencies": {
         "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0",
@@ -7020,15 +7020,6 @@
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/escodegen/node_modules/levn": {
@@ -23975,9 +23966,9 @@
       "optional": true
     },
     "@edx/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-JfbN9kTs6qWNzNL0+GTbifHktXXpe6oPXXEy7jA6FykzD51FcGBPIp88v3AtHgfaoMnD95He3SATdeNCRIjcqQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-3vMX3/vqYxpJK/XKGRjWlsvcIkOQYMxJ1uXcVl70HiQda31xWW4qpg2OTevEdnYo5vThSBVMFe7lRmMpMNDR7Q==",
       "dev": true,
       "requires": {}
     },
@@ -28057,12 +28048,6 @@
         "source-map": "~0.6.1"
       },
       "dependencies": {
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        },
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
     "@babel/preset-env": "^7.16.8",
     "@babel/preset-react": "^7.16.7",
-    "@edx/eslint-config": "^2.0.0",
+    "@edx/eslint-config": "^3.0.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.1",
     "@testing-library/jest-dom": "^5.16.3",

--- a/src/Collapsible/CollapsibleTrigger.jsx
+++ b/src/Collapsible/CollapsibleTrigger.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 import { CollapsibleContext } from './CollapsibleAdvanced';
 
 function CollapsibleTrigger({
-  tag, children, openOnly, closeOnly, ...props
+  tag, children, openOnly, closeOnly, onClick, onKeyDown, ...props
 }) {
   const {
     isOpen, open, close, toggle,
   } = useContext(CollapsibleContext);
 
-  const handleToggle = (e) => {
+  const handleToggle = useCallback((e) => {
     if (openOnly) {
       open(e);
     } else if (closeOnly) {
@@ -18,23 +18,23 @@ function CollapsibleTrigger({
     } else {
       toggle(e);
     }
-  };
+  }, [openOnly, open, closeOnly, close, toggle]);
 
   const handleClick = useCallback((e) => {
-    if (props.onClick) {
-      props.onClick(e);
+    if (onClick) {
+      onClick(e);
     }
     handleToggle(e);
-  });
+  }, [onClick, handleToggle]);
 
   const handleKeyDown = useCallback((e) => {
-    if (props.onKeyDown) {
-      props.onKeyDown(e);
+    if (onKeyDown) {
+      onKeyDown(e);
     }
     if (e.key === 'Enter') {
       handleToggle(e);
     }
-  });
+  }, [onKeyDown, handleToggle]);
 
   return React.createElement(
     tag,

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -18,9 +18,10 @@ const DataViewToggle = () => {
     },
   } = useContext(DataTableContext);
 
+  const [activeValue, setActiveValue] = useState(defaultActiveStateValue || 'card');
+
   if (!isDataViewToggleEnabled) { return null; }
 
-  const [activeValue, setActiveValue] = useState(defaultActiveStateValue || 'card');
   const handleOnChange = value => {
     setActiveValue(value);
     if (onDataViewToggle) {

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -66,7 +66,7 @@ function DataTable({
     manualSortBy,
     initialState,
     ...initialTableOptions,
-  }), [columns, data, defaultColumn, manualFilters, manualPagination, initialState, initialTableOptions]);
+  }), [columns, data, defaultColumn, manualFilters, manualPagination, initialState, initialTableOptions, manualSortBy]);
 
   const [selections, selectionsDispatch] = useReducer(selectionsReducer, initialSelectionsState);
 
@@ -111,10 +111,12 @@ function DataTable({
   // any state changes to current row selections as we don't want to re-fetch data whenever row(s) are selected.
   const tableStateWithoutSelections = { ...instance.state };
   delete tableStateWithoutSelections.selectedRowIds;
+
   useEffect(() => {
     if (fetchData) {
       fetchData(tableStateWithoutSelections);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchData, JSON.stringify(tableStateWithoutSelections)]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);

--- a/src/DataTable/selection/ControlledSelect.jsx
+++ b/src/DataTable/selection/ControlledSelect.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback, useMemo } from 'react';
+import React, { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { CheckboxControl } from '../../Form';
@@ -16,8 +16,6 @@ const ControlledSelect = ({ row }) => {
     controlledTableSelections: [, dispatch],
   } = useContext(DataTableContext);
 
-  const { getToggleRowSelectedProps } = row || {};
-
   const toggleSelected = useCallback(
     () => {
       if (row.isSelected) {
@@ -29,8 +27,7 @@ const ControlledSelect = ({ row }) => {
     [itemCount, row, dispatch],
   );
 
-  const toggleRowSelectedProps = useMemo(() => getToggleRowSelectedProps(), [getToggleRowSelectedProps]);
-  const updatedProps = useConvertIndeterminateProp(toggleRowSelectedProps);
+  const updatedProps = useConvertIndeterminateProp(row.getToggleRowSelectedProps());
 
   return (
     <div className="d-flex align-content-center p-1">

--- a/src/DataTable/selection/ControlledSelect.jsx
+++ b/src/DataTable/selection/ControlledSelect.jsx
@@ -16,6 +16,8 @@ const ControlledSelect = ({ row }) => {
     controlledTableSelections: [, dispatch],
   } = useContext(DataTableContext);
 
+  const { getToggleRowSelectedProps } = row || {};
+
   const toggleSelected = useCallback(
     () => {
       if (row.isSelected) {
@@ -24,10 +26,10 @@ const ControlledSelect = ({ row }) => {
         dispatch(addSelectedRowAction(row, itemCount));
       }
     },
-    [itemCount, row],
+    [itemCount, row, dispatch],
   );
 
-  const toggleRowSelectedProps = useMemo(() => row.getToggleRowSelectedProps(), [row.getToggleRowSelectedProps]);
+  const toggleRowSelectedProps = useMemo(() => getToggleRowSelectedProps(), [getToggleRowSelectedProps]);
   const updatedProps = useConvertIndeterminateProp(toggleRowSelectedProps);
 
   return (

--- a/src/DataTable/selection/ControlledSelectHeader.jsx
+++ b/src/DataTable/selection/ControlledSelectHeader.jsx
@@ -31,7 +31,7 @@ const ControlledSelectHeader = ({ rows }) => {
         dispatch(setSelectedRowsAction(rows, itemCount));
       }
     },
-    [rows, selectedPageRowIds, isAllPageRowsSelected],
+    [rows, selectedPageRowIds, isAllPageRowsSelected, dispatch, itemCount],
   );
 
   const toggleAllPageRowsSelectedProps = getToggleAllPageRowsSelectedProps();

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -32,7 +32,7 @@ const ControlledSelectionStatus = ({ className, clearSelectionText }) => {
         }
       }
     },
-    [isEntireTableSelected, selectedRows, itemCount, rows],
+    [isEntireTableSelected, selectedRows, itemCount, rows, dispatch],
   );
 
   const numSelectedRows = isEntireTableSelected ? itemCount : selectedRows.length;

--- a/src/DataTable/utils/getVisibleColumns.jsx
+++ b/src/DataTable/utils/getVisibleColumns.jsx
@@ -32,9 +32,7 @@ export const selectColumn = {
   // Proptypes disabled as this prop is passed in separately
   /* eslint-disable react/prop-types */
   Cell: ({ row }) => {
-    const { getToggleRowSelectedProps } = row || {};
-    const toggleRowSelectedProps = useMemo(() => getToggleRowSelectedProps(), [getToggleRowSelectedProps]);
-    const updatedProps = useConvertIndeterminateProp(toggleRowSelectedProps);
+    const updatedProps = useConvertIndeterminateProp(row.getToggleRowSelectedProps());
 
     return (
       <div className="d-flex align-content-center p-1">

--- a/src/DataTable/utils/getVisibleColumns.jsx
+++ b/src/DataTable/utils/getVisibleColumns.jsx
@@ -32,7 +32,8 @@ export const selectColumn = {
   // Proptypes disabled as this prop is passed in separately
   /* eslint-disable react/prop-types */
   Cell: ({ row }) => {
-    const toggleRowSelectedProps = useMemo(() => row.getToggleRowSelectedProps(), [row.getToggleRowSelectedProps]);
+    const { getToggleRowSelectedProps } = row || {};
+    const toggleRowSelectedProps = useMemo(() => getToggleRowSelectedProps(), [getToggleRowSelectedProps]);
     const updatedProps = useConvertIndeterminateProp(toggleRowSelectedProps);
 
     return (

--- a/src/Form/FormGroupContext.jsx
+++ b/src/Form/FormGroupContext.jsx
@@ -36,8 +36,8 @@ const FormGroupContextProvider = ({
   size,
 }) => {
   const controlId = useMemo(() => explicitControlId || newId('form-field'), [explicitControlId]);
-  const [describedByIds, useRegisteredDescriptorId] = useIdList(controlId);
-  const [labelledByIds, useRegisteredLabellerId] = useIdList(controlId);
+  const [describedByIds, registerDescriptorId] = useIdList(controlId);
+  const [labelledByIds, registerLabelerId] = useIdList(controlId);
   const [isControlGroup, useSetIsControlGroupEffect] = useStateEffect(false);
 
   const getControlProps = useCallback((controlProps) => {
@@ -63,8 +63,7 @@ const FormGroupContextProvider = ({
   ]);
 
   const getLabelProps = (labelProps) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const id = useRegisteredLabellerId(labelProps?.id);
+    const id = registerLabelerId(labelProps?.id);
     if (isControlGroup) {
       return { ...labelProps, id };
     }
@@ -72,8 +71,7 @@ const FormGroupContextProvider = ({
   };
 
   const getDescriptorProps = (descriptorProps) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const id = useRegisteredDescriptorId(descriptorProps?.id);
+    const id = registerDescriptorId(descriptorProps?.id);
     return { ...descriptorProps, id };
   };
 

--- a/src/Form/FormGroupContext.jsx
+++ b/src/Form/FormGroupContext.jsx
@@ -63,6 +63,7 @@ const FormGroupContextProvider = ({
   ]);
 
   const getLabelProps = (labelProps) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const id = useRegisteredLabellerId(labelProps?.id);
     if (isControlGroup) {
       return { ...labelProps, id };
@@ -71,6 +72,7 @@ const FormGroupContextProvider = ({
   };
 
   const getDescriptorProps = (descriptorProps) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const id = useRegisteredDescriptorId(descriptorProps?.id);
     return { ...descriptorProps, id };
   };

--- a/src/Form/fieldUtils.js
+++ b/src/Form/fieldUtils.js
@@ -49,7 +49,7 @@ const useIdList = (uniqueIdPrefix, initialList) => {
         setRegisteredId(getNewId(uniqueIdPrefix));
       }
       return () => removeId(registeredId);
-    }, [registeredId]);
+    }, [registeredId, explicitlyRegisteredId]);
     return registeredId;
   };
 

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from '../Button/index';
@@ -18,18 +18,20 @@ const SelectMenu = ({
   const triggerTarget = React.useRef(null);
   const itemsCollection = React.useMemo(
     () => Array.from({ length: children.length }).map(() => React.createRef()),
-    [],
+    [children.length],
   );
 
   const className = classNames(props.className, 'pgn__menu-select');
-  function defaultIndex() {
+
+  const defaultIndex = useCallback(() => {
     for (let i = 0; i < children.length; i++) {
       if (children[i].props && children[i].props.defaultSelected) {
         return i;
       }
     }
     return undefined;
-  }
+  }, [children]);
+
   const [selected, setSelected] = useState(defaultIndex());
   const [isOpen, open, close] = useToggle(false);
   const [vertOffset, setOffset] = useState(0);
@@ -105,7 +107,7 @@ const SelectMenu = ({
       itemsCollection[selected].current.children[0].focus({ preventScroll: (defaultIndex() === selected) });
     }
     prevOpenRef.current = isOpen;
-  }, [isOpen]);
+  }, [isOpen, children.length, defaultIndex, itemsCollection, selected]);
 
   return React.createElement(
     className,

--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -56,7 +56,7 @@ const Checkpoint = React.forwardRef(({
         checkpointPopper.forceUpdate();
       }
     }
-  }, [target, isMobile]);
+  }, [target, isMobile, placement]);
 
   useEffect(() => {
     if (checkpointVisible) {
@@ -81,7 +81,7 @@ const Checkpoint = React.forwardRef(({
       const button = document.querySelector('.pgn__checkpoint-button_advance');
       button.focus();
     }
-  }, [target, checkpointVisible]);
+  }, [target, checkpointVisible, placement]);
 
   const isLastCheckpoint = index + 1 === totalCheckpoints;
   const isOnlyCheckpoint = totalCheckpoints === 1;

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Checkpoint from './Checkpoint';
 
 const ProductTour = React.forwardRef(({ tours }, ref) => {
-  const tourValue = tours.filter((tour) => tour.enabled)[0];
+  const tourValue = tours.find((tour) => tour.enabled);
   const {
     enabled, checkpoints = [], startingIndex, onEscape, onEnd, onDismiss: tourOnDismiss,
     advanceButtonText: tourAdvanceButtonText, dismissButtonText: tourDismissButtonText,

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -40,7 +40,7 @@ const ProgressBarAnnotated = ({
   useEffect(() => {
     placeInfoAtZero(progressInfoRef, isProgressHintAfter, ANNOTATION_CLASS);
     placeInfoAtZero(thresholdInfoRef, isThresholdHintAfter, ANNOTATION_CLASS);
-  }, []);
+  }, [isProgressHintAfter, isThresholdHintAfter]);
 
   const getHint = (text) => (
     <span className="pgn__progress-hint">

--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -51,7 +51,7 @@ const SearchFieldAdvanced = (props) => {
     } else {
       onChange(value);
     }
-  }, [value]);
+  }, [value, onChange]);
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/src/SelectableBox/index.jsx
+++ b/src/SelectableBox/index.jsx
@@ -24,15 +24,17 @@ const SelectableBox = React.forwardRef(({
   className,
 }, ref) => {
   const inputType = getInputType('SelectableBox', type);
+  const { value: radioValue } = useRadioSetContext();
+  const { value: checkboxValues = [] } = useCheckboxSetContext();
 
   const isChecked = () => {
     switch (type) {
       case 'radio':
-        return useRadioSetContext().value === value;
+        return radioValue === value;
       case 'checkbox':
-        return useCheckboxSetContext().value?.includes(value);
+        return checkboxValues.includes(value);
       default:
-        return useRadioSetContext().value === value;
+        return radioValue === value;
     }
   };
 

--- a/src/SelectableBox/index.jsx
+++ b/src/SelectableBox/index.jsx
@@ -53,7 +53,7 @@ const SelectableBox = React.forwardRef(({
     if (onClick && inputRef.current) {
       inputRef.current.onclick = () => onClick(inputRef.current);
     }
-  }, [inputRef.current]);
+  }, [onClick]);
 
   return (
     <div

--- a/src/Stepper/StepperStep.jsx
+++ b/src/Stepper/StepperStep.jsx
@@ -23,7 +23,7 @@ export default function StepperStep({
       hasError,
     });
     return () => removeStep(eventKey);
-  }, [title, eventKey, description, hasError]);
+  }, [title, eventKey, description, hasError, index, registerStep, removeStep]);
 
   const isActive = activeKey === eventKey;
 

--- a/src/Sticky/index.jsx
+++ b/src/Sticky/index.jsx
@@ -21,9 +21,10 @@ const Sticky = React.forwardRef(({
   // eslint-disable-next-line consistent-return
   useLayoutEffect(() => {
     if (resolvedRef.current) {
+      const stickyElement = resolvedRef.current;
       // getComputedStyle is used to get real top/bottom
       // values on the page for proper shadows display
-      const elementStyles = window.getComputedStyle(resolvedRef.current);
+      const elementStyles = window.getComputedStyle(stickyElement);
       const elementOffset = elementStyles[position || 'top'];
       // Margin calculations according to the offset.
       // 1 pixel above/bellow + offset pixels that determines
@@ -38,11 +39,10 @@ const Sticky = React.forwardRef(({
             : `-${elementWithOffset}px 0px 0px 0px`,
         },
       );
-      observer.observe(resolvedRef.current);
+      observer.observe(stickyElement);
 
       return () => {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        observer.unobserve(resolvedRef.current);
+        observer.unobserve(stickyElement);
       };
     }
   }, [position, resolvedRef]);

--- a/src/Sticky/index.jsx
+++ b/src/Sticky/index.jsx
@@ -41,10 +41,11 @@ const Sticky = React.forwardRef(({
       observer.observe(resolvedRef.current);
 
       return () => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         observer.unobserve(resolvedRef.current);
       };
     }
-  }, []);
+  }, [position, resolvedRef]);
 
   return (
     <div

--- a/src/hooks/useArrowKeyNavigation.js
+++ b/src/hooks/useArrowKeyNavigation.js
@@ -84,7 +84,7 @@ export default function useArrowKeyNavigation(props) {
     };
     document.addEventListener('keydown', eventHandler);
     return () => document.removeEventListener('keydown', eventHandler);
-  }, []);
+  }, [selectors]);
 
   return parentNode;
 }

--- a/src/hooks/useIsVisible.jsx
+++ b/src/hooks/useIsVisible.jsx
@@ -25,7 +25,7 @@ const useIsVisible = (defaultIsVisible = true) => {
       // Do nothing if an intersection observer can't be created.
     }
     return () => {};
-  }, [sentinelRef.current]);
+  }, []);
 
   return [isVisible, sentinelRef];
 };


### PR DESCRIPTION
## Description

Most of hooks are updated due to ESLint rules and some are `eslint-disabled` because of big amount of refactor required. `ProductTour` component was refactored because of inefficient `useEffect` usage.

JIRA: https://openedx.atlassian.net/browse/PAR-804

### Deploy Preview

[Preview](https://deploy-preview-1263--paragon-openedx.netlify.app/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
