### PR TITLE
[BD-46]: vars for elevation

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -478,18 +478,48 @@ $level-3-box-shadow:          0 0 .625rem rgba(0, 0, 0, .15), 0 0 1rem rgba(0, 0
 $level-4-box-shadow:          0 .625rem 1.25rem rgba(0, 0, 0, .15), 0 .5rem 1.25rem rgba(0, 0, 0, .15) !default;
 $level-5-box-shadow:          0 1.25px 2.5rem rgba(0, 0, 0, .15), 0 .5rem 2.5rem rgba(0, 0, 0, .15) !default;
 
+$box-shadow-down-1:           0 .0625rem .125rem rgba(0, 0, 0, .15), 0 .0625rem .25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-down-2:           0 .125rem .25rem rgba(0, 0, 0, .15), 0 .125rem .5rem rgba(0, 0, 0, .15) !default;
+$box-shadow-down-3:           0 .5rem 1rem rgba(0, 0, 0, .15), 0 .25rem .625rem rgba(0, 0, 0, .15) !default;
+$box-shadow-down-4:           0 .625rem 1.25rem rgba(0, 0, 0, .15), 0 .5rem 1.25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-down-5:           0 1.25px 2.5rem rgba(0, 0, 0, .15), 0 .5rem 2.5rem rgba(0, 0, 0, .15) !default;
+
+$box-shadow-left-1:           -.0625rem 0 .125rem rgba(0, 0, 0, .15), -.0625rem 0 .25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-left-2:           -.125rem 0 .25rem rgba(0, 0, 0, .15), -.125rem 0 .5rem rgba(0, 0, 0, .15) !default;
+$box-shadow-left-3:           -.5rem 0 1rem rgba(0, 0, 0, .15), -.25rem 0 .625rem rgba(0, 0, 0, .15) !default;
+$box-shadow-left-4:           -.625rem 0 1.25rem rgba(0, 0, 0, .15), -.5rem 0 1.25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-left-5:           -1.25rem 0 2.5rem rgba(0, 0, 0, .15), -.5rem 0 3rem rgba(0, 0, 0, .15) !default;
+
+$box-shadow-up-1:             0 -.0625rem .125rem rgba(0, 0, 0, .15), 0 -.0625rem .25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-up-2:             0 -.125rem .25rem rgba(0, 0, 0, .15), 0 -.125rem .5rem rgba(0, 0, 0, .15) !default;
+$box-shadow-up-3:             0 -.5rem 1rem rgba(0, 0, 0, .15), 0 -.25rem .625rem rgba(0, 0, 0, .15) !default;
+$box-shadow-up-4:             0 -.625rem 1.25rem rgba(0, 0, 0, .15), 0 -.5rem 1.25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-up-5:             0 -1.25rem 2.5rem rgba(0, 0, 0, .15), 0 -.5rem 3rem rgba(0, 0, 0, .15) !default;
+
+$box-shadow-right-1:          .0625rem 0 .125rem rgba(0, 0, 0, .15), .0625rem 0 .25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-right-2:          .125rem 0 .25rem rgba(0, 0, 0, .15), .125rem 0 .5rem rgba(0, 0, 0, .15) !default;
+$box-shadow-right-3:          .5rem 0 1rem rgba(0, 0, 0, .15), .25rem 0 .625rem rgba(0, 0, 0, .15) !default;
+$box-shadow-right-4:          .625rem 0 1.25rem rgba(0, 0, 0, .15), .5rem 0 1.25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-right-5:          1.25rem 0 2.5rem rgba(0, 0, 0, .15), .5rem 0 3rem rgba(0, 0, 0, .15) !default;
+
+$box-shadow-centered-1:       0 0 .125rem rgba(0, 0, 0, .15), 0 0 .25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-centered-2:       0 0 .25rem rgba(0, 0, 0, .15), 0 0 .5rem rgba(0, 0, 0, .15) !default;
+$box-shadow-centered-3:       0 0 .625rem rgba(0, 0, 0, .15), 0 0 1rem rgba(0, 0, 0, .15) !default;
+$box-shadow-centered-4:       0 0 1.25rem rgba(0, 0, 0, .15), 0 0 1.25rem rgba(0, 0, 0, .15) !default;
+$box-shadow-centered-5:       0 0 2.5rem rgba(0, 0, 0, .15), 0 0 3rem rgba(0, 0, 0, .15) !default;
+
 @mixin pgn-box-shadow($level, $side) {
   @if $side == "down" {
     @if $level == 1 {
-      box-shadow: 0 .0625rem .125rem rgba(0, 0, 0, .15), 0 .0625rem .25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-down-1;
     } @else if $level == 2 {
-      box-shadow: 0 .125rem .25rem rgba(0, 0, 0, .15), 0 .125rem .5rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-down-2;
     } @else if $level == 3 {
-      box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15), 0 .25rem .625rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-down-3;
     } @else if $level == 4 {
-      box-shadow: 0 .625rem 1.25rem rgba(0, 0, 0, .15), 0 .5rem 1.25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-down-4;
     } @else if $level == 5 {
-      box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, .15), 0 .5rem 3rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-down-5;
     } @else {
       @error "Box-shadow level #{$level} does not exist";
     }
@@ -497,15 +527,15 @@ $level-5-box-shadow:          0 1.25px 2.5rem rgba(0, 0, 0, .15), 0 .5rem 2.5rem
 
   @if $side == "left" {
     @if $level == 1 {
-      box-shadow: -.0625rem 0 .125rem rgba(0, 0, 0, .15), -.0625rem 0 .25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-left-1;
     } @else if $level == 2 {
-      box-shadow: -.125rem 0 .25rem rgba(0, 0, 0, .15), -.125rem 0 .5rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-left-2;
     } @else if $level == 3 {
-      box-shadow: -.5rem 0 1rem rgba(0, 0, 0, .15), -.25rem 0 .625rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-left-3;
     } @else if $level == 4 {
-      box-shadow: -.625rem 0 1.25rem rgba(0, 0, 0, .15), -.5rem 0 1.25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-left-4;
     } @else if $level == 5 {
-      box-shadow: -1.25rem 0 2.5rem rgba(0, 0, 0, .15), -.5rem 0 3rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-left-5;
     } @else {
       @error "Box-shadow level #{$level} does not exist";
     }
@@ -513,15 +543,15 @@ $level-5-box-shadow:          0 1.25px 2.5rem rgba(0, 0, 0, .15), 0 .5rem 2.5rem
 
   @if $side == "up" {
     @if $level == 1 {
-      box-shadow: 0 -.0625rem .125rem rgba(0, 0, 0, .15), 0 -.0625rem .25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-up-1;
     } @else if $level == 2 {
-      box-shadow: 0 -.125rem .25rem rgba(0, 0, 0, .15), 0 -.125rem .5rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-up-2;
     } @else if $level == 3 {
-      box-shadow: 0 -.5rem 1rem rgba(0, 0, 0, .15), 0 -.25rem .625rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-up-3;
     } @else if $level == 4 {
-      box-shadow: 0 -.625rem 1.25rem rgba(0, 0, 0, .15), 0 -.5rem 1.25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-up-4;
     } @else if $level == 5 {
-      box-shadow: 0 -1.25rem 2.5rem rgba(0, 0, 0, .15), 0 -.5rem 3rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-up-5;
     } @else {
       @error "Box-shadow level #{$level} does not exist";
     }
@@ -529,15 +559,15 @@ $level-5-box-shadow:          0 1.25px 2.5rem rgba(0, 0, 0, .15), 0 .5rem 2.5rem
 
   @if $side == "right" {
     @if $level == 1 {
-      box-shadow: .0625rem 0 .125rem rgba(0, 0, 0, .15), .0625rem 0 .25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-right-1;
     } @else if $level == 2 {
-      box-shadow: .125rem 0 .25rem rgba(0, 0, 0, .15), .125rem 0 .5rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-right-2;
     } @else if $level == 3 {
-      box-shadow: .5rem 0 1rem rgba(0, 0, 0, .15), .25rem 0 .625rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-right-3;
     } @else if $level == 4 {
-      box-shadow: .625rem 0 1.25rem rgba(0, 0, 0, .15), .5rem 0 1.25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-right-4;
     } @else if $level == 5 {
-      box-shadow: 1.25rem 0 2.5rem rgba(0, 0, 0, .15), .5rem 0 3rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-right-5;
     } @else {
       @error "Box-shadow level #{$level} does not exist";
     }
@@ -545,15 +575,15 @@ $level-5-box-shadow:          0 1.25px 2.5rem rgba(0, 0, 0, .15), 0 .5rem 2.5rem
 
   @if $side == "centered" {
     @if $level == 1 {
-      box-shadow: 0 0 .125rem rgba(0, 0, 0, .15), 0 0 .25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-centered-1;
     } @else if $level == 2 {
-      box-shadow: 0 0 .25rem rgba(0, 0, 0, .15), 0 0 .5rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-centered-2;
     } @else if $level == 3 {
-      box-shadow: 0 0 .625rem rgba(0, 0, 0, .15), 0 0 1rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-centered-3;
     } @else if $level == 4 {
-      box-shadow: 0 0 1.25rem rgba(0, 0, 0, .15), 0 0 1.25rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-centered-4;
     } @else if $level == 5 {
-      box-shadow: 0 0 2.5rem rgba(0, 0, 0, .15), 0 0 3rem rgba(0, 0, 0, .15);
+      box-shadow: $box-shadow-centered-5;
     } @else {
       @error "Box-shadow level #{$level} does not exist";
     }

--- a/www/src/pages/foundations/elevation.jsx
+++ b/www/src/pages/foundations/elevation.jsx
@@ -238,32 +238,46 @@ export default function ElevationPage() {
         </div>
 
         <h4>Example classes usage</h4>
-        <p>All classes names are available for use</p>
-        {boxShadowLevels.map(level => (
-          boxShadowSides.map(side => (
-            <code key={side} className="d-block mb-2 bg-gray-100 p-3">
-              .box-shadow-{side}-{level}
-            </code>
-          ))
-        ))}
+        <p>Classes are available with following pattern: </p>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          {'.box-shadow-{direction}-{level}'}
+        </code>
+        <p>For example:</p>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          .box-shadow-right-2
+        </code>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          .box-shadow-up-3
+        </code>
         <br />
 
         <h4>Example mixin usage</h4>
-        {boxShadowLevels.map(level => (
-          boxShadowSides.map(side => (
-            <code key={side} className="d-block mb-2 bg-gray-100 p-3">
-              @include <strong>pgn-box-shadow({level}, &ldquo;{side}&rdquo;)</strong>;
-            </code>
-          ))
-        ))}
+        <p>Mixin can be used as follows: </p>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          @include pgn-box-shadow(level, side);
+        </code>
+        <p>For example:</p>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          @include pgn-box-shadow(1, &quot;down&quot;);
+        </code>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          @include pgn-box-shadow(3, &quot;left&quot;);
+        </code>
         <br />
 
         <h4>Example variables usage</h4>
-        {boxShadowLevels.map(level => (
-          <code key={level} className="d-block mb-2 bg-gray-100 p-3">
-            box-shadow: <strong>$level-{level}-box-shadow</strong>;
-          </code>
-        ))}
+        <p>Variables are available with following pattern: </p>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          {'$box-shadow-{direction}-{level}'}
+        </code>
+        <p>For example:</p>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          $box-shadow-right-2
+        </code>
+        <code className="d-block mb-2 bg-gray-100 p-3">
+          $box-shadow-up-3
+        </code>
+        <br />
 
         <h3 className="mt-5">Box-shadow generator</h3>
         <p>


### PR DESCRIPTION
## Description

There are CSS utility classes and a SCSS mixin to implement shadows in all levels and directions, however, the SCSS variables only account for the level.

This PR ensure there are SCSS variables for each permutation of level and heading.

Github issue: https://github.com/openedx/paragon/issues/1385

### Deploy Preview

https://deploy-preview-1443--paragon-openedx.netlify.app/foundations/elevation

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
