### PR TITLE
[BD-46] docs: deprecate CardDeck

### DIFF
--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -528,10 +528,12 @@ behavior.
 </CardGrid>
 ```
 
-## CardDeck
+## CardDeck (Deprecated)
 
 This component gives any child Card components equal height with an appropriate gutter between cards. However,
 it is meant to be used as a single horizontal row of Cards, not as a grid. See CardGrid for more details.
+
+**Note**: this component is deprecated and is going to be removed soon.
 
 ```jsx live
 <CardDeck>


### PR DESCRIPTION
## Description

CardDeck component is deprecated 
Github issue: https://github.com/openedx/paragon/issues/1375

### Deploy Preview
https://deploy-preview-1377--paragon-openedx.netlify.app/components/card/#carddeckdeprecated

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
