### PR TITLE
[BD-46] docs: fixing category margin gap

### DIFF
--- a/www/src/components/Search/Search.scss
+++ b/www/src/components/Search/Search.scss
@@ -160,9 +160,9 @@
 
       .DocSearch-Hit-source,
       .DocSearch-Title {
-        font-size: .6875rem;
-        line-height: $line-height-sm;
-        font-weight: $font-weight-normal;
+        font-size: $font-size-base;
+        line-height: $line-height-base;
+        font-weight: $font-weight-bold;
         background: $white;
         color: $dark;
         padding: 0 0 .5rem;
@@ -187,11 +187,7 @@
       }
 
       .DocSearch-Hit:last-child {
-        margin-bottom: 10.75rem;
-
-        @media (max-width: map-get($grid-breakpoints, "md")) {
-          margin-bottom: 0;
-        }
+        margin-bottom: 1rem;
       }
 
       .DocSearch-Hit[aria-selected="true"] a {


### PR DESCRIPTION
## Description

After configuring sections for Algolia search markup issues were found

![image](https://user-images.githubusercontent.com/93188219/185069522-42ab4044-cd07-4026-9134-5aadf349516b.png)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
