### PR TITLE
[BD-46] fix: update styles for Chip

### DIFF
--- a/src/Chip/_variables.scss
+++ b/src/Chip/_variables.scss
@@ -1,6 +1,6 @@
 $chip-padding-x:                    .5rem !default;
 $chip-padding-y:                    .125rem !default;
-$chip-padding-to-icon:              .125rem !default;
+$chip-padding-to-icon:              3px !default;
 $chip-icon-padding:                 .25rem !default;
 $chip-margin:                       .125rem !default;
 $chip-border-radius:                .25rem !default;


### PR DESCRIPTION
## Description

Increase left and right paddings for label.

### Deploy Preview

https://deploy-preview-1606--paragon-openedx.netlify.app/components/chip/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
