### PR TITLE
[BD-46] feat: new docs for Cell prop

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -1322,3 +1322,81 @@ You can create your own custom expander column and use it, see code example belo
   );
 }
 ```
+
+## Custom cell content
+
+You can create your own cell content by passing the `Cell` property to a specific column.
+
+```jsx live
+() => {
+  const variants = ['primary', 'warning', 'success', 'danger'];
+  const [cellColors, setCellColors] = useState([0, 1, 2]);
+
+  const handleColorChange = (index) => {
+    const newColors = cellColors.slice();
+    newColors[index] = cellColors[index] < 3 ? cellColors[index] + 1 : 0;
+    setCellColors(newColors);
+  };
+  
+  return (
+    <DataTable
+      isExpandable
+      itemCount={3}
+      data={[
+        {
+          name: 'Lil Bub',
+          color: 'brown tabby',
+          famous_for: 'weird tongue',
+        },
+        {
+          name: 'Grumpy Cat',
+          color: 'siamese',
+          famous_for: 'serving moods',
+        },
+        {
+          name: 'Smoothie', 
+          color: 'orange tabby',
+          famous_for: 'modeling',
+        },
+      ]}
+      columns={[
+        {
+          Header: 'Name',
+          Cell: ({ row }) => (
+            <Badge variant={variants[cellColors[row.id] % 4]}>
+              {row.original.name}
+            </Badge>
+          ),
+        },
+        {
+          Header: 'Famous For',
+          Cell: ({ row }) => (
+            <Badge variant={variants[(cellColors[row.id] + 1) % 4]}>
+              {row.original.famous_for}
+            </Badge>
+          ),
+        },
+        {
+          Header: 'Coat Color',
+          Cell: ({ row }) => (
+            <Badge variant={variants[(cellColors[row.id] + 2) % 4]}>
+              {row.original.color}
+            </Badge>
+          ),
+        },
+      ]}
+      additionalColumns={[
+        {
+          id: 'action',
+          Header: 'Action',
+          Cell: ({ row }) => <Button variant="link" size="sm" onClick={() => handleColorChange(row.id)}>Change</Button>,
+        }
+      ]}
+    >
+      <DataTable.TableControlBar/>
+      <DataTable.Table/>
+      <DataTable.TableFooter/>
+    </DataTable>
+  );
+}
+```


### PR DESCRIPTION
## Description

Add section and example for Cell property.

https://github.com/openedx/paragon/issues/1524

### Deploy Preview

[DataTable](https://deploy-preview-1538--paragon-openedx.netlify.app/components/datatable/#custom-cell-content)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
