### PR TITLE
[BD-46] feat: fixed SelectableBox responsiveness

### DIFF
--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -32,13 +32,15 @@ As ``Checkbox``
   };
   
   const isInvalid = () => checkedCheeses.includes('swiss');
-
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+  
   return (
     <SelectableBox.Set
       value={checkedCheeses}
       type={type}
       onChange={handleChange}
       name="cheeses"
+      columns={isExtraSmall ? 1 : 2}
     >
       <SelectableBox value="swiss" type={type} aria-label="checkbox">
         <div>
@@ -70,6 +72,7 @@ As ``Radio``
   const type = 'radio';
   const [value, setValue] = useState('green');
   const handleChange = e => setValue(e.target.value);
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <SelectableBox.Set
@@ -77,7 +80,7 @@ As ``Radio``
       value={value}
       onChange={handleChange}
       name="colors"
-      columns={3}
+      columns={isExtraSmall ? 1 : 3}
     >
       <SelectableBox value="red" type={type} aria-label="checkbox">
         <div>
@@ -109,6 +112,7 @@ As ``Checkbox`` with ``isIndeterminate``
   const allChecked = allCheeseOptions.every(value => checkedCheeses.includes(value));
   const someChecked = allCheeseOptions.some(value => checkedCheeses.includes(value));
   const isIndeterminate = someChecked && !allChecked;
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
 
   const handleChange = e => {
     e.target.checked ? add(e.target.value) : remove(e.target.value);
@@ -137,7 +141,7 @@ As ``Checkbox`` with ``isIndeterminate``
         type={type}
         onChange={handleChange}
         name="cheeses"
-        columns={3}
+        columns={isExtraSmall ? 1 : 3}
       >
         <SelectableBox value="swiss" type={type} aria-label="checkbox">
           <div>

--- a/src/SelectableBox/SelectableBoxSet.jsx
+++ b/src/SelectableBox/SelectableBoxSet.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useMediaQuery } from 'react-responsive';
 import { getInputType } from './utils';
-import { breakpoints } from '../index';
 
 const INPUT_TYPES = [
   'radio',
@@ -11,7 +9,6 @@ const INPUT_TYPES = [
 ];
 
 const DEFAULT_COLUMNS_NUMBER = 2;
-const DEFAULT_MOBILE_COLUMNS_NUMBER = 1;
 
 const SelectableBoxSet = React.forwardRef(({
   children,
@@ -21,11 +18,9 @@ const SelectableBoxSet = React.forwardRef(({
   onChange,
   type,
   columns,
-  mobileColumns,
   className,
 }, ref) => {
   const inputType = getInputType('SelectableBoxSet', type);
-  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return React.createElement(inputType, {
     name,
@@ -35,7 +30,7 @@ const SelectableBoxSet = React.forwardRef(({
     ref,
     className: classNames(
       'pgn__selectable_box-set',
-      `pgn__selectable_box-set--${isExtraSmall ? mobileColumns || DEFAULT_MOBILE_COLUMNS_NUMBER : columns || DEFAULT_COLUMNS_NUMBER}`,
+      `pgn__selectable_box-set--${columns || DEFAULT_COLUMNS_NUMBER}`,
       className,
     ),
   },
@@ -64,7 +59,6 @@ SelectableBoxSet.propTypes = {
   columns: PropTypes.number,
   /** A class that is be appended to the base element. */
   className: PropTypes.string,
-  mobileColumns: PropTypes.number,
 };
 
 SelectableBoxSet.defaultProps = {
@@ -74,7 +68,6 @@ SelectableBoxSet.defaultProps = {
   defaultValue: undefined,
   type: 'radio',
   columns: DEFAULT_COLUMNS_NUMBER,
-  mobileColumns: DEFAULT_MOBILE_COLUMNS_NUMBER,
   className: undefined,
 };
 

--- a/src/SelectableBox/SelectableBoxSet.jsx
+++ b/src/SelectableBox/SelectableBoxSet.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { useMediaQuery } from 'react-responsive';
 import { getInputType } from './utils';
+import { breakpoints } from '../index';
 
 const INPUT_TYPES = [
   'radio',
@@ -9,6 +11,7 @@ const INPUT_TYPES = [
 ];
 
 const DEFAULT_COLUMNS_NUMBER = 2;
+const DEFAULT_MOBILE_COLUMNS_NUMBER = 1;
 
 const SelectableBoxSet = React.forwardRef(({
   children,
@@ -18,9 +21,11 @@ const SelectableBoxSet = React.forwardRef(({
   onChange,
   type,
   columns,
+  mobileColumns,
   className,
 }, ref) => {
   const inputType = getInputType('SelectableBoxSet', type);
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return React.createElement(inputType, {
     name,
@@ -30,7 +35,7 @@ const SelectableBoxSet = React.forwardRef(({
     ref,
     className: classNames(
       'pgn__selectable_box-set',
-      `pgn__selectable_box-set--${columns || DEFAULT_COLUMNS_NUMBER}`,
+      `pgn__selectable_box-set--${isExtraSmall ? mobileColumns || DEFAULT_MOBILE_COLUMNS_NUMBER : columns || DEFAULT_COLUMNS_NUMBER}`,
       className,
     ),
   },
@@ -59,6 +64,7 @@ SelectableBoxSet.propTypes = {
   columns: PropTypes.number,
   /** A class that is be appended to the base element. */
   className: PropTypes.string,
+  mobileColumns: PropTypes.number,
 };
 
 SelectableBoxSet.defaultProps = {
@@ -68,6 +74,7 @@ SelectableBoxSet.defaultProps = {
   defaultValue: undefined,
   type: 'radio',
   columns: DEFAULT_COLUMNS_NUMBER,
+  mobileColumns: DEFAULT_MOBILE_COLUMNS_NUMBER,
   className: undefined,
 };
 


### PR DESCRIPTION
## Description

Fixed SelectableBox responsiveness.
[JIRA](https://openedx.atlassian.net/browse/PAR-815)

![image](https://user-images.githubusercontent.com/93188219/172570955-3a8156c0-6bc5-40f3-abef-f92c3ee7216f.png)


### Deploy Preview

[SelectableBox component](https://deploy-preview-1362--paragon-openedx.netlify.app/components/selectablebox/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
