### PR TITLE
[BD-46] feat: add message about file restrictions to default state of `Dropzone`

### DIFF
--- a/src/Dropzone/DefaultContent.jsx
+++ b/src/Dropzone/DefaultContent.jsx
@@ -1,21 +1,79 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { getTypesString, formatBytes } from './utils';
+import messages from './messages';
 import Icon from '../Icon';
 import { FileUpload } from '../../icons';
 
-const DefaultContent = () => (
-  <>
-    <div className="pgn__dropzone__upload-icon-wrapper">
-      <Icon src={FileUpload} className="pgn__dropzone__upload-icon" />
-    </div>
-    <p>
-      <FormattedMessage
-        id="pgn.Dropzone.DefaultContent.label"
-        description="A text that appears as a label for input of Dropzone component."
-        defaultMessage="Drag and drop your file here or click to upload."
-      />
-    </p>
-  </>
-);
+const DefaultContent = ({ accept, minSize, maxSize }) => {
+  const intl = useIntl();
+
+  const getFileRestrictionMessage = () => {
+    let fileTypePart;
+    let fileSizePart;
+
+    if (accept) {
+      const allTypes = getTypesString(accept);
+      const lastTypeSeparatorLocation = allTypes.lastIndexOf(',');
+      fileTypePart = intl.formatMessage(messages.fileTypeRestriction, {
+        count: lastTypeSeparatorLocation === -1 ? 1 : 2,
+        firstPart: lastTypeSeparatorLocation === -1 ? allTypes : allTypes.slice(0, lastTypeSeparatorLocation),
+        secondPart: lastTypeSeparatorLocation !== -1 && allTypes.slice(lastTypeSeparatorLocation + 1),
+      });
+    }
+
+    if (minSize && maxSize && Number.isFinite(maxSize)) {
+      fileSizePart = intl.formatMessage(messages.fileSizeBetween, {
+        sizeMin: formatBytes(minSize),
+        sizeMax: formatBytes(maxSize),
+      });
+    } else if (maxSize && Number.isFinite(maxSize)) {
+      fileSizePart = intl.formatMessage(messages.fileSizeMax, { sizeMax: formatBytes(maxSize) });
+    } else if (minSize) {
+      fileSizePart = intl.formatMessage(messages.fileSizeMin, { sizeMin: formatBytes(minSize) });
+    }
+
+    if (fileTypePart && fileSizePart) {
+      return `${fileTypePart} (${fileSizePart})`;
+    }
+    if (fileTypePart) {
+      return fileTypePart;
+    }
+    return fileSizePart;
+  };
+
+  return (
+    <>
+      <div className="pgn__dropzone__upload-icon-wrapper">
+        <Icon src={FileUpload} className="pgn__dropzone__upload-icon" />
+      </div>
+      <p>
+        <FormattedMessage
+          id="pgn.Dropzone.DefaultContent.label"
+          description="A text that appears as a label for input of Dropzone component."
+          defaultMessage="Drag and drop your file here or click to upload."
+        />
+      </p>
+      {[accept, minSize, maxSize].some(value => value) && (
+        <p className="x-small text-gray-500">
+          {getFileRestrictionMessage()}
+        </p>
+      )}
+    </>
+  );
+};
+
+DefaultContent.propTypes = {
+  accept: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)),
+  maxSize: PropTypes.number,
+  minSize: PropTypes.number,
+};
+
+DefaultContent.defaultProps = {
+  accept: undefined,
+  maxSize: undefined,
+  minSize: undefined,
+};
 
 export default DefaultContent;

--- a/src/Dropzone/DefaultContent.jsx
+++ b/src/Dropzone/DefaultContent.jsx
@@ -56,7 +56,7 @@ const DefaultContent = ({ accept, minSize, maxSize }) => {
         />
       </p>
       {[accept, minSize, maxSize].some(value => value) && (
-        <p className="x-small text-gray-500">
+        <p className="pgn__dropzone__upload-restriction-message">
           {getFileRestrictionMessage()}
         </p>
       )}

--- a/src/Dropzone/Dropzone.scss
+++ b/src/Dropzone/Dropzone.scss
@@ -60,3 +60,8 @@
   height: 32px;
   width: 32px;
 }
+
+.pgn__dropzone__upload-restriction-message {
+  font-size: $dropzone-restriction-msg-font-size;
+  color: $dropzone-restriction-msg-color;
+}

--- a/src/Dropzone/README.md
+++ b/src/Dropzone/README.md
@@ -88,6 +88,8 @@ For example:
 - to allow both PNG and JPG images you should pass `{ 'image/*': ['.png', '.jpg'] }` object as `accept` prop;
 - to allow arbitrary images you should pass `{ 'image/*': [] }` object as `accept` prop
 
+The component will render a helpful message about size and type restrictions based on the values you pass to `accept`, `minSize` and `maxSize` props.
+
 ```jsx live
 () => {
   async function handleProcessUpload({

--- a/src/Dropzone/_variables.scss
+++ b/src/Dropzone/_variables.scss
@@ -5,3 +5,5 @@ $dropzone-border-focus:                     2px solid $info-300 !default;
 $dropzone-border-active:                    2px solid $primary-500 !default;
 $dropzone-border-error:                     2px solid $danger-300 !default;
 $dropzone-error-wrapper-color:              $danger-500 !default;
+$dropzone-restriction-msg-font-size:        $x-small-font-size !default;
+$dropzone-restriction-msg-color:            $gray-500 !default;

--- a/src/Dropzone/index.jsx
+++ b/src/Dropzone/index.jsx
@@ -155,7 +155,7 @@ const Dropzone = ({
       return (
         <>
           <GenericError errorMsgs={errors} />
-          <DefaultContent />
+          {inputComponent || <DefaultContent minSize={minSize} maxSize={maxSize} accept={accept} />}
         </>
       );
     }
@@ -171,7 +171,7 @@ const Dropzone = ({
       );
     }
 
-    return inputComponent;
+    return inputComponent || <DefaultContent minSize={minSize} maxSize={maxSize} accept={accept} />;
   };
 
   return (
@@ -210,7 +210,7 @@ Dropzone.defaultProps = {
   },
   progressVariant: 'spinner',
   validator: undefined,
-  inputComponent: <DefaultContent />,
+  inputComponent: undefined,
 };
 
 Dropzone.propTypes = {

--- a/src/Dropzone/messages.js
+++ b/src/Dropzone/messages.js
@@ -31,6 +31,26 @@ const messages = defineMessages({
     defaultMessage: 'An unexpected problem occured during file validation. Please try again.',
     description: 'A message shown in case file validation in Dropzone component for unknown reason.',
   },
+  fileSizeBetween: {
+    id: 'pgn.Dropzone.DefaultContent.fileSizeBetween',
+    defaultMessage: 'Between {sizeMin} and {sizeMax}',
+    description: "A message shown when uploaded file's size must be in given range.",
+  },
+  fileSizeMax: {
+    id: 'pgn.Dropzone.DefaultContent.fileSizeMax',
+    defaultMessage: 'Max {sizeMax}',
+    description: "A message shown when uploaded file's size must be more than some value.",
+  },
+  fileSizeMin: {
+    id: 'pgn.Dropzone.DefaultContent.fileSizeMin',
+    defaultMessage: 'Min {sizeMin}',
+    description: "A message shown when uploaded file's size must be more than some value.",
+  },
+  fileTypeRestriction: {
+    id: 'pgn.Dropzone.DefaultContent.fileTypeRestriction',
+    defaultMessage: 'Upload {count, plural, one {{firstPart} files} other {{firstPart} or {secondPart} files}}',
+    description: 'A message shown when uploaded file must be of certain type(s).',
+  },
 });
 
 export default messages;

--- a/src/Dropzone/tests/DefaultContent.test.jsx
+++ b/src/Dropzone/tests/DefaultContent.test.jsx
@@ -1,12 +1,43 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from 'react-intl';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import DefaultContent from '../DefaultContent';
 
+// eslint-disable-next-line react/prop-types
+const DefaultContentWrapper = ({ children, ...props }) => (
+  <IntlProvider locale="en" messages={{}}>
+    <DefaultContent {...props} />
+  </IntlProvider>
+);
+
 describe('<Dropzone.DefaultContent />', () => {
   it('successfully renders', () => {
-    const tree = renderer.create(<IntlProvider locale="en" messages={{}}><DefaultContent /></IntlProvider>).toJSON();
+    const tree = renderer.create(<DefaultContentWrapper />).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+  it('renders file type restriction message if receives accept prop', () => {
+    const { container } = render(<DefaultContentWrapper accept={{ 'image/*': ['.png', '.jpg'] }} />);
+    expect(container).toHaveTextContent('Upload PNG or JPG files');
+  });
+  it('renders min size restriction message if receives minSize prop', () => {
+    const { container } = render(<DefaultContentWrapper minSize={1048576} />);
+    expect(container).toHaveTextContent('Min 1MB');
+  });
+  it('renders max size restriction message if receives maxSize prop', () => {
+    const { container } = render(<DefaultContentWrapper maxSize={1048576} />);
+    expect(container).toHaveTextContent('Max 1MB');
+  });
+  it('renders type and size restriction message if receives all props', () => {
+    const { container } = render(
+      <DefaultContentWrapper
+        accept={{ 'image/*': ['.png', '.jpg', '.gif'] }}
+        minSize={1048576}
+        maxSize={20 * 1048576}
+      />,
+    );
+    expect(container).toHaveTextContent('Upload PNG, JPG or GIF files (Between 1MB and 20MB)');
   });
 });

--- a/src/Dropzone/tests/__snapshots__/Dropzone.test.jsx.snap
+++ b/src/Dropzone/tests/__snapshots__/Dropzone.test.jsx.snap
@@ -54,6 +54,9 @@ exports[`<Dropzone /> successfully renders 1`] = `
     <p>
       Drag and drop your file here or click to upload.
     </p>
+    <p
+      className="x-small text-gray-500"
+    />
   </div>
 </div>
 `;

--- a/src/Dropzone/tests/__snapshots__/Dropzone.test.jsx.snap
+++ b/src/Dropzone/tests/__snapshots__/Dropzone.test.jsx.snap
@@ -55,7 +55,7 @@ exports[`<Dropzone /> successfully renders 1`] = `
       Drag and drop your file here or click to upload.
     </p>
     <p
-      className="x-small text-gray-500"
+      className="pgn__dropzone__upload-restriction-message"
     />
   </div>
 </div>


### PR DESCRIPTION
## Description

Auto-generate message about file restrictions in `Dropzone` component based on `accept`, `minSize` and `maxSize` props.

### Deploy Preview

https://deploy-preview-1470--paragon-openedx.netlify.app/components/dropzone/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
