### PR TITLE
[BD-46] TextFilter component Header prop usage only handles string, not components (functions) 

### DIFF
--- a/src/DataTable/filters/TextFilter.jsx
+++ b/src/DataTable/filters/TextFilter.jsx
@@ -3,13 +3,24 @@ import PropTypes from 'prop-types';
 import { Form, FormLabel, Input } from '../..';
 import { newId } from '../../utils';
 
+const formatHeaderForLabel = (header) => {
+  if (typeof header === 'function') {
+    return header();
+  }
+  if (typeof header === 'string') {
+    return header.toLowerCase();
+  }
+  return header;
+};
+
 function TextFilter({
   column: {
     filterValue, setFilter, Header, getHeaderProps,
   },
 }) {
   const ariaLabel = useRef(newId(`text-filter-label-${getHeaderProps().key}-`));
-  const inputText = `Search ${Header}`;
+  const formattedHeader = formatHeaderForLabel(Header);
+  const inputText = React.isValidElement(formattedHeader) ? formattedHeader : `Search ${formattedHeader}`;
   return (
     <Form.Group>
       <FormLabel id={ariaLabel.current} className="sr-only">{inputText}</FormLabel>

--- a/src/DataTable/filters/tests/TextFilter.test.jsx
+++ b/src/DataTable/filters/tests/TextFilter.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import TextFilter from '../TextFilter';
+
+describe('<TextFilter />', () => {
+  it('Header as function', () => {
+    const mockKey = () => 'key';
+    const props = {
+      column: {
+        filterValue: 'Demo Course',
+        setFilter: jest.fn(),
+        Header: () => 'test',
+        getHeaderProps: jest.fn().mockImplementation(() => ({ key: mockKey })),
+      },
+    };
+    const wrapper = mount(<TextFilter {...props} />);
+    expect(wrapper.text()).toContain('Search test');
+  });
+
+  it('Header as string', () => {
+    const mockKey = () => 'key';
+    const props = {
+      column: {
+        filterValue: 'Demo Course',
+        setFilter: jest.fn(),
+        Header: 'test',
+        getHeaderProps: jest.fn().mockImplementation(() => ({ key: mockKey })),
+      },
+    };
+    const wrapper = mount(<TextFilter {...props} />);
+    expect(wrapper.text()).toContain('Search test');
+  });
+});

--- a/src/DataTable/filters/tests/TextFilter.test.jsx
+++ b/src/DataTable/filters/tests/TextFilter.test.jsx
@@ -30,4 +30,18 @@ describe('<TextFilter />', () => {
     const wrapper = mount(<TextFilter {...props} />);
     expect(wrapper.text()).toContain('Search test');
   });
+
+  it('Header as component', () => {
+    const mockKey = () => 'key';
+    const props = {
+      column: {
+        filterValue: 'Demo Course',
+        setFilter: jest.fn(),
+        Header: <span>test_component</span>,
+        getHeaderProps: jest.fn().mockImplementation(() => ({ key: mockKey })),
+      },
+    };
+    const wrapper = mount(<TextFilter {...props} />);
+    expect(wrapper.text()).toContain('test_component');
+  });
 });


### PR DESCRIPTION
## Description

Allow function and components to passed as `Header` value to `TextFilter`.

### Deploy Preview

https://deploy-preview-1441--paragon-openedx.netlify.app/components/datatable/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
