### PR TITLE
docs: fix process.env variable name for Algolia env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ www/public
 
 # jetbrains IDEs
 .idea/
+
+# Local Netlify folder
+.netlify

--- a/www/src/components/Seach.jsx
+++ b/www/src/components/Seach.jsx
@@ -4,7 +4,7 @@ import { DocSearch } from '@docsearch/react';
 import '@docsearch/css';
 
 const Search = () => {
-  const algoliaEnvVars = [process.env.GATSBY_ALGOLIA_API_ID, process.env.GATSBY_ALGOLIA_API_KEY, process.env.GATSBY_ALGOLIA_INDEX_NAME];
+  const algoliaEnvVars = [process.env.GATSBY_ALGOLIA_APP_ID, process.env.GATSBY_ALGOLIA_API_KEY, process.env.GATSBY_ALGOLIA_INDEX_NAME];
   if (algoliaEnvVars.some(envVar => !envVar)) {
     // some required environment variables for Algolia not set, so don't render `DocSearch`.
     return null;


### PR DESCRIPTION
## Description

It seems the prefix of `GATSBY_` was indeed the fix, but we weren't seeing the `DocSearch` appear because the conditional was using the wrong variable name...

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
