### PR TITLE
fix: add `border: 0` to dropdown toggle

### DIFF
--- a/src/Dropdown/Dropdown.scss
+++ b/src/Dropdown/Dropdown.scss
@@ -2,6 +2,7 @@
 @import "~bootstrap/scss/dropdown";
 
 .dropdown-toggle::after {
+  border: 0;
   border-style: solid;
   border-width: .15rem .15rem 0 0;
   content: "";


### PR DESCRIPTION
## Description

Fixes dropdown toggle icon that is cut off: 

**Before**
<img width="256" alt="image" src="https://user-images.githubusercontent.com/2828721/169604740-01356edb-58d9-4091-8d4f-159f4553e980.png">

**After**
<img width="240" alt="image" src="https://user-images.githubusercontent.com/2828721/169605412-de9d202c-1ce9-4094-b1a6-60181770a09f.png">

### Deploy Preview
https://deploy-preview-1310--paragon-openedx.netlify.app/components/dropdown/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
