### PR TITLE
[BD-46] feat: fixed Marketing modal scroll

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -162,7 +162,7 @@
     height: 20px;
     position: sticky;
     bottom: calc(#{$modal-inner-padding} / 2 * -1);
-    margin-bottom: -$modal-inner-padding;
+    margin-bottom: -$modal-inner-padding-bottom;
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
     opacity: .5;

--- a/src/Modal/_variables.scss
+++ b/src/Modal/_variables.scss
@@ -2,6 +2,7 @@
 
 // Padding applied to the modal body
 $modal-inner-padding:               1.5rem !default;
+$modal-inner-padding-bottom:        .7rem !default;
 
 // Margin between elements in footer, must be lower than or equal to 2 * $modal-inner-padding
 $modal-footer-margin-between:       .5rem !default;


### PR DESCRIPTION
## Description

Modals have scroll bars when there isn't a need for a scroll bar.

![image](https://user-images.githubusercontent.com/93188219/187645675-9db02b01-8c65-4129-888f-6bbd0c5d4b57.png)


### Deploy Preview

[Marketing modal](https://deploy-preview-1594--paragon-openedx.netlify.app/components/modal/marketing-modal)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
