### PR TITLE
[BD-46] docs: add a11y note to `Popover` description

### DIFF
--- a/src/Popover/README.md
+++ b/src/Popover/README.md
@@ -14,7 +14,11 @@ notes: |
 
 ---
 
-Popovers are small overlays that present additional content and actions without cluttering the page.
+Popovers are small overlays that present additional content without cluttering the page.
+
+Note that from accessibility perspective `Popover` is treated as a tooltip (the element has `role="tooltip"`) which means that it
+shouldn't contain interactive elements (e.g, buttons, links, etc.), you can read more about tooltip specifications [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role).
+Try using <Link to="/components/modal/modal-popup/">ModalPopup</Link> instead if you want `Popover`'s behaviour with interactive elements.
 
 ### Basic Usage
 


### PR DESCRIPTION
## Description

Update `Popover`'s description with note about usage of interactive elements.

### Deploy Preview

https://deploy-preview-1346--paragon-openedx.netlify.app/components/popover/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
