### PR TITLE
[BD-46] docs: documentation for useIndexOfLastVisibleChild

### DIFF
--- a/src/hooks/useIndexOfLastVisibleChild.mdx
+++ b/src/hooks/useIndexOfLastVisibleChild.mdx
@@ -1,0 +1,69 @@
+---
+title: 'useIndexOfLastVisibleChild'
+type: 'hook'
+categories:
+- Hooks
+- Layout
+status: 'New'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
+---
+
+## Sample Usage
+This hook will find the index of the last child of a containing element
+that fits within its bounding rectangle. This is done by summing the widths
+of the children until they exceed the width of the container.
+
+
+```jsx live
+() => {
+  const invisibleStyles = {
+    position: 'absolute',
+    left: 0,
+    pointerEvents: 'none',
+    visibility: 'hidden',
+  };
+  const containerElementRef = React.useRef(null);
+  const overflowElementRef = React.useRef(null);
+  const indexOfLastVisibleChild = useIndexOfLastVisibleChild(
+    containerElementRef.current,
+    overflowElementRef.current,
+  );
+  const elements = ['Element 1', 'Element 2', 'Element 3', 'Element 4', 'Element 5', 'Element 6', 'Element 7'];
+  
+  const children = useMemo(() => {
+    const indexOfOverflowStart = indexOfLastVisibleChild + 1;
+    const childrenList = elements.map((element, i) => (
+      <div className="px-4 pt-2" style={i >= indexOfOverflowStart ? invisibleStyles : {}}>{element}</div>
+    ));
+    const overflowChildren = childrenList.slice(indexOfOverflowStart)
+      .map(overflowChild => (
+          <Dropdown.Item
+            key={`${overflowChild}overflow`}
+          >
+            {overflowChild.props.children}
+          </Dropdown.Item>
+        ));
+    
+    childrenList.splice(indexOfOverflowStart, 0, (
+      <Dropdown ref={overflowElementRef} style={!overflowChildren.length ? invisibleStyles : {}}>
+        <Dropdown.Toggle
+          variant="link"
+        >
+          More...
+        </Dropdown.Toggle>
+        <Dropdown.Menu className="dropdown-menu-right">{overflowChildren}</Dropdown.Menu>
+      </Dropdown>
+    ));
+    
+    return childrenList;
+  }, [indexOfLastVisibleChild]);
+  return (
+    <div className="d-flex" ref={containerElementRef}>
+      {children}
+    </div>
+  )
+};
+
+```


### PR DESCRIPTION
## Description
the documentation site for useIndexOfLastVisibleChild and sample usage

https://github.com/openedx/paragon/issues/1304

### Deploy Preview

https://deploy-preview-1345--paragon-openedx.netlify.app/components/hooks/useindexoflastvisiblechild/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
