### PR TITLE
build: use shared browserslist config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
         "@babel/preset-env": "^7.16.8",
         "@babel/preset-react": "^7.16.7",
+        "@edx/browserslist-config": "1.1.0",
         "@edx/eslint-config": "^3.0.0",
         "@formatjs/cli": "^4.8.4",
         "@semantic-release/changelog": "^5.0.1",
@@ -1857,6 +1858,12 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.0.tgz",
+      "integrity": "sha512-2lxL2emt81vJZWa5ujil8yK2eBKVpbPMULI/ocqMuoJ6QVAKXcuonVGpzBHvKvliBzP14UDaF+yN5Ek/nUTByQ==",
+      "dev": true
     },
     "node_modules/@edx/eslint-config": {
       "version": "3.0.0",
@@ -25220,6 +25227,12 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
+    },
+    "@edx/browserslist-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.0.tgz",
+      "integrity": "sha512-2lxL2emt81vJZWa5ujil8yK2eBKVpbPMULI/ocqMuoJ6QVAKXcuonVGpzBHvKvliBzP14UDaF+yN5Ek/nUTByQ==",
+      "dev": true
     },
     "@edx/eslint-config": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
     "@babel/preset-env": "^7.16.8",
     "@babel/preset-react": "^7.16.7",
+    "@edx/browserslist-config": "1.1.0",
     "@edx/eslint-config": "^3.0.0",
     "@formatjs/cli": "^4.8.4",
     "@semantic-release/changelog": "^5.0.1",
@@ -146,8 +147,7 @@
     ]
   },
   "browserslist": [
-    "last 2 versions",
-    "not ie < 11"
+    "extends @edx/browserslist-config"
   ],
   "husky": {
     "hooks": {


### PR DESCRIPTION
Removes custom browserslist configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).
This change reduces the resultant asset bundle size.
Created this PR due to some issues in rebasing the [older PR](https://github.com/openedx/paragon/pull/868)