### PR TITLE
fix: flip sort direction icons in TableHeaderCell and add white bg color

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -1,3 +1,4 @@
+$data-table-background-color: $white !default;
 $data-table-border: 1px solid $gray-200 !default;
 $data-table-box-shadow: $box-shadow-sm !default;
 $data-table-padding-x: .75rem !default;
@@ -11,6 +12,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 .pgn__data-table-wrapper {
   font-size: $font-size-sm;
   border-radius: $border-radius;
+  background-color: $data-table-background-color;
   box-shadow: $data-table-box-shadow;
 
   &.hide-shadow {
@@ -96,6 +98,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   align-items: flex-start;
 
   .pgn__data-table-layout-sidebar {
+    background-color: $data-table-background-color;
     border-radius: $border-radius;
     box-shadow: $data-table-box-shadow;
     padding: $data-table-padding-small;

--- a/src/DataTable/TableHeaderCell.jsx
+++ b/src/DataTable/TableHeaderCell.jsx
@@ -10,10 +10,10 @@ export const SortIndicator = ({ isSorted, isSortedDesc }) => {
   }
 
   if (isSortedDesc) {
-    return <Icon src={ArrowDropUp} />;
+    return <Icon src={ArrowDropDown} />;
   }
 
-  return <Icon src={ArrowDropDown} />;
+  return <Icon src={ArrowDropUp} />;
 };
 
 SortIndicator.propTypes = {


### PR DESCRIPTION
## Description

* Flips the sort direction arrow for descending vs. ascending to be more in line with convention.
* Adds white background color behind the sidebar filters and table wrapper containers.

### Deploy Preview

https://deploy-preview-1404--paragon-openedx.netlify.app/components/datatable/#frontend-filtering-and-sorting

<img width="194" alt="image" src="https://user-images.githubusercontent.com/2828721/175033584-83895768-2dff-4ada-9f0d-8be15e58c458.png">



## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
