### PR TITLE
[BD-46] feat: useIndexOfLastVisibleChild, responsive tabs

### DIFF
--- a/src/Dropdown/Dropdown.scss
+++ b/src/Dropdown/Dropdown.scss
@@ -2,6 +2,7 @@
 @import "~bootstrap/scss/dropdown";
 
 .dropdown-toggle::after {
+  border: 0;
   border-style: solid;
   border-width: .15rem .15rem 0 0;
   content: "";

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -115,6 +115,43 @@ notes: |
 </Tabs>
 ```
 
+### Responsive support
+
+```jsx live
+<Tabs defaultActiveKey="profile" id="uncontrolled-tab-example">
+  <Tab eventKey="home" title="Home">
+    Hello I am the first panel.
+  </Tab>
+  <Tab eventKey="dashboard" title="Dashboard">
+    Hello I am the second panel.
+  </Tab>
+  <Tab eventKey="profile" title="Profile" notification={1}>
+    Hello I am the third panel.
+  </Tab>
+  <Tab eventKey="products" title="Products">
+    Hello I am the fourth panel.
+  </Tab>
+  <Tab eventKey="help" title="Help">
+    Hello I am the fifth panel.
+  </Tab>
+  <Tab eventKey="about" title="About">
+    Hello I am the sixth panel.
+  </Tab>
+  <Tab eventKey="updates" title="Updates">
+    Hello I am the seventh panel.
+  </Tab>
+  <Tab eventKey="forum" title="Forum">
+    Hello I am the eights panel.
+  </Tab>
+  <Tab eventKey="job" title="Job">
+    Hello I am the ninth panel.
+  </Tab>
+  <Tab eventKey="team" title="Our team">
+    Hello I am the tenth panel.
+  </Tab>
+</Tabs>
+```
+
 ***
 
 ## Tabs.Deprecated

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -141,7 +141,7 @@ notes: |
     Hello I am the seventh panel.
   </Tab>
   <Tab eventKey="forum" title="Forum">
-    Hello I am the eights panel.
+    Hello I am the eighth panel.
   </Tab>
   <Tab eventKey="job" title="Job">
     Hello I am the ninth panel.

--- a/src/Tabs/Tabs.scss
+++ b/src/Tabs/Tabs.scss
@@ -36,4 +36,11 @@
     border-top-width: 4px;
     border-bottom-width: 4px;
   }
+
+  &.active {
+    .dropdown .dropdown-toggle {
+      // stylelint-disable-next-line
+      @extend .nav-link, .active;
+    }
+  }
 }

--- a/src/Tabs/Tabs.scss
+++ b/src/Tabs/Tabs.scss
@@ -1,6 +1,8 @@
 @import "variables";
 
 .pgn__tabs {
+  flex-wrap: nowrap;
+
   & > * {
     position: relative;
   }
@@ -12,5 +14,26 @@
     min-height: $tab-notification-height;
     min-width: $tab-notification-width;
     font-size: $tab-notification-font-size;
+  }
+}
+
+.pgn__tab_invisible {
+  position: absolute;
+  left: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.pgn__tab_more.nav-link {
+  margin-bottom: 0;
+  padding: 0;
+  border-top: none;
+  border-bottom: none;
+
+  .dropdown .dropdown-toggle {
+    display: block;
+    padding: .5rem 1rem;
+    border-top-width: 4px;
+    border-bottom-width: 4px;
   }
 }

--- a/src/Tabs/Tabs.test.jsx
+++ b/src/Tabs/Tabs.test.jsx
@@ -5,6 +5,13 @@ import renderer from 'react-test-renderer';
 import Tabs from './index';
 import Tab from './Tab';
 
+window.ResizeObserver = window.ResizeObserver
+  || jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  }));
+
 describe('<Tabs />', () => {
   describe('correct rendering', () => {
     it('renders successfully', () => {

--- a/src/Tabs/Tabs.test.jsx
+++ b/src/Tabs/Tabs.test.jsx
@@ -2,35 +2,91 @@ import React from 'react';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 
-import Tabs from './index';
+import Tabs, { MORE_TAB_TEXT } from './index';
 import Tab from './Tab';
 
-window.ResizeObserver = window.ResizeObserver
-  || jest.fn().mockImplementation(() => ({
-    disconnect: jest.fn(),
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-  }));
+jest.mock('../hooks/useIndexOfLastVisibleChild', () => ({
+  __esModule: true,
+  default: () => 0,
+}));
+
+let getAttributeValue = 'true';
+
+const disconnect = jest.fn();
+const observeMutation = jest.fn((callback) => callback([{
+  target: {
+    getAttribute: () => getAttributeValue,
+  },
+}]));
+const observeResize = jest.fn();
+const unobserve = jest.fn();
+
+window.MutationObserver = jest.fn((callback) => ({
+  disconnect,
+  observe: () => observeMutation(callback),
+  unobserve,
+}));
+
+window.ResizeObserver = jest.fn(() => ({
+  disconnect,
+  observe: observeResize,
+  unobserve,
+}));
+
+const TabsTestComponent = (props) => (
+  <Tabs {...props} defaultActiveKey="tab_1">
+    <Tab title="Tab 1" notification={4} eventKey="tab_1" />
+    <Tab title="Tab 2" eventKey="tab_2" />
+    <Tab title="Tab 3" eventKey="tab_3" />
+  </Tabs>
+);
 
 describe('<Tabs />', () => {
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = '';
+    observeMutation.mockClear();
+  });
+
   describe('correct rendering', () => {
     it('renders successfully', () => {
-      const tree = renderer.create((
-        <Tabs>
-          <Tab title="Tab 1" />
-          <Tab title="Tab 2" />
-        </Tabs>
-      )).toJSON();
+      const tree = renderer.create(<TabsTestComponent />).toJSON();
       expect(tree).toMatchSnapshot();
     });
     it('renders notification property', () => {
+      const wrapper = mount(<TabsTestComponent />);
+      expect(wrapper.find('.pgn__tab-notification').length).toBeGreaterThan(0);
+    });
+    it('MutationObserver is initialized', () => {
+      mount(<TabsTestComponent />);
+      expect(observeMutation).toHaveBeenCalledTimes(1);
+      getAttributeValue = 'false';
+      mount(<TabsTestComponent />);
+      expect(observeMutation).toHaveBeenCalledTimes(2);
+    });
+    it('dropdown menu is displayed', () => {
+      const wrapper = mount(<TabsTestComponent />);
+      expect(wrapper.find('.pgn__tab_more').at(0).hasClass('pgn__tab_invisible')).toBe(false);
+    });
+    it('moreTabText is displayed', () => {
+      const text = 'Mehr...';
+      const wrapper = mount(<TabsTestComponent />);
+      expect(wrapper.find('#pgn__tab-toggle').at(0).text()).toEqual(MORE_TAB_TEXT);
+      wrapper.setProps({ moreTabText: text });
+      expect(wrapper.find('#pgn__tab-toggle').at(0).text()).toEqual(text);
+    });
+    it('click on the dropdown item activates tab', () => {
+      const wrapper = mount(<TabsTestComponent />);
+      wrapper.find('#pgn__tab-toggle').at(0).simulate('click');
+      wrapper.find('.dropdown-item').at(0).simulate('click');
+      expect(wrapper.find('[data-rb-event-key="tab_2"]').at(0).hasClass('active')).toEqual(true);
+    });
+    it('invalid child does not render', () => {
       const wrapper = mount((
         <Tabs>
-          <Tab title="Tab 1" notification={4} />
-          <Tab title="Tab 2" />
+          {[false, undefined]}
         </Tabs>
       ));
-      expect(wrapper.find('.pgn__tab-notification').length).toBeGreaterThan(0);
+      expect(wrapper.find('nav').children().length).toEqual(1);
     });
   });
 });

--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -1,14 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Tabs /> correct rendering renders successfully 1`] = `
-Array [
+<div>
   <nav
     className="pgn__tabs nav nav-tabs"
     onKeyDown={[Function]}
     role="tablist"
   >
     <a
-      className="nav-item nav-link"
+      className="pgn__tab_more nav-item nav-link"
+      data-rb-event-key={null}
+      href="#"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="tab"
+    >
+      <div
+        className="dropdown"
+        data-testid="dropdown"
+      >
+        <button
+          aria-expanded={false}
+          aria-haspopup={true}
+          className="nav-link dropdown-toggle btn btn-link"
+          disabled={false}
+          id="pgn__tab-toggle"
+          onClick={[Function]}
+          type="button"
+        >
+          More...
+        </button>
+      </div>
+    </a>
+    <a
+      className="pgn__tab_invisible nav-item nav-link"
       data-rb-event-key={null}
       href="#"
       onClick={[Function]}
@@ -18,7 +43,7 @@ Array [
       Tab 1
     </a>
     <a
-      className="nav-item nav-link"
+      className="pgn__tab_invisible nav-item nav-link"
       data-rb-event-key={null}
       href="#"
       onClick={[Function]}
@@ -27,7 +52,7 @@ Array [
     >
       Tab 2
     </a>
-  </nav>,
+  </nav>
   <div
     className="tab-content"
   >
@@ -45,6 +70,13 @@ Array [
       id={null}
       role="tabpanel"
     />
-  </div>,
-]
+    <div
+      aria-hidden={true}
+      aria-labelledby={null}
+      className="fade tab-pane"
+      id={null}
+      role="tabpanel"
+    />
+  </div>
+</div>
 `;

--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -8,6 +8,22 @@ exports[`<Tabs /> correct rendering renders successfully 1`] = `
     role="tablist"
   >
     <a
+      aria-selected={true}
+      className="nav-item nav-link active"
+      data-rb-event-key="tab_1"
+      href="#"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="tab"
+    >
+      Tab 1
+      <div
+        className="pgn__bubble pgn__bubble-error pgn__tab-notification"
+      >
+        4
+      </div>
+    </a>
+    <a
       className="pgn__tab_more nav-item nav-link"
       data-rb-event-key={null}
       href="#"
@@ -33,18 +49,9 @@ exports[`<Tabs /> correct rendering renders successfully 1`] = `
       </div>
     </a>
     <a
+      aria-selected={false}
       className="pgn__tab_invisible nav-item nav-link"
-      data-rb-event-key={null}
-      href="#"
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      role="tab"
-    >
-      Tab 1
-    </a>
-    <a
-      className="pgn__tab_invisible nav-item nav-link"
-      data-rb-event-key={null}
+      data-rb-event-key="tab_2"
       href="#"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -52,10 +59,29 @@ exports[`<Tabs /> correct rendering renders successfully 1`] = `
     >
       Tab 2
     </a>
+    <a
+      aria-selected={false}
+      className="pgn__tab_invisible nav-item nav-link"
+      data-rb-event-key="tab_3"
+      href="#"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="tab"
+    >
+      Tab 3
+    </a>
   </nav>
   <div
     className="tab-content"
   >
+    <div
+      aria-hidden={false}
+      aria-labelledby={null}
+      className="fade tab-pane active show"
+      id={null}
+      notification={4}
+      role="tabpanel"
+    />
     <div
       aria-hidden={true}
       aria-labelledby={null}

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -24,7 +24,6 @@ const Tabs = ({
     containerElementRef.current?.children[0],
     overflowElementRef.current?.parentNode,
   );
-  const indexOfOverflowStart = indexOfLastVisibleChild + 1;
 
   useEffect(() => {
     if (containerElementRef.current) {
@@ -46,7 +45,7 @@ const Tabs = ({
       return () => observer.disconnect();
     }
     return undefined;
-  }, [containerElementRef.current]);
+  }, []);
 
   useEffect(() => {
     if (overflowElementRef.current?.parentNode) {
@@ -60,6 +59,7 @@ const Tabs = ({
   };
 
   const tabsChildren = useMemo(() => {
+    const indexOfOverflowStart = indexOfLastVisibleChild + 1;
     const childrenList = React.Children.map(children, (child, index) => {
       if (!React.isValidElement(child)) {
         return child;
@@ -90,6 +90,7 @@ const Tabs = ({
     const overflowChildren = childrenList.slice(indexOfOverflowStart)
       .map(overflowChild => (
         <Dropdown.Item
+          key={`${overflowChild.props.eventKey}overflow`}
           onClick={() => handleDropdownTabClick(overflowChild.props.eventKey)}
           disabled={overflowChild.props.disabled}
           datakey={overflowChild.props.eventKey}
@@ -103,6 +104,7 @@ const Tabs = ({
 
     childrenList.splice(indexOfOverflowStart, 0, (
       <Tab
+        key="moreTabKey"
         tabClassName={classNames(!overflowChildren.length && 'pgn__tab_invisible', 'pgn__tab_more')}
         title={(
           <Dropdown ref={overflowElementRef}>
@@ -119,7 +121,7 @@ const Tabs = ({
       />
     ));
     return childrenList;
-  }, [children, indexOfLastVisibleChild]);
+  }, [activeKey, children, defaultActiveKey, indexOfLastVisibleChild, moreTabText]);
 
   return (
     <div ref={containerElementRef}>

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -29,11 +29,22 @@ const Tabs = ({
     if (containerElementRef.current) {
       const observer = new MutationObserver((mutations => {
         mutations.forEach(mutation => {
+          // React-Bootstrap attribute 'data-rb-event-key' is responsible for the tab identification
           const eventKey = mutation.target.getAttribute('data-rb-event-key');
+          // React-Bootstrap attribute 'aria-selected' is responsible for selected/unselected state
           const isActive = mutation.target.getAttribute('aria-selected') === 'true';
+          // datakey attribute is added manually to the dropdown
+          // elements so that they correspond to the native tabs' eventKey
           const element = containerElementRef.current.querySelector(`[datakey='${eventKey}']`);
+          const moreTab = containerElementRef.current.querySelector('.pgn__tab_more');
           if (isActive) {
             element?.classList.add('active');
+            // Here we add active class to the 'More Tab' if element exists in the dropdown
+            if (element) {
+              moreTab.classList.add('active');
+            } else {
+              moreTab.classList.remove('active');
+            }
           } else {
             element?.classList.remove('active');
           }
@@ -86,21 +97,26 @@ const Tabs = ({
       });
       return modifiedTab;
     });
-
+    let moreTabHasNotification = false;
     const overflowChildren = childrenList.slice(indexOfOverflowStart)
-      .map(overflowChild => (
-        <Dropdown.Item
-          key={`${overflowChild.props.eventKey}overflow`}
-          onClick={() => handleDropdownTabClick(overflowChild.props.eventKey)}
-          disabled={overflowChild.props.disabled}
-          datakey={overflowChild.props.eventKey}
-          className={classNames({
-            active: overflowChild.props.eventKey === defaultActiveKey || overflowChild.props.eventKey === activeKey,
-          }, 'pgn__tabs__dropdown-item')}
-        >
-          {overflowChild.props.title}
-        </Dropdown.Item>
-      ));
+      .map(overflowChild => {
+        if (!moreTabHasNotification && overflowChild.props.notification) {
+          moreTabHasNotification = true;
+        }
+        return (
+          <Dropdown.Item
+            key={`${overflowChild.props.eventKey}overflow`}
+            onClick={() => handleDropdownTabClick(overflowChild.props.eventKey)}
+            disabled={overflowChild.props.disabled}
+            datakey={overflowChild.props.eventKey}
+            className={classNames({
+              active: overflowChild.props.eventKey === defaultActiveKey || overflowChild.props.eventKey === activeKey,
+            }, 'pgn__tabs__dropdown-item')}
+          >
+            {overflowChild.props.title}
+          </Dropdown.Item>
+        );
+      });
 
     childrenList.splice(indexOfOverflowStart, 0, (
       <Tab
@@ -114,6 +130,9 @@ const Tabs = ({
               id="pgn__tab-toggle"
             >
               {moreTabText}
+              {moreTabHasNotification && (
+                <Bubble variant="error" className="pgn__tab-notification" />
+              )}
             </Dropdown.Toggle>
             <Dropdown.Menu className="dropdown-menu-right">{overflowChildren}</Dropdown.Menu>
           </Dropdown>

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -1,21 +1,72 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import BaseTabs from 'react-bootstrap/Tabs';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import TabsDeprecated from './deprecated';
 import Bubble from '../Bubble';
+import Dropdown from '../Dropdown';
+import useIndexOfLastVisibleChild from '../hooks/useIndexOfLastVisibleChild';
+import Tab from './Tab';
+
+export const MORE_TAB_TEXT = 'More...';
 
 const Tabs = ({
   children,
   className,
+  moreTabText = MORE_TAB_TEXT,
+  defaultActiveKey,
+  activeKey,
   ...props
-}) => (
-  <BaseTabs {...props} className={classNames(className, 'pgn__tabs')}>
-    {React.Children.map(children, (child) => {
+}) => {
+  const containerElementRef = useRef(null);
+  const overflowElementRef = useRef(null);
+  const indexOfLastVisibleChild = useIndexOfLastVisibleChild(
+    containerElementRef.current?.children[0],
+    overflowElementRef.current?.parentNode,
+  );
+  const indexOfOverflowStart = indexOfLastVisibleChild + 1;
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (containerElementRef.current) {
+      const observer = new MutationObserver((mutations => {
+        mutations.forEach(mutation => {
+          const eventKey = mutation.target.getAttribute('data-rb-event-key');
+          const isActive = mutation.target.getAttribute('aria-selected') === 'true';
+          const element = containerElementRef.current.querySelector(`[datakey='${eventKey}']`);
+          if (isActive) {
+            element?.classList.add('active');
+          } else {
+            element?.classList.remove('active');
+          }
+        });
+      }));
+      observer.observe(containerElementRef.current, {
+        attributes: true, subtree: true, attributeFilter: ['aria-selected'],
+      });
+      return () => observer.disconnect();
+    }
+  }, [containerElementRef.current]);
+
+  useEffect(() => {
+    if (overflowElementRef.current?.parentNode) {
+      overflowElementRef.current.parentNode.tabIndex = -1;
+    }
+  }, [overflowElementRef.current?.parentNode]);
+
+  const handleDropdownTabClick = (eventKey) => {
+    const hiddenTab = containerElementRef.current.querySelector(`[data-rb-event-key='${eventKey}']`);
+    hiddenTab.click();
+  };
+
+  const tabsChildren = useMemo(() => {
+    const childrenList = React.Children.map(children, (child, index) => {
       if (!React.isValidElement(child)) {
         return child;
       }
-      const { title, notification, ...rest } = child.props;
+      const {
+        title, notification, tabClassName, ...rest
+      } = child.props;
       let newTitle;
       if (notification) {
         newTitle = (
@@ -27,27 +78,87 @@ const Tabs = ({
       } else {
         newTitle = title;
       }
-      const modifiedTab = React.cloneElement(child, { ...rest, title: newTitle });
+      const tabClass = index > indexOfLastVisibleChild ? 'pgn__tab_invisible' : '';
+      const modifiedTab = React.cloneElement(child, {
+        ...rest,
+        title: newTitle,
+        tabClassName: classNames(tabClass, tabClassName),
+      });
       return modifiedTab;
-    })}
-  </BaseTabs>
-);
+    });
+
+    const overflowChildren = childrenList.slice(indexOfOverflowStart)
+      .map(overflowChild => (
+        <Dropdown.Item
+          onClick={() => handleDropdownTabClick(overflowChild.props.eventKey)}
+          disabled={overflowChild.props.disabled}
+          datakey={overflowChild.props.eventKey}
+          className={classNames({
+            active: overflowChild.props.eventKey === defaultActiveKey || overflowChild.props.eventKey === activeKey,
+          }, 'pgn__tabs__dropdown-item')}
+        >
+          {overflowChild.props.title}
+        </Dropdown.Item>
+      ));
+
+    childrenList.splice(indexOfOverflowStart, 0, (
+      <Tab
+        tabClassName={classNames(!overflowChildren.length && 'pgn__tab_invisible', 'pgn__tab_more')}
+        title={(
+          <Dropdown ref={overflowElementRef}>
+            <Dropdown.Toggle
+              variant="link"
+              className="nav-link"
+              id="pgn__tab-toggle"
+            >
+              {moreTabText}
+            </Dropdown.Toggle>
+            <Dropdown.Menu className="dropdown-menu-right">{overflowChildren}</Dropdown.Menu>
+          </Dropdown>
+        )}
+      />
+    ));
+    return childrenList;
+  }, [children, indexOfLastVisibleChild]);
+
+  return (
+    <div ref={containerElementRef}>
+      <BaseTabs
+        defaultActiveKey={defaultActiveKey}
+        activeKey={activeKey}
+        {...props}
+        className={classNames(className, 'pgn__tabs')}
+      >
+        {tabsChildren}
+      </BaseTabs>
+    </div>
+  );
+};
 
 Tabs.propTypes = {
   /** Specifies elements that is processed to create tabs. */
   children: PropTypes.node.isRequired,
   /** Specifies class name to append to the base element. */
   className: PropTypes.string,
+  /** Specifies text for the 'More' tab. */
+  moreTabText: PropTypes.string,
+  /** Specifies default active tab (uncontrolled usage). */
+  defaultActiveKey: PropTypes.string,
+  /** Specifies active tab (controlled usage). */
+  activeKey: PropTypes.string,
 };
 
 Tabs.defaultProps = {
   className: undefined,
+  moreTabText: MORE_TAB_TEXT,
+  defaultActiveKey: undefined,
+  activeKey: undefined,
 };
 
 Tabs.Deprecated = TabsDeprecated;
 
 export default Tabs;
-export { default as Tab } from './Tab';
+export { Tab };
 export { default as TabContainer } from 'react-bootstrap/TabContainer';
 export { default as TabContent } from 'react-bootstrap/TabContent';
 export { default as TabPane } from 'react-bootstrap/TabPane';

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -26,7 +26,6 @@ const Tabs = ({
   );
   const indexOfOverflowStart = indexOfLastVisibleChild + 1;
 
-  // eslint-disable-next-line consistent-return
   useEffect(() => {
     if (containerElementRef.current) {
       const observer = new MutationObserver((mutations => {
@@ -46,6 +45,7 @@ const Tabs = ({
       });
       return () => observer.disconnect();
     }
+    return undefined;
   }, [containerElementRef.current]);
 
   useEffect(() => {

--- a/src/hooks/tests/useIndexOfLastVisibleChild.test.jsx
+++ b/src/hooks/tests/useIndexOfLastVisibleChild.test.jsx
@@ -4,6 +4,13 @@ import { useIndexOfLastVisibleChild } from '../..';
 
 const dropdownId = 'dropdown';
 
+window.ResizeObserver = window.ResizeObserver
+  || jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  }));
+
 const TestComponent = () => {
   const containerElementRef = React.useRef(null);
   const overflowElementRef = React.useRef(null);

--- a/src/hooks/tests/useIndexOfLastVisibleChild.test.jsx
+++ b/src/hooks/tests/useIndexOfLastVisibleChild.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { useIndexOfLastVisibleChild } from '../..';
+
+const dropdownId = 'dropdown';
+
+const TestComponent = () => {
+  const containerElementRef = React.useRef(null);
+  const overflowElementRef = React.useRef(null);
+  const indexOfLastVisibleChild = useIndexOfLastVisibleChild(containerElementRef.current, overflowElementRef.current);
+
+  return (
+    <div ref={containerElementRef} style={{ display: 'flex' }}>
+      <div style={{ width: '250px' }} className="element">Element 1</div>
+      <div style={{ width: '250px' }} className="element">Element 2</div>
+      <div style={{ width: '250px' }} className="element">Element 3</div>
+      <div ref={overflowElementRef} id={dropdownId}>{indexOfLastVisibleChild}</div>
+    </div>
+  );
+};
+
+describe('useIndexOfLastVisibleChild hook', () => {
+  it('hooks display correct index', () => {
+    const wrapper = mount(<TestComponent />);
+    expect(wrapper.find(`#${dropdownId}`).text()).toEqual((wrapper.find('.element').length - 1).toString());
+  });
+});

--- a/src/hooks/useIndexOfLastVisibleChild.jsx
+++ b/src/hooks/useIndexOfLastVisibleChild.jsx
@@ -65,7 +65,7 @@ const useIndexOfLastVisibleChild = (containerElementRef, overflowElementRef) => 
       });
 
     setIndexOfLastVisibleChild(nextIndexOfLastVisibleChild);
-  }, [windowSize, containerWidth]);
+  }, [windowSize, containerWidth, containerElementRef, overflowElementRef]);
 
   return indexOfLastVisibleChild;
 };

--- a/src/hooks/useIndexOfLastVisibleChild.jsx
+++ b/src/hooks/useIndexOfLastVisibleChild.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useLayoutEffect, useState } from 'react';
+
+import useWindowSize from './useWindowSize';
+
+/**
+ * This hook will find the index of the last child of a containing element
+ * that fits within its bounding rectangle. This is done by summing the widths
+ * of the children until they exceed the width of the container.
+ *
+ * @param {Element} containerElementRef - container element
+ * @param {Element} overflowElementRef - overflow element
+ *
+ * The hook returns an array containing:
+ * [indexOfLastVisibleChild, containerElementRef, overflowElementRef]
+ *
+ * indexOfLastVisibleChild - the index of the last visible child
+ * containerElementRef - a ref to be added to the containing html node
+ * overflowElementRef - a ref to be added to an html node inside the container
+ *    that is likely to be used to contain a "More" type dropdown or other
+ *    mechanism to reveal hidden children. The width of this element is always
+ *    included when determining which children will fit or not. Usage of this ref
+ *    is optional.
+ */
+const useIndexOfLastVisibleChild = (containerElementRef, overflowElementRef) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [indexOfLastVisibleChild, setIndexOfLastVisibleChild] = useState(-1);
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    if (containerElementRef) {
+      const observer = new ResizeObserver(entries => {
+        for (let i = 0; i < entries.length; i++) {
+          setContainerWidth(entries[i].contentRect.width);
+        }
+      });
+      observer.observe(containerElementRef);
+      return () => observer.disconnect();
+    }
+    return undefined;
+  }, [containerElementRef]);
+
+  useLayoutEffect(() => {
+    if (!containerElementRef) {
+      return;
+    }
+    // Get array of child nodes from NodeList form
+    const childNodesArr = Array.prototype.slice.call(containerElementRef.children);
+    const { nextIndexOfLastVisibleChild } = childNodesArr
+      // filter out the overflow element
+      .filter(childNode => childNode !== overflowElementRef)
+      // sum the widths to find the last visible element's index
+      .reduce((acc, childNode, index) => {
+        acc.sumWidth += childNode.getBoundingClientRect().width;
+        if (acc.sumWidth <= containerWidth) {
+          acc.nextIndexOfLastVisibleChild = index;
+        }
+        return acc;
+      }, {
+        // Include the overflow element's width to begin with. Doing this means
+        // sometimes we'll show a dropdown with one item in it when it would fit,
+        // but allowing this case dramatically simplifies the calculations we need
+        // to do above.
+        sumWidth: overflowElementRef ? overflowElementRef.getBoundingClientRect().width : 0,
+        nextIndexOfLastVisibleChild: -1,
+      });
+
+    setIndexOfLastVisibleChild(nextIndexOfLastVisibleChild);
+  }, [windowSize, containerWidth]);
+
+  return indexOfLastVisibleChild;
+};
+
+export default useIndexOfLastVisibleChild;

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,7 @@ export { default as breakpoints } from './utils/breakpoints';
 export { default as Variant } from './utils/constants';
 export { default as useWindowSize } from './hooks/useWindowSize';
 export { default as useToggle } from './hooks/useToggle';
+export { default as useIndexOfLastVisibleChild } from './hooks/useIndexOfLastVisibleChild';
 
 // Pass through any needed whole third-party library functionality
 // useTable for example is needed to use the DataTable component seamlessly


### PR DESCRIPTION
## Description

1. Added `useIndexOfLastVisibleChild` hook:
- got code from [code](https://github.com/openedx/frontend-app-learning/blob/907892e7bb1263d6b9b56d8acc7fe57abd34cbdd/src/generic/tabs/useIndexOfLastVisibleChild.js#L33) and modified
- added support for dynamic style changes on the site
- updated parameters for hook to be able to use it when it is not possible to pass ref straightly to the container element or to the overflow element
- added tests
2. Added code for the `Tabs` component to use new hook and support responsive
- `useMemo` for `children` to update them when hook returns different index
- click on the dropdown item activates corresponding tab
- observer tracks tab change and update active state in the tab
- tab styles
- interactions with tabs using keyboard

JIRA: [PAR-805](https://openedx.atlassian.net/browse/PAR-805)

### Deploy Preview

[Preview link](https://deploy-preview-1287--paragon-openedx.netlify.app)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
