### PR TITLE
docs: only render DocSearch when algolia keys are set

### DIFF
--- a/www/src/components/Header.jsx
+++ b/www/src/components/Header.jsx
@@ -97,7 +97,7 @@ const Navbar = ({
               size="sm"
             />
           </Nav.Item>
-          <Col as={Search} />
+          <Search />
         </Nav>
       </Col>
     </Row>

--- a/www/src/components/Seach.jsx
+++ b/www/src/components/Seach.jsx
@@ -3,12 +3,19 @@ import { DocSearch } from '@docsearch/react';
 
 import '@docsearch/css';
 
-const Search = () => (
-  <DocSearch
-    appId={process.env.ALGOLIA_APP_ID}
-    indexName={process.env.ALGOLIA_INDEX_NAME}
-    apiKey={process.env.ALGOLIA_API_KEY}
-  />
-);
+const Search = () => {
+  const algoliaEnvVars = [process.env.ALGOLIA_API_ID, process.env.ALGOLIA_API_KEY, process.env.ALGOLIA_INDEX_NAME];
+  if (algoliaEnvVars.some(envVar => !envVar)) {
+    // some required environment variables for Algolia not set, so don't render `DocSearch`.
+    return null;
+  }
+  return (
+    <DocSearch
+      appId={process.env.ALGOLIA_APP_ID}
+      indexName={process.env.ALGOLIA_INDEX_NAME}
+      apiKey={process.env.ALGOLIA_API_KEY}
+    />
+  );
+}
 
 export default Search;

--- a/www/src/components/Seach.jsx
+++ b/www/src/components/Seach.jsx
@@ -4,16 +4,16 @@ import { DocSearch } from '@docsearch/react';
 import '@docsearch/css';
 
 const Search = () => {
-  const algoliaEnvVars = [process.env.ALGOLIA_API_ID, process.env.ALGOLIA_API_KEY, process.env.ALGOLIA_INDEX_NAME];
+  const algoliaEnvVars = [process.env.GATSBY_ALGOLIA_API_ID, process.env.GATSBY_ALGOLIA_API_KEY, process.env.GATSBY_ALGOLIA_INDEX_NAME];
   if (algoliaEnvVars.some(envVar => !envVar)) {
     // some required environment variables for Algolia not set, so don't render `DocSearch`.
     return null;
   }
   return (
     <DocSearch
-      appId={process.env.ALGOLIA_APP_ID}
-      indexName={process.env.ALGOLIA_INDEX_NAME}
-      apiKey={process.env.ALGOLIA_API_KEY}
+      appId={process.env.GATSBY_ALGOLIA_APP_ID}
+      indexName={process.env.GATSBY_ALGOLIA_INDEX_NAME}
+      apiKey={process.env.GATSBY_ALGOLIA_API_KEY}
     />
   );
 }


### PR DESCRIPTION
## Description

We just recently merged a PR to add search to the Paragon documentation website, via Algolia `DocSearch`. However, there seems to be an issue with the environment variables configured in Netlify where they are not getting picked up (they are coming back as `undefined`).

To prevent a temporarily broken search from being on production, this PR will hide `DocSearch` until there are valid Algolia environment variables coming through.

This will also prevent search from appearing on the PR deploy previews, where the environment variables configured in Netlify are not applied.

Also included in this PR, though, is an attempt to fix the environment variables. Because the docs site is using Gatsby, we may actually need to prefix the environment variables with `GATSBY_` ([docs](https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/#client-side-javascript)) so they are accessible at runtime. By default, in Gatsby, environment variables are only available at build time, which is why the `SEGMENT_KEY` environment variable works as expected.

The previous environment variables, when defined in `.env.development` during local development, works because they are explicitly sourced via `dotenv` in gatsby-config.js?

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
