### PR TITLE
[WS-3120] feat: add multiselect functionality to InputSelect

### DIFF
--- a/src/InputSelect/README.md
+++ b/src/InputSelect/README.md
@@ -81,6 +81,22 @@ notes: |
   ]}
 />
 ```
+## select multiple
+
+```jsx live
+<InputSelect
+  name="fruits"
+  label="Fruits"
+  options={[
+    'apple',
+    'orange',
+    'strawberry',
+    'banana',
+  ]}
+  multiple
+  value={["strawberry", "apple"]}
+/>
+```
 
 ## with validation
 
@@ -110,8 +126,8 @@ notes: |
   label="Fruits"
   aria-label="Fruits"
   value="strawberry"
-  options={['
-    apple',
+  options={[
+    'apple',
     'orange',
     'strawberry',
     'banana',


### PR DESCRIPTION
## Description

This PR implements multiselect functionality on the InputSelect component, which is currently being used widely across Publisher.

It looks like InputSelect will be deprecated, so at some point Publisher will need to be updated to use the newer Paragon Form components, and multi-select functionality will have to be implemented there. However, I thought that might be a separate scope of work - this PR is just to get the multiselect functionality into Publisher in the short-term so that we can use it.

See https://2u-internal.atlassian.net/browse/WS-3120

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
