### PR TITLE
fix: correct missing interpolation

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -129,7 +129,7 @@
 
 .pgn__modal-body {
   flex-grow: 1;
-  padding: $modal-inner-padding $modal-inner-padding calc($modal-inner-padding / 2);
+  padding: $modal-inner-padding $modal-inner-padding calc(#{$modal-inner-padding} / 2);
   overflow: auto;
   position: relative;
 
@@ -161,7 +161,7 @@
     display: block;
     height: 20px;
     position: sticky;
-    bottom: calc($modal-inner-padding / 2 * -1);
+    bottom: calc(#{$modal-inner-padding} / 2 * -1);
     margin-bottom: -$modal-inner-padding;
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
@@ -225,7 +225,7 @@
   background-color: $modal-content-bg;
   transition: box-shadow 150ms ease;
   padding: $modal-footer-padding;
-  padding-top: calc($modal-inner-padding / 2);
+  padding-top: calc(#{$modal-inner-padding} / 2);
 }
 
 // Color Variants
@@ -234,14 +234,14 @@
   // Default style modals don't have a background on the header which
   // ends up looking spaced too far away from the body content.
   .pgn__modal-header {
-    padding-bottom: calc($modal-inner-padding / 2);
+    padding-bottom: calc(#{$modal-inner-padding} / 2);
   }
 
   .pgn__modal-body {
-    padding: calc($modal-inner-padding / 2) $modal-inner-padding;
+    padding: calc(#{$modal-inner-padding} / 2) $modal-inner-padding;
 
     &::before {
-      top: calc($modal-inner-padding / 2 * -1);
+      top: calc(#{$modal-inner-padding} / 2 * -1);
     }
   }
 }


### PR DESCRIPTION
## Description

The Modal scss was missing interpolation for calculated styles.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
