### PR TITLE
[BD-46] feat: refactoring mobile view Breadcrumbs component

### DIFF
--- a/src/Breadcrumb/Breadcrumb.scss
+++ b/src/Breadcrumb/Breadcrumb.scss
@@ -1,6 +1,16 @@
 @import "variables";
 @import "~bootstrap/scss/breadcrumb";
 
+.pgn-doc__code-block-preview {
+  .pgn__breadcrumb {
+    overflow-x: scroll;
+
+    .list-inline-item {
+      white-space: nowrap;
+    }
+  }
+}
+
 .pgn__breadcrumb {
   .list-inline-item {
     &.active {

--- a/src/Breadcrumb/Breadcrumb.scss
+++ b/src/Breadcrumb/Breadcrumb.scss
@@ -1,16 +1,6 @@
 @import "variables";
 @import "~bootstrap/scss/breadcrumb";
 
-.pgn-doc__code-block-preview {
-  .pgn__breadcrumb {
-    overflow-x: scroll;
-
-    .list-inline-item {
-      white-space: nowrap;
-    }
-  }
-}
-
 .pgn__breadcrumb {
   .list-inline-item {
     &.active {

--- a/src/Breadcrumb/README.md
+++ b/src/Breadcrumb/README.md
@@ -17,13 +17,20 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 ### Basic Usage
 
 ```jsx live
-<Breadcrumb ariaLabel="Breadcrumb basic"
-  links={[
-    { label: 'Link 1', url: '#link-1' },
-    { label: 'Link 2', url: '#link-2' },
-    { label: 'Link 3', url: '#link-3' },
-  ]}
-/>
+() => {
+  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+
+  return (
+    <Breadcrumb ariaLabel="Breadcrumb basic"
+      links={[
+        { label: 'Link 1', url: '#link-1' },
+        { label: 'Link 2', url: '#link-2' },
+        { label: 'Link 3', url: '#link-3' },
+      ]}
+      isMobile={isExtraSmall}
+    />
+  )
+}
 ```
 
 ### Basic Usage (Mobile View)
@@ -42,40 +49,61 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 ### Basic Usage (Inverse Pallete)
 
 ```jsx live
-<div className="bg-dark-700 p-4">
-  <Breadcrumb ariaLabel="Breadcrumb inverse pallete"
-    links={[
-      { label: 'Link 1', url: '/link-1' },
-      { label: 'Link 2', url: '/link-2' },
-      { label: 'Link 3', url: '/link-3' },
-    ]}
-    variant="dark"
-  />
-</div>
+() => {
+  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+
+  return (
+    <div className="bg-dark-700 p-4">
+      <Breadcrumb ariaLabel="Breadcrumb inverse pallete"
+        links={[
+          {label: 'Link 1', url: '/link-1'},
+          {label: 'Link 2', url: '/link-2'},
+          {label: 'Link 3', url: '/link-3'},
+        ]}
+        variant="dark"
+        isMobile={isExtraSmall}
+      />
+    </div>
+  )
+}
 ```
 
 ### With active label
 
 ```jsx live
-<Breadcrumb ariaLabel="Breadcrumb is active"
-  links={[
-    { label: 'Link 1', url: '#link-1' },
-    { label: 'Link 2', url: '#link-2' },
-    { label: 'Link 3', url: '#link-3' },
-  ]}
-  activeLabel="Link 4"
-/>
+() => {
+  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+
+  return (
+    <Breadcrumb ariaLabel="Breadcrumb is active"
+      links={[
+        { label: 'Link 1', url: '#link-1' },
+        { label: 'Link 2', url: '#link-2' },
+        { label: 'Link 3', url: '#link-3' },
+      ]}
+      activeLabel="Link 4"
+      isMobile={isExtraSmall}
+    />
+  )
+}
 ```
 
 ### With custom spacer
 
 ```jsx live
-<Breadcrumb ariaLabel="Breadcrumb custom spacer"
-  links={[
-    { label: 'Link 1', url: '#link-1' },
-    { label: 'Link 2', url: '#link-2' },
-    { label: 'Link 3', url: '#link-3' },
-  ]}
-  spacer={<span className="custom-spacer">/</span>}
-/>
+() => {
+  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+
+  return (
+    <Breadcrumb ariaLabel="Breadcrumb custom spacer"
+      links={[
+        { label: 'Link 1', url: '#link-1' },
+        { label: 'Link 2', url: '#link-2' },
+        { label: 'Link 3', url: '#link-3' },
+      ]}
+      spacer={<span className="custom-spacer">/</span>}
+      isMobile={isExtraSmall}
+    />
+  )
+}
 ```


### PR DESCRIPTION
## Description

Fixed display of the list of links in the Breadcrumb component on mobile devices.

![image](https://user-images.githubusercontent.com/93188219/172308403-d09abeab-33fc-45a1-9d2b-096e05aaa27e.png)

[JIRA](https://openedx.atlassian.net/browse/PAR-815)

### Deploy Preview

[Breadcrumbs component](https://deploy-preview-1358--paragon-openedx.netlify.app/components/breadcrumb/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
