### PR TITLE
[BD-46] docs: fixing the number of columns in the All Components menu

### DIFF
--- a/www/src/components/Menu.scss
+++ b/www/src/components/Menu.scss
@@ -1,5 +1,9 @@
 .menu-component-list {
   columns: 3;
+
+  @media (max-width: $max-width-xs) {
+    columns: 2;
+  }
 }
 
 .menu-component-list-category {
@@ -11,5 +15,13 @@
 .menu-all-components {
   .menu-component-list {
     columns: 4;
+
+    @media (max-width: $max-width-sm) {
+      columns: 3;
+    }
+
+    @media (max-width: $max-width-xs) {
+      columns: 2;
+    }
   }
 }


### PR DESCRIPTION
## Description

Fixing the number of columns in the All Components menu in the footer of the site on the mobile version.
[JIRA](https://openedx.atlassian.net/browse/PAR-815)

![image](https://user-images.githubusercontent.com/93188219/171611550-67c88402-8828-44e8-b41c-0c6330d744d6.png)

## Deploy preview
- [Home page](https://deploy-preview-1333--paragon-openedx.netlify.app/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
