### PR TITLE
[BD-46] docs: added support for making `Card` a hyperlink

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -6,6 +6,10 @@
   width: 100%;
 }
 
+a:hover {
+  text-decoration: none;
+}
+
 .pgn__card-grid {
   .row > div[class*="col-"] {
     margin-bottom: $card-grid-margin;
@@ -129,6 +133,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  a:hover {
+    text-decoration: underline;
+  }
 
   &.vertical {
     justify-content: flex-end;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -9,6 +9,7 @@
 a .pgn__card {
   color: $gray-700;
   display: inline-block;
+  margin-right: 100%;
 }
 
 .pgn__card-grid {

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -6,13 +6,9 @@
   width: 100%;
 }
 
-.link {
-  color: $black;
-
-  &:hover {
-    text-decoration: none;
-    color: $black;
-  }
+a .pgn__card {
+  color: $gray-700;
+  display: inline-block;
 }
 
 .pgn__card-grid {
@@ -138,10 +134,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-
-  a:hover {
-    text-decoration: underline;
-  }
 
   &.vertical {
     justify-content: flex-end;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -6,8 +6,13 @@
   width: 100%;
 }
 
-a:hover {
-  text-decoration: none;
+.link {
+  color: $black;
+
+  &:hover {
+    text-decoration: none;
+    color: $black;
+  }
 }
 
 .pgn__card-grid {

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -86,7 +86,7 @@ your CSS class or available CSS classes of the Bootstrap library for link.
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
-    <Hyperlink className="link" destination="https://www.edx.org">
+    <Hyperlink destination="https://www.edx.org">
       <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} isClickable>
         <Card.ImageCap
           src="https://source.unsplash.com/360x200/?nature,flower"

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -86,8 +86,8 @@ your CSS class or available CSS classes of the Bootstrap library for link.
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
-    <Hyperlink destination="https://www.edx.org">
-      <Card style={{ width: isExtraSmall ? "100%" : "18rem" }}>
+    <Hyperlink className="link" destination="https://www.edx.org">
+      <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} isClickable>
         <Card.ImageCap
           src="https://source.unsplash.com/360x200/?nature,flower"
           srcAlt="Card image"

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -86,7 +86,7 @@ your CSS class or available CSS classes of the Bootstrap library for link.
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
-    <Hyperlink className="text-decoration-none text-gray-700" destination="https://www.edx.org">
+    <Hyperlink destination="https://www.edx.org">
       <Card style={{ width: isExtraSmall ? "100%" : "18rem" }}>
         <Card.ImageCap
           src="https://source.unsplash.com/360x200/?nature,flower"

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -77,6 +77,34 @@ You use `isClickable` prop to add additional `hover` and `focus` styling to the 
 )};
 ```
 
+## As link
+The ability to place a Card inside the link is also available. To reset the default link styles, you need to add 
+your CSS class or available CSS classes of the Bootstrap library for link.
+
+```jsx live
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Hyperlink className="text-decoration-none text-gray-700" destination="https://www.edx.org">
+      <Card style={{ width: isExtraSmall ? "100%" : "18rem" }}>
+        <Card.ImageCap
+          src="https://source.unsplash.com/360x200/?nature,flower"
+          srcAlt="Card image"
+        />
+        <Card.Header title="Card Title"/>
+        <Card.Section>
+          This is a card section. It can contain anything but usually text, a list, or list of links. 
+          Multiple sections have a card divider between them.
+        </Card.Section>
+        <Card.Footer>
+          <Button>Action 1</Button>
+        </Card.Footer>
+      </Card>
+    </Hyperlink>
+)}
+```
+
 ## Header
 You may add a header by adding a ``Card.Header`` component.
 This header displays a title, subtitle, and may contain actions.

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -78,8 +78,8 @@ You use `isClickable` prop to add additional `hover` and `focus` styling to the 
 ```
 
 ## As link
-The ability to place a Card inside the link is also available. To reset the default link styles, you need to add 
-your CSS class or available CSS classes of the Bootstrap library for link.
+You can also use `Card` as a link by wrapping it into appropriate component, note that `Card` will override default 
+link styling to make its content appear as a regular text.
 
 ```jsx live
 () => {


### PR DESCRIPTION
## Description

Added support for making `Card` a hyperlink

### Deploy Preview

[Card component](https://deploy-preview-1478--paragon-openedx.netlify.app/components/card/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
