### PR TITLE
[BD-46] fix: fixed Sheet button gaps

### DIFF
--- a/src/Sheet/README.md
+++ b/src/Sheet/README.md
@@ -35,13 +35,13 @@ notes: |
           <Dropdown.Item eventKey={position}>{position}</Dropdown.Item>
         ))}
       </DropdownButton><br />
-      <Button onClick={() => setShow(true)}>
+      <Button onClick={() => setShow(true)} className="mb-2 mb-md-0">
         Show the Sheet
       </Button>{' '}
-      <Button onClick={() => setBlocking(!blocking)}>
+      <Button onClick={() => setBlocking(!blocking)} className="mb-2 mb-md-0">
         {blocking ? "Disable": "Enable"} blocking content
       </Button>{' '}
-      <Button onClick={() => setDark(!dark)}>
+      <Button onClick={() => setDark(!dark)} className="mb-2 mb-md-0">
         Set {dark ? "Light": "Dark"} mode
       </Button>
 


### PR DESCRIPTION
## Description

 Fixed Sheet button gaps on the mobile version of the site.
[JIRA](https://openedx.atlassian.net/browse/PAR-815)

![image](https://user-images.githubusercontent.com/93188219/171610698-42521b8d-1d52-4d0c-a4d7-2c2c45a9f044.png)

## Deploy preview
- [Sheet component](https://deploy-preview-1335--paragon-openedx.netlify.app/components/sheet/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
