### PR TITLE
[BD-46] docs: add 'Responsive' page

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -25,7 +25,10 @@
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
     "string-quotes": "double",
-    "scss/at-import-partial-extension": "never",
-    "scss/comment-no-empty": null
+    "scss/at-import-partial-extension": null,
+    "scss/comment-no-empty": null,
+    "property-no-unknown": [true, {
+      "ignoreProperties": ["xs", "sm", "md", "lg", "xl", "xxl"]
+    }]
   }
 }

--- a/scss/core/_exports.module.scss
+++ b/scss/core/_exports.module.scss
@@ -4,19 +4,19 @@
 // adapting to different screen sizes, for use in media queries.
 
 $grid-breakpoints: (
-        xs: 0,
-        sm: 576px,
-        md: 768px,
-        lg: 992px,
-        xl: 1200px,
-        xxl: 1400px
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1400px
 ) !default;
 
 :export {
-    xs: map-get($grid-breakpoints, 'xs');
-    sm: map-get($grid-breakpoints, 'sm');
-    md: map-get($grid-breakpoints, 'md');
-    lg: map-get($grid-breakpoints, 'lg');
-    xl: map-get($grid-breakpoints, 'xl');
-    xxl: map-get($grid-breakpoints, 'xxl');
+  xs: map-get($grid-breakpoints, "xs");
+  sm: map-get($grid-breakpoints, "sm");
+  md: map-get($grid-breakpoints, "md");
+  lg: map-get($grid-breakpoints, "lg");
+  xl: map-get($grid-breakpoints, "xl");
+  xxl: map-get($grid-breakpoints, "xxl");
 }

--- a/scss/core/_exports.module.scss
+++ b/scss/core/_exports.module.scss
@@ -1,0 +1,22 @@
+// Grid breakpoints
+//
+// Define the minimum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
+
+$grid-breakpoints: (
+        xs: 0,
+        sm: 576px,
+        md: 768px,
+        lg: 992px,
+        xl: 1200px,
+        xxl: 1400px
+) !default;
+
+:export {
+    xs: map-get($grid-breakpoints, 'xs');
+    sm: map-get($grid-breakpoints, 'sm');
+    md: map-get($grid-breakpoints, 'md');
+    lg: map-get($grid-breakpoints, 'lg');
+    xl: map-get($grid-breakpoints, 'xl');
+    xxl: map-get($grid-breakpoints, 'xxl');
+}

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -2,6 +2,7 @@
 //
 // Variables should follow the `$component-state-property-size` formula for
 // consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
+@import "exports.module";
 
 // Color system
 $white:    #FFFFFF !default;
@@ -424,19 +425,6 @@ $emphasized-link-hover-darken-percentage: 15% !default;
 // Style p element.
 
 $paragraph-margin-bottom:   1rem !default;
-
-// Grid breakpoints
-//
-// Define the minimum dimensions at which your layout will change,
-// adapting to different screen sizes, for use in media queries.
-
-$grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px
-) !default;
 
 @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
 @include _assert-starts-at-zero($grid-breakpoints, "$grid-breakpoints");

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -2,7 +2,7 @@
 //
 // Variables should follow the `$component-state-property-size` formula for
 // consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
-@import "exports.module";
+@import "exports.module.scss";
 
 // Color system
 $white:    #FFFFFF !default;

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -1,27 +1,31 @@
-// NOTE: These are the breakpoints used in Bootstrap v4.0.0 as seen in
-// the documentation (https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)
+import breakpointSizes from '../../scss/core/_exports.module.scss';
+
+const {
+  sm, md, lg, xl, xxl,
+} = breakpointSizes;
+
 const breakpoints = {
   extraSmall: {
-    maxWidth: 575.98,
+    maxWidth: parseFloat(sm) || 575.98,
   },
   small: {
-    minWidth: 576,
-    maxWidth: 767.98,
+    minWidth: parseFloat(sm) || 576,
+    maxWidth: parseFloat(md) || 767.98,
   },
   medium: {
-    minWidth: 768,
-    maxWidth: 991.98,
+    minWidth: parseFloat(md) || 768,
+    maxWidth: parseFloat(lg) || 991.98,
   },
   large: {
-    minWidth: 992,
-    maxWidth: 1199.98,
+    minWidth: parseFloat(lg) || 992,
+    maxWidth: parseFloat(xl) || 1199.98,
   },
   extraLarge: {
-    minWidth: 1200,
-    maxWidth: 1399.98,
+    minWidth: parseFloat(xl) || 1200,
+    maxWidth: parseFloat(xxl) || 1399.98,
   },
   extraExtraLarge: {
-    minWidth: 1400,
+    minWidth: parseFloat(xxl) || 1400,
   },
 };
 

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -13,7 +13,16 @@ const segmentPlugin = {
 };
 
 const plugins = [
-  "gatsby-plugin-sass",
+  {
+    resolve: `gatsby-plugin-sass`,
+    options: {
+     cssLoaderOptions: {
+       modules: {
+         namedExport: false,
+       },
+     },
+   },
+  },
   `gatsby-plugin-react-helmet`,
   {
     resolve: `gatsby-plugin-manifest`,

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@edx/brand-edx.org": "^2.0.3",
+        "@edx/brand-edx.org": "^2.0.6",
         "@edx/brand-openedx": "^1.1.0",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@mdx-js/mdx": "^1.6.22",
@@ -4511,9 +4511,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@edx/brand-edx.org": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.3.tgz",
-      "integrity": "sha512-QRmq2su1Xy+9GhY3NRZ+WdjtYWHmgfuKbVCW2skxgfgW9Q6kea8L6LrgigfrZtW+kQq/KdX2tVJcYBkB9xALtQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.6.tgz",
+      "integrity": "sha512-rVUXzIOQf8mHi92OcGCXDEfSGQqahCHaIU/0WYt9lsuirJdUJ5k4FtHTdpmHuYdK6VO6N6dxOXxL9OjYFsdNXw=="
     },
     "node_modules/@edx/brand-openedx": {
       "version": "1.1.0",
@@ -29874,9 +29874,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@edx/brand-edx.org": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.3.tgz",
-      "integrity": "sha512-QRmq2su1Xy+9GhY3NRZ+WdjtYWHmgfuKbVCW2skxgfgW9Q6kea8L6LrgigfrZtW+kQq/KdX2tVJcYBkB9xALtQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.6.tgz",
+      "integrity": "sha512-rVUXzIOQf8mHi92OcGCXDEfSGQqahCHaIU/0WYt9lsuirJdUJ5k4FtHTdpmHuYdK6VO6N6dxOXxL9OjYFsdNXw=="
     },
     "@edx/brand-openedx": {
       "version": "1.1.0",

--- a/www/package.json
+++ b/www/package.json
@@ -3,7 +3,7 @@
   "description": "Paragon Pattern Library Documentation",
   "version": "1.0.0",
   "dependencies": {
-    "@edx/brand-edx.org": "^2.0.3",
+    "@edx/brand-edx.org": "^2.0.6",
     "@edx/brand-openedx": "^1.1.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@mdx-js/mdx": "^1.6.22",

--- a/www/src/components/Menu.jsx
+++ b/www/src/components/Menu.jsx
@@ -154,6 +154,9 @@ const Menu = () => {
             <li className="mr-3">
               <Link to="/foundations/css-utilities">CSS Utility Classes</Link>
             </li>
+            <li className="mr-3">
+              <Link to="/foundations/responsive">Responsive</Link>
+            </li>
           </ul>
           <h3 className="mb-4">
             Playground
@@ -167,7 +170,7 @@ const Menu = () => {
               <OverlayTrigger
                 trigger="focus"
                 overlay={(
-                  <Popover>
+                  <Popover id="playground-popover">
                     <Popover.Title as="h3">
                       <Icon src={Issue} />
                       Сoming soon

--- a/www/src/pages/foundations/responsive.jsx
+++ b/www/src/pages/foundations/responsive.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DataTable, Container, breakpoints } from '~paragon-react'; // eslint-disable-line
+import SEO from '../../components/SEO';
+import Layout from '../../components/PageLayout';
+import CodeBlock from '../../components/CodeBlock';
+
+const BREAKPOINT_DESCRIPTIONS = {
+  extraSmall: { name: 'Extra small', identifier: 'xs' },
+  small: { name: 'Small', identifier: 'xs' },
+  medium: { name: 'Medium', identifier: 'md' },
+  large: { name: 'Large', identifier: 'lg' },
+  extraLarge: { name: 'Extra large', identifier: 'xl' },
+  extraExtraLarge: { name: 'Extra extra large', identifier: 'xxl' },
+};
+
+const getBreakpointDescription = (breakpoint) => BREAKPOINT_DESCRIPTIONS[breakpoint] || {};
+
+const IdentifierCell = ({ row }) => <code>{row.values.identifier}</code>;
+const MinWidthCell = ({ row }) => <code>{row.values.minWidth ? `${row.values.minWidth}px` : '-'}</code>;
+const MaxWidthCell = ({ row }) => <code>{row.values.maxWidth ? `${row.values.maxWidth}px` : '-'}</code>;
+
+const Responsive = () => {
+  const breakpointsData = Object.keys(breakpoints).map(breakpoint => {
+    const { minWidth, maxWidth } = breakpoints[breakpoint];
+    const breakpointData = getBreakpointDescription(breakpoint);
+    breakpointData.minWidth = minWidth;
+    breakpointData.maxWidth = maxWidth;
+    return breakpointData;
+  });
+
+  return (
+    <Layout>
+      <Container size="md" className="py-5">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
+        <SEO title="Responsive" />
+        <h1>Responsive</h1>
+        <h3>Available breakpoints</h3>
+        <p>
+          Define the minimum and maximum dimensions at which your layout will change,
+          adapting to different screen sizes, for use in media queries.
+        </p>
+        <DataTable
+          className="pgn-doc__spacing-table"
+          data={breakpointsData}
+          columns={[
+            { Header: 'Breakpoint', accessor: 'name' },
+            { Header: 'Class infix', accessor: 'identifier', Cell: IdentifierCell },
+            { Header: 'Min width', accessor: 'minWidth', Cell: MinWidthCell },
+            { Header: 'Max Width', accessor: 'maxWidth', Cell: MaxWidthCell },
+          ]}
+        >
+          <DataTable.Table />
+        </DataTable>
+        <h3 className="mt-3">Basic usage</h3>
+        <p>
+          To access or change the breakpoints in the scss use <code>$grid-breakpoints</code> variable.
+        </p>
+        <p>
+          Example when the screen is narrower than <code>md</code> breakpoint.
+        </p>
+        <CodeBlock className="language-scss">
+          {'@include media-breakpoint-down(map-get($grid-breakpoints, \'md\')) { // styles here }'}
+        </CodeBlock>
+        <p>
+          Example when the screen is wider than <code>lg</code> breakpoint.
+        </p>
+        <CodeBlock className="language-scss">
+          {'@include media-breakpoint-up(map-get($grid-breakpoints, \'lg\')) { // styles here }'}
+        </CodeBlock>
+      </Container>
+    </Layout>
+  );
+};
+
+const cellPropTypes = {
+  row: PropTypes.shape({
+    values: PropTypes.shape({
+      identifier: PropTypes.string,
+      minWidth: PropTypes.number,
+      maxWidth: PropTypes.number,
+    }),
+  }),
+};
+
+const cellDefaultProps = {
+  row: {},
+};
+
+IdentifierCell.propTypes = cellPropTypes;
+MinWidthCell.propTypes = cellPropTypes;
+MaxWidthCell.propTypes = cellPropTypes;
+
+IdentifierCell.defaultProps = cellDefaultProps;
+MinWidthCell.defaultProps = cellDefaultProps;
+MaxWidthCell.defaultProps = cellDefaultProps;
+
+export default Responsive;


### PR DESCRIPTION
## Description

Implement single source of truth for breakpoints used in Paragon, this is the improved version of [reverted PR](https://github.com/openedx/paragon/pull/1242) that fixes issues with MFE's

JIRA: [PAR-813](https://openedx.atlassian.net/browse/PAR-813)

### Deploy Preview

https://deploy-preview-1288--paragon-openedx.netlify.app/foundations/responsive

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
