### PR TITLE
[BD-46] is-mutted props for card

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -4,6 +4,10 @@
 .pgn__card,
 .pgn__card-body {
   width: 100%;
+
+  &.is-muted {
+    background-color: $light-200;
+  }
 }
 
 .pgn__card-grid {

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -50,6 +50,33 @@ This component uses a `Card` from react-bootstrap as a base component and extend
 )}
 ```
 
+## With muted styling
+
+Use `muted` prop to show `Card` in inactive state.
+
+```jsx live
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} muted>
+      <Card.ImageCap 
+        src="https://source.unsplash.com/360x200/?nature,flower"
+        srcAlt="Card image"
+      />
+      <Card.Header
+        title="Card Title"
+      />
+      <Card.Section>
+        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
+      </Card.Section>
+      <Card.Footer>
+        <Button>Action 1</Button>
+      </Card.Footer>
+    </Card>
+)}
+```
+
 ## Clickable variant
 
 You use `isClickable` prop to add additional `hover` and `focus` styling to the `Card`.

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -15,6 +15,7 @@ const Card = React.forwardRef(({
   isLoading,
   className,
   isClickable,
+  muted,
   ...props
 }, ref) => (
   <CardContextProvider orientation={orientation} isLoading={isLoading}>
@@ -23,6 +24,7 @@ const Card = React.forwardRef(({
       className={classNames(className, 'pgn__card', {
         horizontal: orientation === 'horizontal',
         clickable: isClickable,
+        'is-muted': muted,
       })}
       ref={ref}
       tabIndex={isClickable ? '0' : '-1'}
@@ -46,6 +48,8 @@ Card.propTypes = {
   isClickable: PropTypes.bool,
   /** Specifies loading state. */
   isLoading: PropTypes.bool,
+  /** Specifies whether to display `Card` in muted styling. */
+  muted: PropTypes.bool,
 };
 
 Card.defaultProps = {
@@ -53,6 +57,7 @@ Card.defaultProps = {
   className: undefined,
   orientation: 'vertical',
   isClickable: false,
+  muted: false,
   isLoading: false,
 };
 


### PR DESCRIPTION
## Description
is-mutted props for Card component were added 

Github issue: https://github.com/openedx/paragon/issues/1376
### Deploy Preview

https://deploy-preview-1455--paragon-openedx.netlify.app/components/card/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
