### PR TITLE
[BD-46] fix: fixed Icon button component

### DIFF
--- a/src/IconButton/README.md
+++ b/src/IconButton/README.md
@@ -18,7 +18,7 @@ notes: ''
 () => {
   const variants = ["brand", "primary", "secondary", "success", "warning", "danger", "light", "dark", "black"];
   return (
-    <div className="d-flex">
+    <div className="d-flex flex-wrap">
       {variants.map((variant) => (
         <IconButton key={variant} src={Close} iconAs={Icon} alt="Close" onClick={() => {}} variant={variant} className="mr-2" />
       ))}
@@ -68,7 +68,7 @@ notes: ''
           alt="Close"
           onClick={() => {}}
           variant={variant}
-          className="mr-2"
+          className="mr-2 mb-2"
         />
       ))}
     </div>


### PR DESCRIPTION
## Description

Fixed icon button on the mobile version of the site.
[JIRA](https://openedx.atlassian.net/browse/PAR-815)

![image](https://user-images.githubusercontent.com/93188219/171610224-71a5a98e-4b6b-49e2-aafd-d81ab9f108be.png)

## Deploy preview
- [Icon button](https://deploy-preview-1336--paragon-openedx.netlify.app/components/iconbutton/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
