### PR TITLE
fix: filter break style is not align correctly

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -178,7 +178,6 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 }
 
 .pgn__data-table-filters-breakout-filter {
-  align-self: flex-end;
   margin-inline-end: map_get($spacers, 2);
 }
 


### PR DESCRIPTION
## Description
<img width="964" alt="Screen Shot 2022-07-29 at 12 43 00 PM" src="https://user-images.githubusercontent.com/83240113/181806038-8541fde1-e23e-4a15-a705-3dfbdf24bdc3.png">

### Deploy Preview
<img width="948" alt="Screen Shot 2022-07-29 at 12 42 43 PM" src="https://user-images.githubusercontent.com/83240113/181806051-f52f2edb-5b2c-4d70-bce6-5da8dc76ec0c.png">




## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
