### PR TITLE
[BD-46]: Add headers to form input components on docs site

### DIFF
--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -52,6 +52,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
   const handleChange = (e) => setValue(e.target.value);
   return (
     <>
+      <h3>Default</h3>
       <Form.Group>
         <Form.Control
           value={value}
@@ -61,6 +62,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
         />
       </Form.Group>
 
+      <h3>Textarea</h3>
       <Form.Group>
         <Form.Control
           as="textarea"
@@ -71,6 +73,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
         />
       </Form.Group>
 
+      <h3>Select</h3>
       <Form.Group>
         <Form.Control
           as="select"
@@ -87,6 +90,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
         </Form.Control>
       </Form.Group>
 
+      <h3>Password</h3>
       <Form.Group>
         <Form.Control
           type="password"
@@ -97,6 +101,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
         />
       </Form.Group>
 
+      <h3>Date picker</h3>
       <Form.Group>
         <Form.Control
           type="date"
@@ -107,6 +112,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
         />
       </Form.Group>
 
+      <h3>Number</h3>
       <Form.Group>
         <Form.Control
           type="number"
@@ -117,6 +123,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
         />
       </Form.Group>
 
+      <h3>Time picker</h3>
       <Form.Group>
         <Form.Control
           type="time"


### PR DESCRIPTION
## Description
Each input type should have its own label.

https://paragon-openedx.netlify.app/components/form/form-control/#input-types

Labels in order from top to bottom:
- Default
- Textarea
- Select
- Password
- Date picker
- Number
- Time picker

GitHub issue: https://github.com/openedx/paragon/issues/1433

### Deploy Preview
https://deploy-preview-1447--paragon-openedx.netlify.app/components/form/form-control/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
