### PR TITLE
[BD-46] docs: fixing the Header menu in RTL format

### DIFF
--- a/www/src/components/Header.jsx
+++ b/www/src/components/Header.jsx
@@ -26,7 +26,7 @@ const Navbar = ({
 }) => (
   <Container as="header" className="py-3 bg-dark text-white sticky-top">
     <Row className="align-items-center text-center text-sm-left">
-      <Col className="mb-2 mb-sm-0 col-4" sm={5}>
+      <Col className="pgn-doc__header-button--menu mb-2 mb-sm-0 col-4" sm={5}>
         <Button
           className="d-inline-flex align-items-center"
           variant="inverse-tertiary"
@@ -73,7 +73,7 @@ const Navbar = ({
           <Nav.Item>
             <Link
               style={{ textDecoration: 'none' }}
-              className="text-white"
+              className="text-white nav-link"
               to="/changelog"
             >
               Changelog

--- a/www/src/components/LinkedHeading.scss
+++ b/www/src/components/LinkedHeading.scss
@@ -12,3 +12,7 @@
     text-decoration: none;
   }
 }
+
+[dir="rtl"] .pgn-doc__header-button--menu {
+  text-align: right;
+}


### PR DESCRIPTION
## Description

Fixing the Header menu in RTL format

![image](https://user-images.githubusercontent.com/93188219/172320705-4657659b-c133-45f9-a454-daedd9446cea.png)
<img width="185" alt="image" src="https://user-images.githubusercontent.com/93188219/172320782-c924ae99-8ecd-4d21-a00c-75e6f8d8ad27.png">


### Deploy Preview

[Home page](https://deploy-preview-1359--paragon-openedx.netlify.app)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
