### PR TITLE
[BD-46] refactor: refactoring mobile page styles

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -248,3 +248,98 @@
     flex-direction: row;
   }
 }
+
+@media (max-width: map-get($grid-breakpoints, "sm")) {
+  .pgn__card {
+    width: 100% !important;
+  }
+
+  .pgn__card.horizontal {
+    flex-direction: column;
+  }
+
+  .pgn__card-wrapper-image-cap.horizontal {
+    max-width: none;
+
+    .pgn__card-image-cap {
+      max-width: 100%;
+      width: 100%;
+    }
+  }
+
+  .pgn__card-footer {
+    flex-direction: column;
+
+    &.horizontal > :not(:last-child) {
+      margin-inline-end: 0;
+    }
+
+    .pgn__card-footer-text {
+      margin-top: 10px;
+    }
+
+    .btn {
+      width: 100%;
+      margin: 10px 0 0;
+    }
+  }
+
+  .pgn__card-header {
+    padding: 0 1.5rem 1rem;
+
+    .pgn__card-header-content {
+      overflow: visible;
+    }
+  }
+
+  .pgn__action-row {
+    flex-direction: column;
+
+    .btn:not(:last-child) {
+      margin-bottom: 5px;
+    }
+
+    & > * + * {
+      margin-inline-start: 0;
+    }
+  }
+}
+
+@media (max-width: map-get($grid-breakpoints, "md")) {
+  .card-deck {
+    flex-flow: column wrap;
+
+    .card {
+      margin: 0 0 12px;
+    }
+  }
+
+  .pgn__card.horizontal {
+    flex-direction: column;
+  }
+
+  .pgn__card-wrapper-image-cap.horizontal {
+    max-width: none;
+
+    .pgn__card-image-cap {
+      max-width: 100%;
+      width: 100%;
+    }
+  }
+}
+
+@media (max-width: map-get($grid-breakpoints, "xl")) {
+  .pgn__card-wrapper.pgn__card-footer {
+    &.horizontal {
+      flex-direction: column;
+
+      & button {
+        margin: 0 0 5px;
+      }
+    }
+
+    &-text.horizontal {
+      margin-top: 1.5rem;
+    }
+  }
+}

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -229,12 +229,12 @@ Note that `Card.Footer` has a separate `orientation` prop which will override th
 
 ```jsx live
 <Card style={{width: '40%'}}>
-  <Card.Footer orientation="horizontal">
+  <Card.Footer className="pgn__card-wrapper" orientation="horizontal">
     <Button>Action 1</Button>
     <Button>Action 2</Button>
   </Card.Footer>
   <Card.Divider />
-  <Card.Footer orientation="horizontal" textElement="Optional footer text to display">
+  <Card.Footer className="pgn__card-wrapper" orientation="horizontal" textElement="Optional footer text to display">
     <Button>Action 1</Button>
     <Button>Action 2</Button>
   </Card.Footer>
@@ -409,6 +409,7 @@ behavior.
 <CardGrid
   columnSizes={{
     xs: 12,
+    sm: 6,
     lg: 6,
     xl: 4,
   }}


### PR DESCRIPTION
## Description

Refactoring mobile Card page styles

[JIRA](https://openedx.atlassian.net/browse/PAR-815)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
