### PR TITLE
[BD-46] feat: add expandable bubble

### DIFF
--- a/src/Bubble/Bubble.scss
+++ b/src/Bubble/Bubble.scss
@@ -21,4 +21,8 @@
   &.disabled {
     background: $gray-500;
   }
+
+  &.expandable {
+    padding: $bubble-expandable-padding-y $bubble-expandable-padding-x;
+  }
 }

--- a/src/Bubble/Bubble.test.jsx
+++ b/src/Bubble/Bubble.test.jsx
@@ -24,5 +24,10 @@ describe('<Bubble />', () => {
       const bubble = wrapper.find('.pgn__bubble');
       expect(bubble.hasClass('disabled')).toEqual(true);
     });
+    it('renders with disabled variant', () => {
+      const wrapper = mount(<Bubble expandable>1</Bubble>);
+      const bubble = wrapper.find('.pgn__bubble');
+      expect(bubble.hasClass('expandable')).toEqual(true);
+    });
   });
 });

--- a/src/Bubble/README.md
+++ b/src/Bubble/README.md
@@ -52,7 +52,7 @@ Represents the filled circle with a number of an icon, supporting the usual colo
 }
 ```
 
-## Disabled variant
+### Disabled variant
 
 ```jsx live
 () => {
@@ -65,6 +65,36 @@ Represents the filled circle with a number of an icon, supporting the usual colo
         <Icon src={Check} />
       </Bubble>
     </Stack>
+  );
+}
+```
+
+### Expandable
+
+In the case of long content use `expandable` prop. It adds padding to `Bubble`. Padding value is configurable through `scss` variables.
+
+```jsx live
+() => {
+  const [isExpandable, setIsExpandable] = useState(true);
+  const handleExpandableChange = (e) => setIsExpandable(e.target.value === 'true');
+
+  return (
+    <>
+      <Form.Group>
+        <Form.Label><code>expandable</code> prop is:</Form.Label>
+        <Form.RadioSet
+          name="expandable"
+          onChange={handleExpandableChange}
+          value={isExpandable.toString()}
+        >
+          <Form.Radio value="true">On</Form.Radio>
+          <Form.Radio value="false">Off</Form.Radio>
+        </Form.RadioSet>
+      </Form.Group>
+      <Bubble variant="error" expandable={isExpandable}>
+        1234
+      </Bubble>
+    </>
   );
 }
 ```

--- a/src/Bubble/_variables.scss
+++ b/src/Bubble/_variables.scss
@@ -4,3 +4,5 @@ $bubble-variants: (
   "error":      ( "background-color": $danger, "color": $white ),
   "primary":    ( "background-color": $primary, "color": $white ),
 ) !default;
+$bubble-expandable-padding-x:              .25rem !default;
+$bubble-expandable-padding-y:              0 !default;

--- a/src/Bubble/index.jsx
+++ b/src/Bubble/index.jsx
@@ -14,6 +14,7 @@ const Bubble = React.forwardRef(({
   className,
   children,
   disabled,
+  expandable,
   ...props
 }, ref) => (
   <div
@@ -22,7 +23,7 @@ const Bubble = React.forwardRef(({
       'pgn__bubble',
       `pgn__bubble-${variant}`,
       className,
-      { disabled },
+      { disabled, expandable },
     )}
     {...props}
   >
@@ -39,12 +40,15 @@ Bubble.propTypes = {
   disabled: PropTypes.bool,
   /** A class name to append to the base element. */
   className: PropTypes.string,
+  /** Specifies whether to add padding to the `Bubble` or not. */
+  expandable: PropTypes.bool,
 };
 
 Bubble.defaultProps = {
   variant: 'primary',
   disabled: false,
   className: undefined,
+  expandable: false,
 };
 
 export default Bubble;

--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`<Tabs /> correct rendering renders successfully 1`] = `
     >
       Tab 1
       <div
-        className="pgn__bubble pgn__bubble-error pgn__tab-notification"
+        className="pgn__bubble pgn__bubble-error pgn__tab-notification expandable"
       >
         4
       </div>

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -83,7 +83,13 @@ const Tabs = ({
         newTitle = (
           <>
             {title}
-            <Bubble variant="error" className="pgn__tab-notification">{notification}</Bubble>
+            <Bubble
+              variant="error"
+              className="pgn__tab-notification"
+              expandable
+            >
+              {notification}
+            </Bubble>
           </>
         );
       } else {


### PR DESCRIPTION
## Description

- add `expandable` prop to `Bubble`
- add `scss` variables to control padding with `expandable={true}`

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
