### PR TITLE
[BD-46] docs: added role for Bubble notification

### DIFF
--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<Tabs /> correct rendering renders successfully 1`] = `
       Tab 1
       <div
         className="pgn__bubble pgn__bubble-error pgn__tab-notification expandable"
+        role="status"
       >
         4
       </div>

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -85,6 +85,7 @@ const Tabs = ({
             {title}
             <Bubble
               variant="error"
+              role="status"
               className="pgn__tab-notification"
               expandable
             >
@@ -137,7 +138,7 @@ const Tabs = ({
             >
               {moreTabText}
               {moreTabHasNotification && (
-                <Bubble variant="error" className="pgn__tab-notification" />
+                <Bubble variant="error" role="status" className="pgn__tab-notification" />
               )}
             </Dropdown.Toggle>
             <Dropdown.Menu className="dropdown-menu-right">{overflowChildren}</Dropdown.Menu>

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -138,7 +138,11 @@ const Tabs = ({
             >
               {moreTabText}
               {moreTabHasNotification && (
-                <Bubble variant="error" role="status" className="pgn__tab-notification" />
+                <Bubble
+                  variant="error"
+                  role="status"
+                  className="pgn__tab-notification"
+                />
               )}
             </Dropdown.Toggle>
             <Dropdown.Menu className="dropdown-menu-right">{overflowChildren}</Dropdown.Menu>


### PR DESCRIPTION
## Description

Added role="status" to Badge in notification in Tabs component.

### Deploy Preview

[Tabs component](https://deploy-preview-1477--paragon-openedx.netlify.app/components/tabs/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
