### PR TITLE
[BD-46] DRAFT: show truncation examples for Card component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.4",
         "react-focus-on": "^3.5.4",
+        "react-lines-ellipsis": "^0.15.1",
         "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^8.2.0",
@@ -17787,11 +17788,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19280,6 +19276,19 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-lines-ellipsis": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/react-lines-ellipsis/-/react-lines-ellipsis-0.15.1.tgz",
+      "integrity": "sha512-u84rLwoQx+ixuIdPGY9MrdduBBkjeGVchBH502Mn0ExPgHBEch3Sd7CNEQQSBm3w3+aePzXaD6dVaczdURmNPg==",
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/react-overlays": {
       "version": "5.1.1",
@@ -37843,6 +37852,12 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-lines-ellipsis": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/react-lines-ellipsis/-/react-lines-ellipsis-0.15.1.tgz",
+      "integrity": "sha512-u84rLwoQx+ixuIdPGY9MrdduBBkjeGVchBH502Mn0ExPgHBEch3Sd7CNEQQSBm3w3+aePzXaD6dVaczdURmNPg==",
+      "requires": {}
     },
     "react-overlays": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prop-types": "^15.8.1",
     "react-bootstrap": "^1.6.4",
     "react-focus-on": "^3.5.4",
+    "react-lines-ellipsis": "^0.15.1",
     "react-popper": "^2.2.5",
     "react-proptype-conditional-require": "^1.0.4",
     "react-responsive": "^8.2.0",

--- a/src/Card/CardFooter.jsx
+++ b/src/Card/CardFooter.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import LinesEllipsis from 'react-lines-ellipsis';
 import CardContext from './CardContext';
 
 const CardFooter = React.forwardRef(({
@@ -9,6 +10,7 @@ const CardFooter = React.forwardRef(({
   isStacked,
   textElement,
   orientation,
+  maxLine,
 }, ref) => {
   const { orientation: cardOrientation } = useContext(CardContext);
   const footerOrientation = orientation || cardOrientation;
@@ -17,7 +19,14 @@ const CardFooter = React.forwardRef(({
 
   return (
     <div className={classNames(className, wrapperClassName)} ref={ref}>
-      {textElement && <div className={textElementClassName}>{textElement}</div>}
+      {textElement
+      && (
+      <LinesEllipsis
+        className={textElementClassName}
+        text={`${textElement}`}
+        maxLine={maxLine}
+      />
+      )}
       {children}
     </div>
   );
@@ -34,6 +43,8 @@ CardFooter.propTypes = {
   isStacked: PropTypes.bool,
   /** Specifies which orientation to use. This prop will override context value if provided. */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /** Max count of lines allowed */
+  maxLine: PropTypes.string,
 };
 
 CardFooter.defaultProps = {
@@ -41,6 +52,7 @@ CardFooter.defaultProps = {
   textElement: undefined,
   isStacked: false,
   orientation: undefined,
+  maxLine: undefined,
 };
 
 export default CardFooter;

--- a/src/Card/CardHeader.jsx
+++ b/src/Card/CardHeader.jsx
@@ -1,6 +1,13 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import LinesEllipsis from 'react-lines-ellipsis';
+// import responsiveHOC from 'react-lines-ellipsis/lib/responsiveHOC';
+
+// const ResponsiveEllipsis = responsiveHOC()(LinesEllipsis);
+
+const TITLE_LINES_COUNT = 2;
+const SUBTITLE_LINES_COUNT = TITLE_LINES_COUNT;
 
 const CardHeader = React.forwardRef(({
   actions,
@@ -8,6 +15,8 @@ const CardHeader = React.forwardRef(({
   size,
   subtitle,
   title,
+  maxLineTitle,
+  maxLineSubTitle,
 }, ref) => {
   const cloneActions = useCallback(
     (Action) => {
@@ -28,8 +37,24 @@ const CardHeader = React.forwardRef(({
   return (
     <div className={classNames('pgn__card-header', className)} ref={ref}>
       <div className="pgn__card-header-content">
-        {title && <div className={`pgn__card-header-title-${size}`}>{title}</div>}
-        {subtitle && <div className={`pgn__card-header-subtitle-${size}`}>{subtitle}</div>}
+        {title
+        && (
+        <LinesEllipsis
+          basedOn="letters"
+          className={`pgn__card-header-title-${size}`}
+          text={`${title}`}
+          maxLine={maxLineTitle}
+        />
+        )}
+        {subtitle
+        && (
+        <LinesEllipsis
+          basedOn="letters"
+          className={`pgn__card-header-subtitle-${size}`}
+          text={`${subtitle}`}
+          maxLine={maxLineSubTitle}
+        />
+        )}
       </div>
       {actions && (
         <div className="pgn__card-header-actions">
@@ -53,6 +78,10 @@ CardHeader.propTypes = {
   size: PropTypes.oneOf(['sm', 'md']),
   /** The subtitle of the CardHeader component */
   subtitle: PropTypes.node,
+  /** Max count of lines allowed for Title */
+  maxLineTitle: PropTypes.string,
+  /** Max count of lines allowed for SubTitle */
+  maxLineSubTitle: PropTypes.string,
 };
 
 CardHeader.defaultProps = {
@@ -61,6 +90,8 @@ CardHeader.defaultProps = {
   size: 'md',
   title: null,
   subtitle: null,
+  maxLineTitle: TITLE_LINES_COUNT,
+  maxLineSubTitle: SUBTITLE_LINES_COUNT,
 };
 
 export default CardHeader;

--- a/src/Card/CardSection.jsx
+++ b/src/Card/CardSection.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import LinesEllipsis from 'react-lines-ellipsis';
+
+const TITLE_LINES_COUNT = 1;
 
 const CardSection = React.forwardRef(({
   className,
@@ -8,14 +11,27 @@ const CardSection = React.forwardRef(({
   title,
   actions,
   muted,
+  maxLineTitle,
 }, ref) => (
   <div
     className={classNames('pgn__card-section', className, { 'is-muted': muted })}
     ref={ref}
   >
-    {title && <div className="pgn__card-section-title">{title}</div>}
-    {children}
-    {actions && <div className="pgn__card-section-actions">{actions}</div>}
+    {title
+    && (
+    <LinesEllipsis
+      className="pgn__card-section-title"
+      text={`${title}`}
+      maxLine={maxLineTitle}
+    />
+    )}
+    <LinesEllipsis
+      className="pgn__card-section-title"
+      text={`${children}`}
+      maxLine={maxLineTitle}
+    />
+    {/* {children} */}
+    {actions && (<div className="pgn__card-section-actions">{actions}</div>)}
   </div>
 ));
 
@@ -30,6 +46,8 @@ CardSection.propTypes = {
   actions: PropTypes.node,
   /** Specifies whether to display `Section` with muted styling. */
   muted: PropTypes.bool,
+  /** Max count of lines allowed */
+  maxLineTitle: PropTypes.string,
 };
 
 CardSection.defaultProps = {
@@ -37,6 +55,7 @@ CardSection.defaultProps = {
   title: undefined,
   actions: undefined,
   muted: false,
+  maxLineTitle: TITLE_LINES_COUNT,
 };
 
 export default CardSection;

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -399,6 +399,60 @@ When using horizontal variant Paragon provides additional component `Card.Body` 
 </Card>
 ```
 
+## Truncated text
+
+### Vertical variant
+
+```jsx live
+<Card style={{ width: '18rem' }}>
+  <Card.ImageCap 
+    src="https://source.unsplash.com/360x200/?nature,flower"
+    srcAlt="Card image"
+  />
+  <Card.Header
+    title="This is a card header. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them."
+    subtitle="Multiple sections have a card divider between them."
+    maxLineSubTitle={2}
+  />
+  <Card.Section
+    title="This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them."
+    maxLineTitle={2}
+  >
+    This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
+  </Card.Section>
+  <Card.Footer>
+    <Button>Action 1</Button>
+  </Card.Footer>
+</Card>
+```
+### Horizontal variant
+
+```jsx live
+  <Card orientation="horizontal">
+    <Card.ImageCap 
+      src="https://source.unsplash.com/360x200/?nature,flower"
+      srcAlt="Card image"
+      logoSrc="https://via.placeholder.com/150"
+      logoAlt="Card logo"
+    />
+    <Card.Body>
+      <Card.Header
+        title="This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation. This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation."
+      />
+      <Card.Section 
+        title="This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation. This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation."
+      >
+        This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation.
+      </Card.Section>
+      <Card.Footer orientation="vertical" textElement="This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation. This is a special case where we want to have Footer with vertical orientation in the Card with horizontal orientation."
+      >
+        <Button>Action 1</Button>
+        <Button>Action 2</Button>
+      </Card.Footer>
+    </Card.Body>
+  </Card>
+```
+
 ## CardGrid
 
 This component displays a collection of Cards as a grid (with customizable responsive behavior), where


### PR DESCRIPTION
## Description

Show truncation examples for Card component

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
