### PR TITLE
[BD-46] feat: add unmountOnExit

### DIFF
--- a/src/Collapsible/Collapsible.scss
+++ b/src/Collapsible/Collapsible.scss
@@ -78,6 +78,10 @@
   .collapsible-body {
     padding: $collapsible-basic-spacer-y $collapsible-basic-spacer-x;
     text-align: start;
+
+    &.collapsing {
+      transition: height 300ms ease;
+    }
   }
 
   .collapsible-icon {

--- a/src/Collapsible/Collapsible.test.jsx
+++ b/src/Collapsible/Collapsible.test.jsx
@@ -89,6 +89,29 @@ describe('<Collapsible />', () => {
       wrapper.update();
       collapsibleIsClosed(wrapper);
     });
+    it('correct behavior with unmountOnExit', () => {
+      let i = 0;
+      const Comp = () => {
+        i += 1;
+        return <h1>Hello world</h1>;
+      };
+      const component = mount((
+        <Collapsible.Advanced unmountOnExit={false}>
+          <Collapsible.Body>
+            <Comp />
+          </Collapsible.Body>
+        </Collapsible.Advanced>
+      ));
+      const instance = component.instance();
+      instance.open();
+      component.update();
+      expect(i).toEqual(1);
+      instance.close();
+      component.update();
+      instance.open();
+      component.update();
+      expect(i).toEqual(1);
+    });
   });
 
   describe('Mouse Interactions', () => {

--- a/src/Collapsible/CollapsibleAdvanced.jsx
+++ b/src/Collapsible/CollapsibleAdvanced.jsx
@@ -59,6 +59,7 @@ class CollapsibleAdvanced extends React.Component {
     const {
       children,
       className,
+      unmountOnExit,
       ...props
     } = this.props;
 
@@ -81,6 +82,7 @@ class CollapsibleAdvanced extends React.Component {
             open: this.open,
             close: this.close,
             toggle: this.toggle,
+            unmountOnExit,
           }}
         >
           {children}
@@ -105,6 +107,8 @@ CollapsibleAdvanced.propTypes = {
   onOpen: PropTypes.func,
   /** Callback fired when `Collapsible` closes. */
   onClose: PropTypes.func,
+  /** Unmount the component (remove it from the DOM) when it is collapsed */
+  unmountOnExit: PropTypes.bool,
 };
 
 CollapsibleAdvanced.defaultProps = {
@@ -115,6 +119,7 @@ CollapsibleAdvanced.defaultProps = {
   onToggle: undefined,
   onOpen: undefined,
   onClose: undefined,
+  unmountOnExit: true,
 };
 
 export default CollapsibleAdvanced;

--- a/src/Collapsible/CollapsibleAdvanced.jsx
+++ b/src/Collapsible/CollapsibleAdvanced.jsx
@@ -107,7 +107,7 @@ CollapsibleAdvanced.propTypes = {
   onOpen: PropTypes.func,
   /** Callback fired when `Collapsible` closes. */
   onClose: PropTypes.func,
-  /** Unmount the component (remove it from the DOM) when it is collapsed */
+  /** Unmount the component (remove it from the DOM) when it is collapsed. */
   unmountOnExit: PropTypes.bool,
 };
 

--- a/src/Collapsible/CollapsibleBody.jsx
+++ b/src/Collapsible/CollapsibleBody.jsx
@@ -1,26 +1,28 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
+import Collapse from '../Collapse';
 import { CollapsibleContext } from './CollapsibleAdvanced';
 import TransitionReplace from '../TransitionReplace';
 
 function CollapsibleBody({
   children, transitionWrapper, tag, ...props
 }) {
-  const { isOpen } = useContext(CollapsibleContext);
+  const { isOpen, unmountOnExit } = useContext(CollapsibleContext);
 
   // Keys are added to these elements so that TransitionReplace
   // will recognize them as unique components and perform the
   // transition properly.
-  const content = isOpen
-    ? React.createElement(tag, { key: 'body', ...props }, children)
-    : <div key="empty" />;
+  const content = React.createElement(tag, { key: 'body', ...props }, children);
+  const transitionBody = isOpen ? content : <div key="empty" />;
 
   if (transitionWrapper) {
-    return React.cloneElement(transitionWrapper, {}, content);
+    return React.cloneElement(transitionWrapper, {}, transitionBody);
   }
   /* istanbul ignore next */
-  return <TransitionReplace>{content}</TransitionReplace>;
+  return unmountOnExit
+    ? <TransitionReplace>{transitionBody}</TransitionReplace>
+    : <Collapse in={isOpen}>{content}</Collapse>;
 }
 
 CollapsibleBody.propTypes = {

--- a/src/Collapsible/index.jsx
+++ b/src/Collapsible/index.jsx
@@ -73,6 +73,8 @@ Collapsible.propTypes = {
   styling: PropTypes.oneOf(['basic', 'card', 'card-lg']),
   /** Specifies title. */
   title: PropTypes.node.isRequired,
+  /** Unmount the component (remove it from the DOM) when it is collapsed */
+  unmountOnExit: PropTypes.bool,
 };
 Collapsible.defaultProps = {
   className: undefined,
@@ -84,6 +86,7 @@ Collapsible.defaultProps = {
   onToggle: undefined,
   open: undefined,
   styling: 'card',
+  unmountOnExit: true,
 };
 
 Collapsible.Advanced = CollapsibleAdvanced;

--- a/www/src/components/CodeBlock.jsx
+++ b/www/src/components/CodeBlock.jsx
@@ -24,6 +24,7 @@ function CollapsibleLiveEditor({ children }) {
   return (
     <div className="pgn-doc__collapsible-live-editor">
       <Collapsible.Advanced
+        unmountOnExit={false}
         open={collapseIsOpen}
         onToggle={(isOpen) => setCollapseIsOpen(isOpen)}
       >


### PR DESCRIPTION
## Description

Added `unmountOnExit` that uses Collapse inside if it is equal to false. React Bootstrap by default implements `unmountOnExit=false`. `TransitionReplace` is based on the children re-render so I decided to use `Collapse` instead of updating `TransitionReplace`

### Deploy Preview

[Collapsible](https://deploy-preview-1502--paragon-openedx.netlify.app/components/collapsible/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
