### PR TITLE
fix: remove prop type warning and use only CSS for threshold dot

### DIFF
--- a/src/Popover/Popover.test.jsx
+++ b/src/Popover/Popover.test.jsx
@@ -6,17 +6,17 @@ import Popover from './index';
 describe('<Popover />', () => {
   describe('correct rendering', () => {
     it('renders with correct class for variant success', () => {
-      const wrapper = mount(<Popover variant="success" />);
+      const wrapper = mount(<Popover id="popover-id" variant="success" />);
       const popover = wrapper.find('.popover');
       expect(popover.hasClass('popover-success')).toEqual(true);
     });
     it('renders with correct class for variant warning', () => {
-      const wrapper = mount(<Popover variant="warning" />);
+      const wrapper = mount(<Popover id="popover-id" variant="warning" />);
       const popover = wrapper.find('.popover');
       expect(popover.hasClass('popover-warning')).toEqual(true);
     });
     it('renders with correct class for variant danger', () => {
-      const wrapper = mount(<Popover variant="danger" />);
+      const wrapper = mount(<Popover id="popover-id" variant="danger" />);
       const popover = wrapper.find('.popover');
       expect(popover.hasClass('popover-danger')).toEqual(true);
     });

--- a/src/ProgressBar/ProgressBar.scss
+++ b/src/ProgressBar/ProgressBar.scss
@@ -47,17 +47,6 @@
       .pgn__progress-bar--#{$name} {
         background-color: $color;
       }
-
-      .pgn__progress-threshold-dot--#{$name} {
-        background: $color;
-        position: absolute;
-        margin-top: -(calc($progress-threshold-circle / 2) - calc($annotated-progress-height / 2));
-        margin-left: -(calc($progress-threshold-circle / 2));
-        width: $progress-threshold-circle;
-        height: $progress-threshold-circle;
-        border-radius: calc($progress-threshold-circle / 2);
-        z-index: 1;
-      }
     }
   }
 
@@ -72,6 +61,19 @@
 
   .progress::after {
     right: 0;
+  }
+
+  @each $name, $color in $progress-colors {
+    .pgn__progress-threshold-dot--#{$name} {
+      background: $color;
+      position: absolute;
+      margin-top: -(calc(($progress-threshold-circle + $annotated-progress-height) / 2));
+      margin-left: -(calc($progress-threshold-circle / 2));
+      width: $progress-threshold-circle;
+      height: $progress-threshold-circle;
+      border-radius: calc($progress-threshold-circle / 2);
+      z-index: 1;
+    }
   }
 
   .pgn__progress-info {

--- a/src/ProgressBar/ProgressBar.scss
+++ b/src/ProgressBar/ProgressBar.scss
@@ -76,19 +76,6 @@
     right: 0;
   }
 
-  @each $name, $color in $progress-colors {
-    .pgn__progress-threshold-dot--#{$name} {
-      background: $color;
-      position: absolute;
-      margin-top: -(calc(($progress-threshold-circle + $annotated-progress-height) / 2));
-      margin-left: -(calc($progress-threshold-circle / 2));
-      width: $progress-threshold-circle;
-      height: $progress-threshold-circle;
-      border-radius: calc($progress-threshold-circle / 2);
-      z-index: 1;
-    }
-  }
-
   .pgn__progress-info {
     display: inline-block;
     position: relative;

--- a/src/ProgressBar/ProgressBar.scss
+++ b/src/ProgressBar/ProgressBar.scss
@@ -46,6 +46,19 @@
     @each $name, $color in $progress-colors {
       .pgn__progress-bar--#{$name} {
         background-color: $color;
+
+        &::after {
+          content: "";
+          display: block;
+          background: $color;
+          position: absolute;
+          top: -(calc($progress-threshold-circle / 2) - calc($annotated-progress-height / 2));
+          right: -(calc($progress-threshold-circle / 2));
+          width: $progress-threshold-circle;
+          height: $progress-threshold-circle;
+          border-radius: calc($progress-threshold-circle / 2);
+          z-index: 1;
+        }
       }
     }
   }

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -80,13 +80,15 @@ const ProgressBarAnnotated = ({
             srOnly
           />
         )}
-        {!!threshold && (
+      </ProgressBarBase>
+      {!!threshold && (
+        <div className="d-flex">
           <div
             className={`pgn__progress-threshold-dot--${thresholdColor}`}
             style={{ left: `${threshold}%` }}
           />
-        )}
-      </ProgressBarBase>
+        </div>
+      )}
       {(!!threshold && !!thresholdLabel) && (
         <div
           className="pgn__progress-info"
@@ -116,8 +118,6 @@ ProgressBarAnnotated.propTypes = {
   variant: PropTypes.oneOf(VARIANTS),
   /** Specifies an additional `className` to add to the base element. */
   className: PropTypes.string,
-  /** Hide's the label visually. */
-  visuallyHidden: PropTypes.bool,
   /** Threshold current value. */
   threshold: PropTypes.number,
   /** Specifies label for `threshold`. */
@@ -135,7 +135,6 @@ ProgressBarAnnotated.defaultProps = {
   label: undefined,
   variant: PROGRESS_DEFAULT_VARIANT,
   className: undefined,
-  visuallyHidden: false,
   threshold: undefined,
   thresholdLabel: undefined,
   thresholdVariant: THRESHOLD_DEFAULT_VARIANT,

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import ProgressBarBase from 'react-bootstrap/ProgressBar';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -37,10 +37,20 @@ const ProgressBarAnnotated = ({
   const progressColor = VARIANTS.includes(variant) ? variant : PROGRESS_DEFAULT_VARIANT;
   const thresholdColor = VARIANTS.includes(thresholdVariant) ? thresholdVariant : THRESHOLD_DEFAULT_VARIANT;
 
-  useEffect(() => {
+  const positionAnnotations = useCallback(() => {
     placeInfoAtZero(progressInfoRef, isProgressHintAfter, ANNOTATION_CLASS);
     placeInfoAtZero(thresholdInfoRef, isThresholdHintAfter, ANNOTATION_CLASS);
   }, [isProgressHintAfter, isThresholdHintAfter]);
+
+  useEffect(() => {
+    positionAnnotations();
+    const observer = new ResizeObserver(() => {
+      positionAnnotations();
+    });
+    const progressInfoEl = progressInfoRef.current;
+    observer.observe(progressInfoEl);
+    return () => progressInfoEl && progressInfoEl.unobserve(progressInfoEl);
+  }, [positionAnnotations]);
 
   const getHint = (text) => (
     <span className="pgn__progress-hint">
@@ -81,14 +91,6 @@ const ProgressBarAnnotated = ({
           />
         )}
       </ProgressBarBase>
-      {!!threshold && (
-        <div className="d-flex">
-          <div
-            className={`pgn__progress-threshold-dot--${thresholdColor}`}
-            style={{ left: `${threshold}%` }}
-          />
-        </div>
-      )}
       {(!!threshold && !!thresholdLabel) && (
         <div
           className="pgn__progress-info"

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -49,7 +49,7 @@ const ProgressBarAnnotated = ({
     });
     const progressInfoEl = progressInfoRef.current;
     observer.observe(progressInfoEl);
-    return () => progressInfoEl && progressInfoEl.unobserve(progressInfoEl);
+    return () => progressInfoEl?.unobserve(progressInfoEl);
   }, [positionAnnotations]);
 
   const getHint = (text) => (

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -49,7 +49,7 @@ const ProgressBarAnnotated = ({
     });
     const progressInfoEl = progressInfoRef.current;
     observer.observe(progressInfoEl);
-    return () => progressInfoEl?.unobserve(progressInfoEl);
+    return () => progressInfoEl && observer.unobserve(progressInfoEl);
   }, [positionAnnotations]);
 
   const getHint = (text) => (

--- a/src/ProgressBar/tests/__snapshots__/ProgressBar.test.jsx.snap
+++ b/src/ProgressBar/tests/__snapshots__/ProgressBar.test.jsx.snap
@@ -17,7 +17,6 @@ exports[`<ProgressBar.Annotated /> correct rendering renders without props 1`] =
           "width": "NaN%",
         }
       }
-      visuallyHidden={false}
     >
       <span
         className="sr-only"

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -3,4 +3,20 @@ import 'regenerator-runtime/runtime';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
+class ResizeObserver {
+  observe() {
+    // do nothing
+  }
+
+  unobserve() {
+    // do nothing
+  }
+
+  disconnect() {
+    // do nothing
+  }
+}
+
+window.ResizeObserver = ResizeObserver;
+
 Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
## Description

<img width="942" alt="image" src="https://user-images.githubusercontent.com/2828721/173597961-83e713dc-2145-4c3f-886d-0e1ebdf3d61b.png">

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
