### PR TITLE
[BD-46] docs: fix links to sections in default mdx page template

### DIFF
--- a/www/gatsby-browser.js
+++ b/www/gatsby-browser.js
@@ -4,13 +4,13 @@ const { SettingsContextProvider } = require('./src/context/SettingsContext');
 // wrap whole app in settings context
 exports.wrapRootElement = ({ element }) => <SettingsContextProvider>{element}</SettingsContextProvider>;
 
-exports.onRouteUpdate = ({ location }) => {
-  if (location.hash) {
+exports.onRouteUpdate = ({ location: { hash, pathname, href } }) => {
+  if (hash) {
     setTimeout(() => {
-      const id = location.href.split('#')[1];
+      const id = href.split('#')[1];
       const element = document.getElementById(id);
       if (element) {
-        window.scrollTo({ top: element.offsetTop })
+        window.scrollTo({ top: pathname.startsWith('/components/') ? element.offsetTop : element.offsetTop - 75 })
       }
     }, 0);
   }

--- a/www/src/templates/default-mdx-page-template.jsx
+++ b/www/src/templates/default-mdx-page-template.jsx
@@ -7,8 +7,15 @@ import { Container } from '~paragon-react'; // eslint-disable-line
 import CodeBlock from '../components/CodeBlock';
 import Layout from '../components/PageLayout';
 import SEO from '../components/SEO';
+import LinkedHeading from '../components/LinkedHeading';
 
 const shortcodes = {
+  h1: (props) => <LinkedHeading h="1" {...props} />,
+  h2: (props) => <LinkedHeading h="2" {...props} />,
+  h3: (props) => <LinkedHeading h="3" {...props} />,
+  h4: (props) => <LinkedHeading h="4" {...props} />,
+  h5: (props) => <LinkedHeading h="5" {...props} />,
+  h6: (props) => <LinkedHeading h="6" {...props} />,
   pre: props => <div {...props} />,
   code: CodeBlock,
   Link,


### PR DESCRIPTION
## Description

Fixes how anchor links are displayed when using default mdx page and updates scroll behaviour to those headings to include sticky header size

### Deploy Preview

See [Installation and Usage page](https://deploy-preview-1274--paragon-openedx.netlify.app/guides/installation-and-usage/) for example, and its [version](https://paragon-openedx.netlify.app/guides/installation-and-usage) before this PR

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
