### PR TITLE
feat: [BD-46] adding caret for ModalPopup component

### DIFF
--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -111,13 +111,12 @@
 }
 
 .pgn__modal-popup__tooltip {
-  margin: .5rem 0;
   border: $border-width solid rgba($black, 20%);
 }
 
 .pgn__modal-popup__arrow {
   position: absolute;
-  left: 5.438rem;
+  //left: 5.438rem;
   width: 1rem;
   height: .5rem;
 
@@ -135,17 +134,48 @@
   border-top-color: rgba($black, 20%);
 }
 
+[data-popper-placement^="bottom-start"] .pgn__modal-popup__tooltip {
+  margin: .5rem 0;
+}
+
+[data-popper-placement^="top-start"] .pgn__modal-popup__tooltip {
+  margin: .5rem 0;
+}
+
 [data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow {
   transform: rotate(180deg);
   top: 0;
+  left: 5.438rem;
 }
 
 [data-popper-placement^="top-start"] .pgn__modal-popup__arrow {
   bottom: 0;
+  left: 5.438rem;
 }
 
 .pgn__modal-popup__arrow::after,
 [data-popper-placement^="top-start"] .pgn__modal-popup__arrow::after {
   bottom: $border-width;
   border-top-color: $white;
+}
+
+[data-popper-placement^="right"] .pgn__modal-popup__arrow {
+  left: -3px;
+  top: 50%;
+  transform: rotate(90deg);
+  margin: 0 .5rem;
+}
+
+[data-popper-placement^="left"] .pgn__modal-popup__arrow {
+  right: -3px;
+  top: 50%;
+  transform: rotate(-90deg);
+}
+
+[data-popper-placement^="left"] .pgn__modal-popup__tooltip {
+  margin: 0 .5rem;
+}
+
+[data-popper-placement^="right"] .pgn__modal-popup__tooltip {
+  margin: 0 .5rem;
 }

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -109,3 +109,43 @@
 .modal-footer {
   flex: 0 0 auto;
 }
+
+.pgn__modal-popup__tooltip {
+  margin: .5rem 0;
+  border: $border-width solid rgba($black, 20%);
+}
+
+.pgn__modal-popup__arrow {
+  position: absolute;
+  left: 5.438rem;
+  width: 1rem;
+  height: .5rem;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    border-color: transparent;
+    border-style: solid;
+    border-width: .5rem .5rem 0;
+  }
+}
+
+.pgn__modal-popup__arrow::before {
+  border-top-color: rgba($black, 20%);
+}
+
+[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow {
+  transform: rotate(180deg);
+  top: 0;
+}
+
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow {
+  bottom: 0;
+}
+
+.pgn__modal-popup__arrow::after,
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow::after {
+  bottom: $border-width;
+  border-top-color: $white;
+}

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -153,8 +153,8 @@
   border-top-color: $white;
 }
 
-[data-popper-placement^="right"] .pgn__modal-popup__arrow,
-[data-popper-placement^="right-start"] .pgn__modal-popup__arrow {
+[data-popper-placement^="right-start"] .pgn__modal-popup__arrow,
+[data-popper-placement^="right"] .pgn__modal-popup__arrow {
   left: -1.25rem;
   top: 50%;
   transform: rotate(90deg);

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -133,26 +133,30 @@
   }
 }
 
+[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-bottom-start {
   transform: rotate(180deg);
   top: -.5rem;
   left: 33%;
 }
 
-.pgn__modal-popup__arrow-bottom,
-[data-popper-placement^="bottom"] .pgn__modal-popup__arrow {
+[data-popper-placement^="bottom"] .pgn__modal-popup__arrow-auto,
+.pgn__modal-popup__arrow-bottom {
   transform: rotate(180deg);
   top: -.5rem;
   left: 48%;
 }
 
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-top-start {
   bottom: -.5rem;
   left: 33%;
 }
 
-.pgn__modal-popup__arrow-top,
-[data-popper-placement^="top"] .pgn__modal-popup__arrow {
+[data-popper-placement^="top"] .pgn__modal-popup__arrow-auto,
+.pgn__modal-popup__arrow-top {
   bottom: -.5rem;
   left: 48%;
 }
@@ -164,50 +168,64 @@
   border-top-color: $white;
 }
 
+[data-popper-placement^="right"] .pgn__modal-popup__arrow-auto,
+[data-popper-placement^="right-start"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="right-start"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-right-start,
-.pgn__modal-popup__arrow-right,
-[data-popper-placement^="right"] .pgn__modal-popup__arrow {
+.pgn__modal-popup__arrow-right {
   left: -1.25rem;
   top: 50%;
   transform: rotate(90deg);
   margin: 0 .5rem;
 }
 
-.pgn__modal-popup__arrow-left,
-[data-popper-placement^="left"] .pgn__modal-popup__arrow {
+[data-popper-placement^="left"] .pgn__modal-popup__arrow,
+.pgn__modal-popup__arrow-left {
   right: -.75rem;
   top: 50%;
   transform: rotate(-90deg);
 }
 
+[data-popper-placement^="left-end"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="left-end"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-left-end {
   top: 77%;
-  right: -12px;
+  right: -.75rem;
   transform: rotate(-90deg);
 }
 
+[data-popper-placement^="right-end"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="right-end"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-right-end {
   top: 77%;
   transform: rotate(90deg);
-  left: -12px;
+  left: -.75rem;
 }
 
+[data-popper-placement^="left-start"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="left-start"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-left-start {
   top: 15%;
-  right: -12px;
+  right: -.75rem;
   transform: rotate(-90deg);
 }
 
+[data-popper-placement^="right-start"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="right-start"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-right-start {
   top: 15%;
 }
 
+[data-popper-placement^="top-end"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="top-end"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-top-end {
   left: 62%;
 }
 
+[data-popper-placement^="bottom-end"] .pgn__modal-popup__arrow-auto-start,
+[data-popper-placement^="bottom-end"] .pgn__modal-popup__arrow-auto-end,
 .pgn__modal-popup__arrow-bottom-end {
-  top: -8px;
+  top: -.5rem;
   left: 62%;
   transform: rotate(180deg);
 }

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -110,10 +110,6 @@
   flex: 0 0 auto;
 }
 
-.pgn__modal-popup__tooltip {
-  border: $border-width solid rgba($black, 20%);
-}
-
 .pgn__modal-popup__arrow {
   position: absolute;
   width: 1rem;

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -133,27 +133,39 @@
   }
 }
 
-[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow,
+.pgn__modal-popup__arrow-bottom-start {
+  transform: rotate(180deg);
+  top: -.5rem;
+  left: 33%;
+}
+
+.pgn__modal-popup__arrow-bottom,
 [data-popper-placement^="bottom"] .pgn__modal-popup__arrow {
   transform: rotate(180deg);
   top: -.5rem;
-  left: 5.438rem;
+  left: 48%;
 }
 
-[data-popper-placement^="top-start"] .pgn__modal-popup__arrow,
+.pgn__modal-popup__arrow-top-start {
+  bottom: -.5rem;
+  left: 33%;
+}
+
+.pgn__modal-popup__arrow-top,
 [data-popper-placement^="top"] .pgn__modal-popup__arrow {
   bottom: -.5rem;
-  left: 5.438rem;
+  left: 48%;
 }
 
 .pgn__modal-popup__arrow::after,
-[data-popper-placement^="top-start"] .pgn__modal-popup__arrow::after,
-[data-popper-placement^="top"] .pgn__modal-popup__arrow::after {
+.pgn__modal-popup__arrow-top-start::after,
+.pgn__modal-popup__arrow-top::after {
   bottom: $border-width;
   border-top-color: $white;
 }
 
-[data-popper-placement^="right-start"] .pgn__modal-popup__arrow,
+.pgn__modal-popup__arrow-right-start,
+.pgn__modal-popup__arrow-right,
 [data-popper-placement^="right"] .pgn__modal-popup__arrow {
   left: -1.25rem;
   top: 50%;
@@ -161,9 +173,41 @@
   margin: 0 .5rem;
 }
 
-[data-popper-placement^="left"] .pgn__modal-popup__arrow,
-[data-popper-placement^="left-start"] .pgn__modal-popup__arrow {
+.pgn__modal-popup__arrow-left,
+[data-popper-placement^="left"] .pgn__modal-popup__arrow {
   right: -.75rem;
   top: 50%;
   transform: rotate(-90deg);
+}
+
+.pgn__modal-popup__arrow-left-end {
+  top: 77%;
+  right: -12px;
+  transform: rotate(-90deg);
+}
+
+.pgn__modal-popup__arrow-right-end {
+  top: 77%;
+  transform: rotate(90deg);
+  left: -12px;
+}
+
+.pgn__modal-popup__arrow-left-start {
+  top: 15%;
+  right: -12px;
+  transform: rotate(-90deg);
+}
+
+.pgn__modal-popup__arrow-right-start {
+  top: 15%;
+}
+
+.pgn__modal-popup__arrow-top-end {
+  left: 62%;
+}
+
+.pgn__modal-popup__arrow-bottom-end {
+  top: -8px;
+  left: 62%;
+  transform: rotate(180deg);
 }

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -116,7 +116,6 @@
 
 .pgn__modal-popup__arrow {
   position: absolute;
-  //left: 5.438rem;
   width: 1rem;
   height: .5rem;
 
@@ -128,54 +127,43 @@
     border-style: solid;
     border-width: .5rem .5rem 0;
   }
+
+  &::before {
+    border-top-color: rgba($black, 20%);
+  }
 }
 
-.pgn__modal-popup__arrow::before {
-  border-top-color: rgba($black, 20%);
-}
-
-[data-popper-placement^="bottom-start"] .pgn__modal-popup__tooltip {
-  margin: .5rem 0;
-}
-
-[data-popper-placement^="top-start"] .pgn__modal-popup__tooltip {
-  margin: .5rem 0;
-}
-
-[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow {
+[data-popper-placement^="bottom-start"] .pgn__modal-popup__arrow,
+[data-popper-placement^="bottom"] .pgn__modal-popup__arrow {
   transform: rotate(180deg);
-  top: 0;
+  top: -.5rem;
   left: 5.438rem;
 }
 
-[data-popper-placement^="top-start"] .pgn__modal-popup__arrow {
-  bottom: 0;
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow,
+[data-popper-placement^="top"] .pgn__modal-popup__arrow {
+  bottom: -.5rem;
   left: 5.438rem;
 }
 
 .pgn__modal-popup__arrow::after,
-[data-popper-placement^="top-start"] .pgn__modal-popup__arrow::after {
+[data-popper-placement^="top-start"] .pgn__modal-popup__arrow::after,
+[data-popper-placement^="top"] .pgn__modal-popup__arrow::after {
   bottom: $border-width;
   border-top-color: $white;
 }
 
-[data-popper-placement^="right"] .pgn__modal-popup__arrow {
-  left: -3px;
+[data-popper-placement^="right"] .pgn__modal-popup__arrow,
+[data-popper-placement^="right-start"] .pgn__modal-popup__arrow {
+  left: -1.25rem;
   top: 50%;
   transform: rotate(90deg);
   margin: 0 .5rem;
 }
 
-[data-popper-placement^="left"] .pgn__modal-popup__arrow {
-  right: -3px;
+[data-popper-placement^="left"] .pgn__modal-popup__arrow,
+[data-popper-placement^="left-start"] .pgn__modal-popup__arrow {
+  right: -.75rem;
   top: 50%;
   transform: rotate(-90deg);
-}
-
-[data-popper-placement^="left"] .pgn__modal-popup__tooltip {
-  margin: 0 .5rem;
-}
-
-[data-popper-placement^="right"] .pgn__modal-popup__tooltip {
-  margin: 0 .5rem;
 }

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -179,7 +179,7 @@
   margin: 0 .5rem;
 }
 
-[data-popper-placement^="left"] .pgn__modal-popup__arrow,
+[data-popper-placement^="left"],
 .pgn__modal-popup__arrow-left {
   right: -.75rem;
   top: 50%;

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -52,13 +52,13 @@ const ModalPopup = ({
             {isOpen && (
               <div className="pgn__modal-popup__tooltip">
                 {children}
-                {hasArrow ? (
+                {hasArrow && (
                   <div
                     id="arrow"
                     className={`pgn__modal-popup__arrow pgn__modal-popup__arrow-${placement}`}
                     data-popper-arrow=""
                   />
-                ) : null}
+                )}
               </div>
             )}
           </FocusOn>
@@ -87,7 +87,7 @@ ModalPopup.propTypes = {
   ]),
   /** Specifies position according to the element that the ``positionRef`` prop points to */
   placement: PopperElement.propTypes.placement,
-  /** Caret to the modal window pointing to the button */
+  /** Caret to the modal popup pointing to the target */
   hasArrow: PropTypes.bool,
 };
 

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -13,10 +13,11 @@ const ModalPopup = ({
   isBlocking,
   withPortal,
   placement,
+  hasArrow,
   ...popperProps
 }) => {
   const RootComponent = withPortal ? Portal : React.Fragment;
-
+  // debugger;
   return (
     <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>
       <RootComponent>
@@ -28,10 +29,12 @@ const ModalPopup = ({
             onClickOutside={onClose}
           >
             {isOpen && (
-              <div id="too">
+              <>
                 {children}
-                <div id="arrow" className="pgn__modal-popup__arrow" data-popper-arrow="" />
-              </div>
+                {hasArrow ? (
+                  <div id="arrow" className="pgn__modal-popup__arrow" data-popper-arrow="" />
+                ) : null}
+              </>
             )}
           </FocusOn>
         </PopperElement>
@@ -59,6 +62,7 @@ ModalPopup.propTypes = {
   ]),
   /** Specifies position according to the element that the ``positionRef`` prop points to */
   placement: PopperElement.propTypes.placement,
+  hasArrow: PropTypes.bool,
 };
 
 ModalPopup.defaultProps = {
@@ -66,6 +70,7 @@ ModalPopup.defaultProps = {
   withPortal: false,
   placement: 'bottom-start',
   positionRef: null,
+  hasArrow: false,
 };
 
 export default ModalPopup;

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -17,11 +17,38 @@ const ModalPopup = ({
   ...popperProps
 }) => {
   const RootComponent = withPortal ? Portal : React.Fragment;
-  // debugger;
+
+  const popperParams = [
+    {
+      name: 'eventListeners',
+      options: { scroll: false },
+    },
+    {
+      name: 'offset',
+      options: {
+        offset: () => {
+          switch (placement) {
+            case 'right':
+              return [-2, 10];
+            case 'left':
+              return [-2, 10];
+            default:
+              return [0, 10];
+          }
+        },
+      },
+    },
+  ];
+
   return (
     <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>
       <RootComponent>
-        <PopperElement target={positionRef} placement={placement} {...popperProps}>
+        <PopperElement
+          modifiers={hasArrow ? popperParams : null}
+          target={positionRef}
+          placement={placement}
+          {...popperProps}
+        >
           <FocusOn
             scrollLock={false}
             enabled={isOpen}
@@ -32,7 +59,11 @@ const ModalPopup = ({
               <>
                 {children}
                 {hasArrow ? (
-                  <div id="arrow" className="pgn__modal-popup__arrow" data-popper-arrow="" />
+                  <div
+                    id="arrow"
+                    className="pgn__modal-popup__arrow"
+                    data-popper-arrow=""
+                  />
                 ) : null}
               </>
             )}
@@ -62,6 +93,7 @@ ModalPopup.propTypes = {
   ]),
   /** Specifies position according to the element that the ``positionRef`` prop points to */
   placement: PopperElement.propTypes.placement,
+  /** Caret to the modal window pointing to the button */
   hasArrow: PropTypes.bool,
 };
 

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -56,7 +56,7 @@ const ModalPopup = ({
             onClickOutside={onClose}
           >
             {isOpen && (
-              <>
+              <div className="pgn__modal-popup__tooltip">
                 {children}
                 {hasArrow ? (
                   <div
@@ -65,7 +65,7 @@ const ModalPopup = ({
                     data-popper-arrow=""
                   />
                 ) : null}
-              </>
+              </div>
             )}
           </FocusOn>
         </PopperElement>

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -28,9 +28,10 @@ const ModalPopup = ({
             onClickOutside={onClose}
           >
             {isOpen && (
-              <>
+              <div id="too">
                 {children}
-              </>
+                <div id="arrow" className="pgn__modal-popup__arrow" data-popper-arrow="" />
+              </div>
             )}
           </FocusOn>
         </PopperElement>

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -5,6 +5,8 @@ import Portal from './Portal';
 import PopperElement from './PopperElement';
 import { ModalContextProvider } from './ModalContext';
 
+const PLACEMENT_OFFSET = { right: [-2, 10], left: [-2, 10] };
+
 const ModalPopup = ({
   children,
   onClose,
@@ -26,16 +28,7 @@ const ModalPopup = ({
     {
       name: 'offset',
       options: {
-        offset: () => {
-          switch (placement) {
-            case 'right':
-              return [-2, 10];
-            case 'left':
-              return [-2, 10];
-            default:
-              return [0, 10];
-          }
-        },
+        offset: () => PLACEMENT_OFFSET[placement] || [0, 10],
       },
     },
   ];

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -5,7 +5,7 @@ import Portal from './Portal';
 import PopperElement from './PopperElement';
 import { ModalContextProvider } from './ModalContext';
 
-const PLACEMENT_OFFSET = { right: [-2, 10], left: [-2, 10] };
+const PLACEMENT_OFFSETS = { right: [-2, 10], left: [-2, 10] };
 
 const ModalPopup = ({
   children,
@@ -19,6 +19,7 @@ const ModalPopup = ({
   ...popperProps
 }) => {
   const RootComponent = withPortal ? Portal : React.Fragment;
+  const placementOffsetValue = PLACEMENT_OFFSETS[placement] || [0, 10];
 
   const popperParams = [
     {
@@ -28,7 +29,7 @@ const ModalPopup = ({
     {
       name: 'offset',
       options: {
-        offset: () => PLACEMENT_OFFSET[placement] || [0, 10],
+        offset: () => placementOffsetValue,
       },
     },
   ];

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -61,7 +61,7 @@ const ModalPopup = ({
                 {hasArrow ? (
                   <div
                     id="arrow"
-                    className="pgn__modal-popup__arrow"
+                    className={`pgn__modal-popup__arrow pgn__modal-popup__arrow-${placement}`}
                     data-popper-arrow=""
                   />
                 ) : null}

--- a/src/Modal/ModalPopup.test.jsx
+++ b/src/Modal/ModalPopup.test.jsx
@@ -37,7 +37,11 @@ describe('<ModalPopup />', () => {
     const isOpen = true;
     const closeFn = jest.fn();
     const wrapper = shallow((
-      <ModalPopup positionRef={mockPositionRef} isOpen={isOpen} onClose={closeFn}>
+      <ModalPopup
+        positionRef={mockPositionRef}
+        isOpen={isOpen}
+        onClose={closeFn}
+      >
         <Dialog />
       </ModalPopup>
     ));
@@ -89,5 +93,54 @@ describe('<ModalPopup />', () => {
       ));
       expect(wrapper.find(Portal).length).toBe(1);
     });
+  });
+  it('myTest', () => {
+    const isOpen = true;
+    const closeFn = jest.fn();
+    const wrapperPopup = shallow((
+      <ModalPopup isOpen={isOpen} onClose={closeFn}>
+        <Dialog />
+      </ModalPopup>));
+    expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(false);
+  });
+
+  it('myTest 2', () => {
+    const isOpen = true;
+    const closeFn = jest.fn();
+    const wrapperPopup = shallow((
+      <ModalPopup hasArrow isOpen={isOpen} onClose={closeFn}>
+        <Dialog />
+      </ModalPopup>));
+    expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(true);
+  });
+
+  it('myTest 3', () => {
+    const isOpen = true;
+    const closeFn = jest.fn();
+    const wrapperPopup = shallow((
+      <ModalPopup hasArrow placement="right" isOpen={isOpen} onClose={closeFn}>
+        <Dialog />
+      </ModalPopup>));
+    expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right')).toBe(true);
+  });
+
+  it('myTest 4', () => {
+    const isOpen = true;
+    const closeFn = jest.fn();
+    const wrapperPopup = shallow((
+      <ModalPopup hasArrow placement="left" isOpen={isOpen} onClose={closeFn}>
+        <Dialog />
+      </ModalPopup>));
+    expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left')).toBe(true);
+  });
+
+  it('myTest 4', () => {
+    const isOpen = true;
+    const closeFn = jest.fn();
+    const wrapperPopup = shallow((
+      <ModalPopup hasArrow placement="left-start" isOpen={isOpen} onClose={closeFn}>
+        <Dialog />
+      </ModalPopup>));
+    expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left-start')).toBe(true);
   });
 });

--- a/src/Modal/ModalPopup.test.jsx
+++ b/src/Modal/ModalPopup.test.jsx
@@ -94,53 +94,129 @@ describe('<ModalPopup />', () => {
       expect(wrapper.find(Portal).length).toBe(1);
     });
   });
-  it('myTest', () => {
-    const isOpen = true;
-    const closeFn = jest.fn();
-    const wrapperPopup = shallow((
-      <ModalPopup isOpen={isOpen} onClose={closeFn}>
-        <Dialog />
-      </ModalPopup>));
-    expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(false);
-  });
-
-  it('myTest 2', () => {
-    const isOpen = true;
-    const closeFn = jest.fn();
-    const wrapperPopup = shallow((
-      <ModalPopup hasArrow isOpen={isOpen} onClose={closeFn}>
-        <Dialog />
-      </ModalPopup>));
-    expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(true);
-  });
-
-  it('myTest 3', () => {
-    const isOpen = true;
-    const closeFn = jest.fn();
-    const wrapperPopup = shallow((
-      <ModalPopup hasArrow placement="right" isOpen={isOpen} onClose={closeFn}>
-        <Dialog />
-      </ModalPopup>));
-    expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right')).toBe(true);
-  });
-
-  it('myTest 4', () => {
-    const isOpen = true;
-    const closeFn = jest.fn();
-    const wrapperPopup = shallow((
-      <ModalPopup hasArrow placement="left" isOpen={isOpen} onClose={closeFn}>
-        <Dialog />
-      </ModalPopup>));
-    expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left')).toBe(true);
-  });
-
-  it('myTest 4', () => {
-    const isOpen = true;
-    const closeFn = jest.fn();
-    const wrapperPopup = shallow((
-      <ModalPopup hasArrow placement="left-start" isOpen={isOpen} onClose={closeFn}>
-        <Dialog />
-      </ModalPopup>));
-    expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left-start')).toBe(true);
+  describe('withArrow', () => {
+    it('renders without arrow', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(false);
+    });
+    it('renders with arrow', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(true);
+    });
+    it('renders with placement auto', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="auto" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-auto')).toBe(true);
+    });
+    it('renders with placement auto-start', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="auto-start" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-auto-start')).toBe(true);
+    });
+    it('renders with placement auto-end', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="auto-end" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-auto-end')).toBe(true);
+    });
+    it('renders with placement right', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="right" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right')).toBe(true);
+    });
+    it('renders with placement right-start', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="right-start" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right-start')).toBe(true);
+    });
+    it('renders with placement right-end', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="right-end" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right-end')).toBe(true);
+    });
+    it('renders with placement left', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="left" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left')).toBe(true);
+    });
+    it('renders with placement left-start', () => {
+      const isOpen = true;
+      const closeFn = jest.fn();
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="left-start" isOpen={isOpen} onClose={closeFn}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left-start')).toBe(true);
+    });
+    it('renders with placement left-end', () => {
+      const isOpen = true;
+      const closeFn = jest.fn();
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="left-end" isOpen={isOpen} onClose={closeFn}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left-end')).toBe(true);
+    });
+    it('renders with placement top', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="top" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-top')).toBe(true);
+    });
+    it('renders with placement top-start', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="top-start" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-top-start')).toBe(true);
+    });
+    it('renders with placement top-end', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="top-end" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-top-end')).toBe(true);
+    });
+    it('renders with placement bottom', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="bottom" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-bottom')).toBe(true);
+    });
+    it('renders with placement bottom-start', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="bottom-start" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-bottom-start')).toBe(true);
+    });
+    it('renders with placement bottom-end', () => {
+      const wrapperPopup = shallow((
+        <ModalPopup hasArrow placement="bottom-end" isOpen onClose={jest.fn()}>
+          <Dialog />
+        </ModalPopup>));
+      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-bottom-end')).toBe(true);
+    });
   });
 });

--- a/src/Modal/ModalPopup.test.jsx
+++ b/src/Modal/ModalPopup.test.jsx
@@ -32,6 +32,24 @@ const Dialog = () => (
 
 const mockPositionRef = { current: null };
 
+const arrowPlacements = [
+  'auto',
+  'auto-start',
+  'auto-end',
+  'top',
+  'top-start',
+  'top-end',
+  'bottom',
+  'bottom-start',
+  'bottom-end',
+  'right',
+  'right-start',
+  'right-end',
+  'left',
+  'left-start',
+  'left-end',
+];
+
 describe('<ModalPopup />', () => {
   describe('when isOpen', () => {
     const isOpen = true;
@@ -95,128 +113,29 @@ describe('<ModalPopup />', () => {
     });
   });
   describe('withArrow', () => {
+    const popupArrowModalClass = '.pgn__modal-popup__arrow';
+    arrowPlacements.forEach((side) => {
+      it(`renders with placement ${side}`, () => {
+        const wrapperPopup = shallow((
+          <ModalPopup hasArrow placement={side} isOpen onClose={jest.fn()}>
+            <Dialog />
+          </ModalPopup>));
+        expect(wrapperPopup.exists(`${popupArrowModalClass}-${side}`)).toBe(true);
+      });
+    });
     it('renders without arrow', () => {
       const wrapperPopup = shallow((
         <ModalPopup isOpen onClose={jest.fn()}>
           <Dialog />
         </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(false);
+      expect(wrapperPopup.exists(popupArrowModalClass)).toBe(false);
     });
     it('renders with arrow', () => {
       const wrapperPopup = shallow((
         <ModalPopup hasArrow isOpen onClose={jest.fn()}>
           <Dialog />
         </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow')).toBe(true);
-    });
-    it('renders with placement auto', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="auto" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-auto')).toBe(true);
-    });
-    it('renders with placement auto-start', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="auto-start" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-auto-start')).toBe(true);
-    });
-    it('renders with placement auto-end', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="auto-end" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-auto-end')).toBe(true);
-    });
-    it('renders with placement right', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="right" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right')).toBe(true);
-    });
-    it('renders with placement right-start', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="right-start" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right-start')).toBe(true);
-    });
-    it('renders with placement right-end', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="right-end" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-right-end')).toBe(true);
-    });
-    it('renders with placement left', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="left" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left')).toBe(true);
-    });
-    it('renders with placement left-start', () => {
-      const isOpen = true;
-      const closeFn = jest.fn();
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="left-start" isOpen={isOpen} onClose={closeFn}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left-start')).toBe(true);
-    });
-    it('renders with placement left-end', () => {
-      const isOpen = true;
-      const closeFn = jest.fn();
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="left-end" isOpen={isOpen} onClose={closeFn}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-left-end')).toBe(true);
-    });
-    it('renders with placement top', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="top" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-top')).toBe(true);
-    });
-    it('renders with placement top-start', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="top-start" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-top-start')).toBe(true);
-    });
-    it('renders with placement top-end', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="top-end" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-top-end')).toBe(true);
-    });
-    it('renders with placement bottom', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="bottom" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-bottom')).toBe(true);
-    });
-    it('renders with placement bottom-start', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="bottom-start" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-bottom-start')).toBe(true);
-    });
-    it('renders with placement bottom-end', () => {
-      const wrapperPopup = shallow((
-        <ModalPopup hasArrow placement="bottom-end" isOpen onClose={jest.fn()}>
-          <Dialog />
-        </ModalPopup>));
-      expect(wrapperPopup.exists('.pgn__modal-popup__arrow-bottom-end')).toBe(true);
+      expect(wrapperPopup.exists(popupArrowModalClass)).toBe(true);
     });
   });
 });

--- a/src/Modal/PopperElement.jsx
+++ b/src/Modal/PopperElement.jsx
@@ -11,7 +11,6 @@ const PopperElement = ({
     styles,
     attributes,
   } = usePopper(target, popperElement, popperOptions);
-  console.log(styles)
 
   if (!target) {
     return null;

--- a/src/Modal/PopperElement.jsx
+++ b/src/Modal/PopperElement.jsx
@@ -11,6 +11,7 @@ const PopperElement = ({
     styles,
     attributes,
   } = usePopper(target, popperElement, popperOptions);
+  console.log(styles)
 
   if (!target) {
     return null;

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -35,11 +35,13 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         </Button>
       </div>
       <ModalPopup
+        hasArrow
+        placement="auto-end"
         positionRef={target}
         isOpen={isOpen}
         onClose={close}>
         <div
-          className="pgn__modal-popup__tooltip bg-white p-3 rounded shadow"
+          className="bg-white p-3 rounded shadow"
           style={{textAlign: 'start'}}>
           <p>This could be a menu or tray.</p>
 

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -35,8 +35,6 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         </Button>
       </div>
       <ModalPopup
-        hasArrow
-        placement="auto-end"
         positionRef={target}
         isOpen={isOpen}
         onClose={close}>

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -29,8 +29,7 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         <Button
           ref={setTarget}
           variant="outline-primary"
-          onClick={open}
-        >
+          onClick={open}>
           Open modal popup
         </Button>
       </div>
@@ -40,6 +39,44 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         onClose={close}>
         <div
           className="bg-white p-3 rounded shadow"
+          style={{textAlign: 'start'}}>
+          <p>This could be a menu or tray.</p>
+
+          <Button variant="primary" className="mie-2">Action</Button>
+          <ModalCloseButton variant="outline-primary">Close</ModalCloseButton>
+        </div>
+      </ModalPopup>
+    </>
+  )
+}
+```
+### With arrow
+
+The arrow modifier positions an inner element of the modal popup so it appears centered relative to the reference.
+
+```jsx live
+() => {
+  const [isOpen, open, close] = useToggle(false);
+  const [target, setTarget] = React.useState(null);
+
+  return (
+    <>
+      <div className="d-flex">
+        <Button
+          ref={setTarget}
+          variant="outline-primary"
+          onClick={open}>
+          Open modal popup
+        </Button>
+      </div>
+      <ModalPopup
+        hasArrow
+        placement="right"
+        positionRef={target}
+        isOpen={isOpen}
+        onClose={close}>
+        <div
+          className="bg-white p-3 rounded shadow border"
           style={{textAlign: 'start'}}>
           <p>This could be a menu or tray.</p>
 

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -35,8 +35,6 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         </Button>
       </div>
       <ModalPopup
-        hasArrow
-        placement="left-start"
         positionRef={target}
         isOpen={isOpen}
         onClose={close}>

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -29,7 +29,7 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
         <Button ref={setTarget} variant="outline-primary" onClick={open}>Open modal popup</Button>
       </div>
       <ModalPopup positionRef={target} isOpen={isOpen} onClose={close}>
-        <div className="bg-white p-3 rounded shadow" style={{textAlign: 'start'}}>
+        <div className="pgn__modal-popup__tooltip bg-white p-3 rounded shadow" style={{textAlign: 'start'}}>
           <p>This could be a menu or tray.</p>
 
           <Button variant="primary" className="mie-2">Action</Button>

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -26,10 +26,23 @@ A proper way to implement this is to use [callback refs](https://reactjs.org/doc
   return (
     <>
       <div className="d-flex">
-        <Button ref={setTarget} variant="outline-primary" onClick={open}>Open modal popup</Button>
+        <Button
+          ref={setTarget}
+          variant="outline-primary"
+          onClick={open}
+        >
+          Open modal popup
+        </Button>
       </div>
-      <ModalPopup positionRef={target} isOpen={isOpen} onClose={close}>
-        <div className="pgn__modal-popup__tooltip bg-white p-3 rounded shadow" style={{textAlign: 'start'}}>
+      <ModalPopup
+        hasArrow
+        placement="left-start"
+        positionRef={target}
+        isOpen={isOpen}
+        onClose={close}>
+        <div
+          className="pgn__modal-popup__tooltip bg-white p-3 rounded shadow"
+          style={{textAlign: 'start'}}>
           <p>This could be a menu or tray.</p>
 
           <Button variant="primary" className="mie-2">Action</Button>


### PR DESCRIPTION
## Description

Added caret for ModalPopup component.

### Deploy Preview

[Modal popup component](https://deploy-preview-1363--paragon-openedx.netlify.app/components/modal/modal-popup/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
