### PR TITLE
[BD-46] fix: floating label expand beyond input field

### DIFF
--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -187,6 +187,9 @@ $select-icon-padding: .5625rem !default;
     border-top: solid 2px transparent;
     position: relative;
     inset-inline-start: -.5em;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .pgn__form-control-floating-label-text {

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -188,8 +188,6 @@ $select-icon-padding: .5625rem !default;
     position: relative;
     inset-inline-start: -.5em;
     max-width: 100%;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .pgn__form-control-floating-label-text {


### PR DESCRIPTION
## Description

Fix expanding of floating label in the `Form.Control`.

### Deploy Preview

https://deploy-preview-1605--paragon-openedx.netlify.app/components/form/form-control/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
