### PR TITLE
[BD-46] feat: added a new box-shadow for the Card component

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -234,8 +234,9 @@
 
   &.clickable {
     &:hover {
-      box-shadow: $level-1-box-shadow;
       cursor: pointer;
+
+      @include pgn-box-shadow(2, "down");
     }
 
     &:focus,

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -230,6 +230,8 @@
 }
 
 .pgn__card {
+  @include pgn-box-shadow(1, "down");
+
   &.clickable {
     &:hover {
       box-shadow: $level-1-box-shadow;


### PR DESCRIPTION
## Description

Added a new box-shadow for the Card component.
[Figma](https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=3460%3A286)

### Deploy Preview

[Card component](https://deploy-preview-1364--paragon-openedx.netlify.app/components/card/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
