### PR TITLE
[BD-46] docs: added caret for ModalPopup component

### DIFF
--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -109,3 +109,43 @@
 .modal-footer {
   flex: 0 0 auto;
 }
+
+.pgn__modal-popup__tooltip {
+  margin: .5rem 0;
+  border: $border-width solid rgba(0 0 0 / 20%);
+}
+
+.pgn__modal-popup__arrow {
+  position: absolute;
+  left: 5.438rem;
+  width: 1rem;
+  height: .5rem;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    border-color: transparent;
+    border-style: solid;
+    border-width: .5rem .5rem 0;
+  }
+}
+
+.pgn__modal-popup__arrow::before {
+  border-top-color: rgba(0 0 0 / 20%);
+}
+
+[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow {
+  transform: rotate(180deg);
+  top: 0;
+}
+
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow {
+  bottom: 0;
+}
+
+.pgn__modal-popup__arrow::after,
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow::after {
+  bottom: $border-width;
+  border-top-color: $white;
+}

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -30,6 +30,7 @@ const ModalPopup = ({
             {isOpen && (
               <>
                 {children}
+                <div id="arrow" className="pgn__modal-popup__arrow" data-popper-arrow="" />
               </>
             )}
           </FocusOn>

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -29,7 +29,7 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         <Button ref={setTarget} variant="outline-primary" onClick={open}>Open modal popup</Button>
       </div>
       <ModalPopup positionRef={target} isOpen={isOpen} onClose={close}>
-        <div className="bg-white p-3 rounded shadow" style={{textAlign: 'start'}}>
+        <div className="pgn__modal-popup__tooltip bg-white p-3 rounded shadow" style={{textAlign: 'start'}}>
           <p>This could be a menu or tray.</p>
 
           <Button variant="primary" className="mie-2">Action</Button>


### PR DESCRIPTION
## Description

- Added caret for ModalPopup component.

### Deploy Preview

[ModalPopup component](https://deploy-preview-1361--paragon-openedx.netlify.app/components/modal/modal-popup/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
