### PR TITLE
[BD-46] docs: fix incorrect display of tables in the DataTable component

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -95,6 +95,10 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   display: flex;
   align-items: flex-start;
 
+  @media (max-width: $max-width-xs) {
+    overflow-x: scroll;
+  }
+
   .pgn__data-table-layout-sidebar {
     border-radius: $border-radius;
     box-shadow: $data-table-box-shadow;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -95,7 +95,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   display: flex;
   align-items: flex-start;
 
-  @media (max-width: $max-width-xs) {
+  @media (max-width: $max-width-xl) {
     overflow-x: scroll;
   }
 


### PR DESCRIPTION
## Description

 Fix incorrect display of tables in the DataTable component on the mobile version of the site.
[JIRA](https://openedx.atlassian.net/browse/PAR-815)

![image](https://user-images.githubusercontent.com/93188219/171611765-2850f29c-dd5e-4301-bf92-93ad2e557c46.png)

## Deploy preview
- [DataTable](https://deploy-preview-1332--paragon-openedx.netlify.app/components/datatable/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
