### PR TITLE
[BD-46] docs: refactoring Card component on the mobile page styles #1314

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -251,10 +251,14 @@
 
 @media (max-width: map-get($grid-breakpoints, "sm")) {
   .pgn__card-footer {
+    &.horizontal > :not(:last-child) {
+      margin-inline-end: 0;
+    }
+
     .btn {
       width: 100%;
       margin: .625rem 0 0;
-      margin-inline-end: 0 !important;
+      margin-inline-end: 0;
     }
   }
 

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -248,3 +248,23 @@
     flex-direction: row;
   }
 }
+
+@media (max-width: map-get($grid-breakpoints, "sm")) {
+  .pgn__card-footer {
+    .btn {
+      width: 100%;
+      margin: .625rem 0 0;
+      margin-inline-end: 0 !important;
+    }
+  }
+
+  .pgn__action-row {
+    .btn:not(:last-child) {
+      margin-bottom: .3125rem;
+    }
+
+    & > * + * {
+      margin-inline-start: 0;
+    }
+  }
+}

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -271,4 +271,11 @@
       margin-inline-start: 0;
     }
   }
+
+  .pgn__action-row-stacked,
+  .pgn__card-section {
+    .btn {
+      width: 100%;
+    }
+  }
 }

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -28,21 +28,26 @@ This component uses a `Card` from react-bootstrap as a base component and extend
 ## Basic Usage
 
 ```jsx live
-<Card style={{ width: '18rem' }}>
-  <Card.ImageCap 
-    src="https://source.unsplash.com/360x200/?nature,flower"
-    srcAlt="Card image"
-  />
-  <Card.Header
-    title="Card Title"
-  />
-  <Card.Section>
-    This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
-  </Card.Section>
-  <Card.Footer>
-    <Button>Action 1</Button>
-  </Card.Footer>
-</Card>
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Card style={{ width: isExtraSmall ? "100%" : "18rem" }}>
+      <Card.ImageCap 
+        src="https://source.unsplash.com/360x200/?nature,flower"
+        srcAlt="Card image"
+      />
+      <Card.Header
+        title="Card Title"
+      />
+      <Card.Section>
+        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
+      </Card.Section>
+      <Card.Footer>
+        <Button>Action 1</Button>
+      </Card.Footer>
+    </Card>
+)}
 ```
 
 ## Clickable variant
@@ -50,21 +55,26 @@ This component uses a `Card` from react-bootstrap as a base component and extend
 You use `isClickable` prop to add additional `hover` and `focus` styling to the `Card`.
 
 ```jsx live
-<Card style={{ width: '18rem' }} isClickable>
-  <Card.ImageCap 
-    src="https://source.unsplash.com/360x200/?nature,flower"
-    srcAlt="Card image"
-  />
-  <Card.Header
-    title="Card Title"
-  />
-  <Card.Section>
-    This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
-  </Card.Section>
-  <Card.Footer>
-    <Button>Action 1</Button>
-  </Card.Footer>
-</Card>
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return(
+    <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} isClickable>
+      <Card.ImageCap 
+        src="https://source.unsplash.com/360x200/?nature,flower"
+        srcAlt="Card image"
+      />
+      <Card.Header
+        title="Card Title"
+      />
+      <Card.Section>
+        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
+      </Card.Section>
+      <Card.Footer>
+        <Button>Action 1</Button>
+      </Card.Footer>
+    </Card>
+)};
 ```
 
 ## Header
@@ -91,43 +101,52 @@ This header displays a title, subtitle, and may contain actions.
 The `Card.Header` supports custom actions via the actions prop and renders them on the top right of the header.
 
 ```jsx live
-<div>
-  <Card className="mb-2">
-    <Card.Header
-      title="Title"
-      subtitle="Subtitle"
-      actions={
-        <ActionRow>
-          <Button variant="tertiary">Action</Button>
-          <Button>Action</Button>
-        </ActionRow>
-      } 
-    />
-  </Card>
-  <Card>
-    <Card.Header
-      title="Title"
-      subtitle="Subtitle"
-      actions={
-        <Dropdown>
-          <Dropdown.Toggle
-            id="dropdown-toggle-with-iconbutton"
-            as={IconButton}
-            src={MoreVert}
-            iconAs={Icon}
-            variant="primary"
-            alt="Actions dropdown"
-          />
-          <Dropdown.Menu>
-            <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
-            <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-            <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
-      }
-    />
-  </Card>
-</div>
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <div>
+      <Card className="mb-2">
+        <Card.Header
+          title="Title"
+          subtitle="Subtitle"
+          style={{ flexDirection: isExtraSmall ? "column-reverse" : "row" }}
+          actions={
+            <ActionRow 
+              style={{ flexDirection: isExtraSmall ? "column" : "row", 
+              marginBottom: isExtraSmall ? ".5rem" : 0 }}
+            >
+              <Button variant="tertiary">Action 1</Button>
+              <Button>Action 2</Button>
+            </ActionRow>
+          } 
+        />
+      </Card>
+      <Card>
+        <Card.Header
+          title="Title"
+          subtitle="Subtitle"
+          actions={
+            <Dropdown>
+              <Dropdown.Toggle
+                id="dropdown-toggle-with-iconbutton"
+                as={IconButton}
+                src={MoreVert}
+                iconAs={Icon}
+                variant="primary"
+                alt="Actions dropdown"
+              />
+              <Dropdown.Menu>
+                <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+                <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+                <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
+          }
+        />
+      </Card>
+    </div>
+)}
 ```
 
 ### Sizes
@@ -153,36 +172,41 @@ Add ``size="sm"`` for smaller header content and actions.
 `Card.Section` is the main block to display card content. Can include its own title and actions separate from other card components. Multiple sections have a `Card.Divider` between them.
 
 ```jsx live
-<Card>
-  <Card.Section 
-    title="Section title"
-    actions={
-      <ActionRow>
-        <Button>Action 1</Button>
-        <Button>Action 2</Button>
-      </ActionRow>
-    }
-  >
-    This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
-  </Card.Section>
-  <Card.Divider />
-  <Card.Section 
-    title="Muted section"
-    actions={
-      <ActionRow>
-        <Button>Action 1</Button>
-        <Button>Action 2</Button>
-      </ActionRow>
-    }
-    muted
-  >
-    This is a muted variant.
-  </Card.Section>
-  <Card.Divider />
-  <Card.Section>
-    This is a section without title or actions, just content.
-  </Card.Section>
-</Card>
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Card>
+      <Card.Section 
+        title="Section title"
+        actions={
+          <ActionRow style={{ flexDirection: isExtraSmall ? "column" : "row" }}>
+            <Button>Action 1</Button>
+            <Button>Action 2</Button>
+          </ActionRow>
+        }
+      >
+        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
+      </Card.Section>
+      <Card.Divider />
+      <Card.Section 
+        title="Muted section"
+        actions={
+          <ActionRow style={{ flexDirection: isExtraSmall ? "column" : "row"  }}>
+            <Button>Action 1</Button>
+            <Button>Action 2</Button>
+          </ActionRow>
+        }
+        muted
+      >
+        This is a muted variant.
+      </Card.Section>
+      <Card.Divider />
+      <Card.Section>
+        This is a section without title or actions, just content.
+      </Card.Section>
+    </Card>
+)}
 ```
 
 ## Footer
@@ -195,26 +219,33 @@ Note that `Card.Footer` has a separate `orientation` prop which will override th
 ```jsx live
 () => {
   const footerLink = <a href='#link'>Footer text as a link</a>;
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <>
       <Card>
-        <Card.Footer>
+        <Card.Footer orientation={isExtraSmall ? "horizontal" : "vertical"}>
           <Button>Action 1</Button>
           <Button>Action 2</Button>
         </Card.Footer>
         <Card.Divider />
-        <Card.Footer textElement="Optional footer text to display">
+        <Card.Footer 
+          orientation={isExtraSmall ? "horizontal" : "vertical"} 
+          textElement="Optional footer text to display"
+        >
           <Button>Action 1</Button>
           <Button>Action 2</Button>
         </Card.Footer>
         <Card.Divider />
-        <Card.Footer textElement={footerLink}>
+        <Card.Footer
+          orientation={isExtraSmall ? "horizontal" : "vertical"} 
+          textElement={footerLink}
+        >
           <Button>Action 1</Button>
           <Button>Action 2</Button>
         </Card.Footer>
       </Card>
-      <Card style={{width: '40%'}}>
+      <Card style={{ width: isExtraSmall ? "100%" : "40%" }}>
         <Card.Footer textElement="Stacked vertical variant" isStacked>
           <Button>Action 1</Button>
           <Button>Action 2</Button>
@@ -228,22 +259,27 @@ Note that `Card.Footer` has a separate `orientation` prop which will override th
 ### Horizontal variant
 
 ```jsx live
-<Card style={{width: '40%'}}>
-  <Card.Footer orientation="horizontal">
-    <Button>Action 1</Button>
-    <Button>Action 2</Button>
-  </Card.Footer>
-  <Card.Divider />
-  <Card.Footer orientation="horizontal" textElement="Optional footer text to display">
-    <Button>Action 1</Button>
-    <Button>Action 2</Button>
-  </Card.Footer>
-  <Card.Divider />
-  <Card.Footer orientation="horizontal" textElement="Horizontal stacked variant" isStacked>
-    <Button>Action 1</Button>
-    <Button>Action 2</Button>
-  </Card.Footer>
-</Card>
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+  
+  return (
+    <Card style={{ width: isExtraSmall ? "100%" : "40%" }}>
+    <Card.Footer orientation="horizontal">
+      <Button>Action 1</Button>
+      <Button>Action 2</Button>
+    </Card.Footer>
+    <Card.Divider />
+    <Card.Footer orientation="horizontal" textElement="Optional footer text to display">
+      <Button>Action 1</Button>
+      <Button>Action 2</Button>
+    </Card.Footer>
+    <Card.Divider />
+    <Card.Footer orientation="horizontal" textElement="Horizontal stacked variant" isStacked>
+      <Button>Action 1</Button>
+      <Button>Action 2</Button>
+    </Card.Footer>
+  </Card>
+)}
 ```
 
 ## With Image Cap
@@ -251,42 +287,18 @@ Note that `Card.Footer` has a separate `orientation` prop which will override th
 `ImageCap` is an image that sits on the top or the left edge of a `Card`. Can contain an optional logo image.
 
 ```jsx live
-<Card style={{width: '40%'}}>
-  <Card.ImageCap 
-    src="https://source.unsplash.com/360x200/?nature,flower"
-    srcAlt="Card image"
-    logoSrc="https://via.placeholder.com/150"
-    logoAlt="Card logo"
-  />
-  <Card.Header
-    title="Title"
-    subtitle="Subtitle"
-  />
-  <Card.Section 
-    title="Section title"
-  >
-    This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
-  </Card.Section>
-  <Card.Footer>
-    <Button>Action 1</Button>
-  </Card.Footer>
-</Card>
-```
 
-## Horizontal variant
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
 
-When using horizontal variant Paragon provides additional component `Card.Body` which acts as a wrapper for content you want to display between `ImageCap` and `Footer`. Use it if content contains multiple components.
-
-```jsx live
-<>
-  <Card orientation="horizontal" className="mb-4">
-    <Card.ImageCap 
-      src="https://source.unsplash.com/360x200/?nature,flower"
-      srcAlt="Card image"
-      logoSrc="https://via.placeholder.com/150"
-      logoAlt="Card logo"
-    />
-    <Card.Body>
+  return (
+    <Card style={{ width: isExtraSmall ? "100%" : "40%" }}>
+      <Card.ImageCap 
+        src="https://source.unsplash.com/360x200/?nature,flower"
+        srcAlt="Card image"
+        logoSrc="https://via.placeholder.com/150"
+        logoAlt="Card logo"
+      />
       <Card.Header
         title="Title"
         subtitle="Subtitle"
@@ -294,109 +306,172 @@ When using horizontal variant Paragon provides additional component `Card.Body` 
       <Card.Section 
         title="Section title"
       >
-        Here we want to display both Header and Section between ImageCap and Footer components, so we use Card.Body to accomplish that. 
+        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
       </Card.Section>
-    </Card.Body>
-    <Card.Footer>
-      <Button>Action 1</Button>
-      <Button>Action 2</Button>
-    </Card.Footer>
-  </Card>
-  <Card orientation="horizontal" className="mb-4">
-    <Card.ImageCap 
-      src="https://source.unsplash.com/360x200/?nature,flower"
-      srcAlt="Card image"
-      logoSrc="https://via.placeholder.com/150"
-      logoAlt="Card logo"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      In this Card we only want to display Section, therefore no need to use Card.Body wrapper.
-    </Card.Section>
-    <Card.Footer>
-      <Button>Action 1</Button>
-      <Button>Action 2</Button>
-    </Card.Footer>
-  </Card>
-  <Card orientation="horizontal">
-    <Card.ImageCap 
-      src="https://source.unsplash.com/360x200/?nature,flower"
-      srcAlt="Card image"
-      logoSrc="https://via.placeholder.com/150"
-      logoAlt="Card logo"
-    />
-    <Card.Body>
-      <Card.Header
-        title="Title"
-      />
-      <Card.Section 
-        title="Section title"
-      >
-        This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation.
-      </Card.Section>
-      <Card.Footer orientation="vertical" textElement="Some footer text">
+      <Card.Footer>
         <Button>Action 1</Button>
-        <Button>Action 2</Button>
       </Card.Footer>
-    </Card.Body>
-  </Card>
-</>
+    </Card>
+)}
+```
+
+## Horizontal variant
+
+When using horizontal variant Paragon provides additional component `Card.Body` which acts as a wrapper for content you want to display between `ImageCap` and `Footer`. Use it if content contains multiple components.
+
+```jsx live
+
+() => {
+  const isSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+  
+  return (
+    <>
+      <Card
+        className="mb-4" 
+        orientation={isSmall ? "vertical" : "horizontal"}
+      >
+        <Card.ImageCap 
+          src="https://source.unsplash.com/360x200/?nature,flower"
+          srcAlt="Card image"
+          logoSrc="https://via.placeholder.com/150"
+          logoAlt="Card logo"
+        />
+        <Card.Body>
+          <Card.Header
+            title="Title"
+            subtitle="Subtitle"
+          />
+          <Card.Section 
+            title="Section title"
+          >
+            Here we want to display both Header and Section between ImageCap and Footer components, so we use Card.Body to accomplish that. 
+          </Card.Section>
+        </Card.Body>
+        <Card.Footer orientation={isExtraSmall ? "horizontal" : "vertical"}>
+          <Button>Action 1</Button>
+          <Button>Action 2</Button>
+        </Card.Footer>
+      </Card>
+      <Card className="mb-4" orientation={isSmall ? "vertical" : "horizontal"}>
+        <Card.ImageCap 
+          src="https://source.unsplash.com/360x200/?nature,flower"
+          srcAlt="Card image"
+          logoSrc="https://via.placeholder.com/150"
+          logoAlt="Card logo"
+        />
+        <Card.Section 
+          title="Section title"
+        >
+          In this Card we only want to display Section, therefore no need to use Card.Body wrapper.
+        </Card.Section>
+        <Card.Footer orientation={isExtraSmall ? "horizontal" : "vertical"}>
+          <Button>Action 1</Button>
+          <Button>Action 2</Button>
+        </Card.Footer>
+      </Card>
+      <Card orientation={isSmall ? "vertical" : "horizontal"}>
+        <Card.ImageCap 
+          src="https://source.unsplash.com/360x200/?nature,flower"
+          srcAlt="Card image"
+          logoSrc="https://via.placeholder.com/150"
+          logoAlt="Card logo"
+        />
+        <Card.Body>
+          <Card.Header
+            title="Title"
+          />
+          <Card.Section 
+            title="Section title"
+          >
+            This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation.
+          </Card.Section>
+          <Card.Footer orientation={isExtraSmall ? "horizontal" : "vertical"} textElement="Some footer text">
+            <Button>Action 1</Button>
+            <Button>Action 2</Button>
+          </Card.Footer>
+        </Card.Body>
+      </Card>
+    </>
+)}
 ```
 
 ## Card Content Block Empty
 ### With image
 
 ```jsx live
-<Card style={{ width: '25rem' }}>
-  <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image"/>
-  <Card.Section className="text-center">
-    <h2>Headline</h2>
-    <p>This is an optional text description.</p>
-    <Button variant="brand">Action</Button>
-  </Card.Section>
-</Card>
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+
+  return (
+    <Card style={{ width: isExtraSmall ? "100%" : "25rem" }}>
+      <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image"/>
+      <Card.Section className="text-center">
+        <h2>Headline</h2>
+        <p>This is an optional text description.</p>
+        <Button variant="brand">Action</Button>
+      </Card.Section>
+    </Card>
+)}
 ```
 
 ### Without image
 
 ```jsx live
-<Card style={{ width: '25rem' }}>
-  <Card.Section className="text-center">
-    <h2>Headline</h2>
-    <p>This is an optional text description.</p>
-    <Button variant="brand">Action</Button>
-  </Card.Section>
-</Card>
+
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+
+  return (
+    <Card style={{ width: isExtraSmall ? "100%" : "25rem" }}>
+      <Card.Section className="text-center">
+        <h2>Headline</h2>
+        <p>This is an optional text description.</p>
+        <Button variant="brand">Action</Button>
+      </Card.Section>
+    </Card>
+)}
 ```
 
 ### Horizontal variant with image
 
 ```jsx live
-<Card orientation="horizontal">
-  <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image"/>
-  <Card.Section>
-    <h2>Headline</h2>
-    <p>This is an optional text description.</p>
-  </Card.Section>
-  <Card.Footer className="justify-content-end">
-    <Button variant="brand">Action</Button>
-  </Card.Footer>
-</Card>
+() => {
+  const isSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+
+  return (
+    <Card orientation={isSmall ? "vertical" : "horizontal"}>
+      <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image"/>
+      <Card.Body>
+        <Card.Section>
+          <h2>Headline</h2>
+          <p>This is an optional text description.</p>
+        </Card.Section>
+      </Card.Body>
+      <Card.Footer className="justify-content-end">
+        <Button variant="brand">Action</Button>
+      </Card.Footer>
+    </Card>
+)}
 ```
 
 ### Horizontal variant without image
 
 ```jsx live
-<Card orientation="horizontal">
-  <Card.Section>
-    <h2>Headline</h2>
-    <p>This is an optional text description.</p>
-  </Card.Section>
-  <Card.Footer className="justify-content-end">
-    <Button variant="brand">Action</Button>
-  </Card.Footer>
-</Card>
+() => {
+  const isSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+
+  return (
+    <Card orientation={isSmall ? "vertical" : "horizontal"}>
+      <Card.Section>
+        <h2>Headline</h2>
+        <p>This is an optional text description.</p>
+      </Card.Section>
+      <Card.Footer className="justify-content-end">
+        <Button variant="brand">Action</Button>
+      </Card.Footer>
+    </Card>
+)}
 ```
 
 ## CardGrid

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -110,11 +110,11 @@ The `Card.Header` supports custom actions via the actions prop and renders them 
         <Card.Header
           title="Title"
           subtitle="Subtitle"
-          style={{ flexDirection: isExtraSmall ? "column-reverse" : "row" }}
+          isStacked={!!isExtraSmall}
           actions={
             <ActionRow 
-              style={{ flexDirection: isExtraSmall ? "column" : "row", 
-              marginBottom: isExtraSmall ? ".5rem" : 0 }}
+            isStacked={!!isExtraSmall}
+              style={{  marginBottom: isExtraSmall ? ".5rem" : 0 }}
             >
               <Button variant="tertiary">Action 1</Button>
               <Button>Action 2</Button>
@@ -180,7 +180,7 @@ Add ``size="sm"`` for smaller header content and actions.
       <Card.Section 
         title="Section title"
         actions={
-          <ActionRow style={{ flexDirection: isExtraSmall ? "column" : "row" }}>
+          <ActionRow isStacked={!!isExtraSmall}>
             <Button>Action 1</Button>
             <Button>Action 2</Button>
           </ActionRow>
@@ -192,7 +192,7 @@ Add ``size="sm"`` for smaller header content and actions.
       <Card.Section 
         title="Muted section"
         actions={
-          <ActionRow style={{ flexDirection: isExtraSmall ? "column" : "row"  }}>
+          <ActionRow isStacked={!!isExtraSmall}>
             <Button>Action 1</Button>
             <Button>Action 2</Button>
           </ActionRow>


### PR DESCRIPTION
## Description

Refactoring the display of the Card component page for mobile devices.

### Deploy Preview

[Card component](https://deploy-preview-1381--paragon-openedx.netlify.app/components/card/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
