### PR TITLE
feat: Export common SCSS variables as CSS variables

### DIFF
--- a/scss/core/_functions.scss
+++ b/scss/core/_functions.scss
@@ -33,3 +33,26 @@
 
   @return $base-color;
 }
+
+
+//
+// Constructs a valid css property name from a bootstrap sass variable name.
+//
+// Sass allows variable names like $spacer-2\.5 however this is not allowed for
+// CSS custom properties. This function automatically constructs a CSS custom
+// property name from a sass variable name.
+// It also takes an option prefix to append to the name.
+// Eg:
+//   css-prop-name(1\.5, "spacer") -> --pgn-spacer-1p5
+//   css-prop-name(1\.5, "spacer") -> --pgn-spacer-1p5
+@function css-prop-name($var-name, $prefix: "") {
+  $prefix: "--pgn-" + $prefix + "-";
+  $str: $prefix + #{$var-name};
+  $pt-idx: str-index($str, "\\.");
+
+  @if $pt-idx {
+    @return str-slice($str, 1, $pt-idx - 1) + "p" + str-slice($str, $pt-idx + 2);
+  }
+
+  @return $str;
+}

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -17,6 +17,7 @@ $gray-800: #333333 !default;
 $gray-900: #212529 !default;
 $black:    #000000 !default;
 
+
 $grays: () !default;
 $grays: map-merge(
   (
@@ -784,6 +785,40 @@ $table-caption-color:         $text-muted !default;
 $table-border-color:          $border-color !default;
 $table-th-font-weight:        null !default;
 
+$font-sizes: () !default;
+$font-sizes: map-merge(
+  (
+    "base": $font-size-base,
+    "lg": $font-size-lg,
+    "xs": $font-size-xs,
+    "h1": $h1-font-size,
+    "h2": $h2-font-size,
+    "h3": $h3-font-size,
+    "h4": $h4-font-size,
+    "h5": $h5-font-size,
+    "h6": $h6-font-size,
+    "small": $small-font-size,
+    "x-small": $x-small-font-size,
+    "micro": $micro-font-size,
+  ),
+  $font-sizes
+);
+
+$font-weights: () !default;
+$font-weights: map-merge(
+  (
+    "base": $font-weight-base,
+    "lighter": $font-weight-lighter,
+    "light": $font-weight-light,
+    "normal": $font-weight-normal,
+    "semi-bold": $font-weight-semi-bold,
+    "bold": $font-weight-bold,
+    "bolder": $font-weight-bolder,
+  ),
+  $font-weights
+);
+
+
 // Z-index master list
 //
 // Warning: Avoid customizing these values. They're used for a bird's eye view
@@ -873,3 +908,37 @@ $list-group-action-hover-color:     $list-group-action-color !default;
 
 $list-group-action-active-color:    $body-color !default;
 $list-group-action-active-bg:       $gray-200 !default;
+
+:root {
+  @each $color, $value in $colors {
+    --pgn-color-#{$color}: #{$value};
+  }
+
+  @each $color, $value in $theme-colors {
+    --pgn-color-#{$color}: #{$value};
+  }
+
+  @each $color, $value in $theme-color-levels {
+    --pgn-color-#{$color}: #{$value};
+  }
+
+  @each $color, $value in $element-color-levels {
+    --pgn-color-#{$color}: #{$value};
+  }
+
+  @each $size, $length in $spacers {
+    --png-spacer-#{$size}: #{$length};
+  }
+
+  @each $size, $value in $font-sizes {
+    --pgn-font-size-#{$size}: #{$value};
+  }
+
+  @each $weight, $value in $font-sizes {
+    --pgn-font-weight-#{$weight}: #{$value};
+  }
+
+  --pgn-box-shadow-sm: #{$box-shadow-sm};
+  --pgn-box-shadow: #{$box-shadow};
+  --pgn-box-shadow-lg: #{$box-shadow-lg};
+}

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -909,33 +909,34 @@ $list-group-action-hover-color:     $list-group-action-color !default;
 $list-group-action-active-color:    $body-color !default;
 $list-group-action-active-bg:       $gray-200 !default;
 
+
 :root {
   @each $color, $value in $colors {
-    --pgn-color-#{$color}: #{$value};
+    #{css-prop-name($color, "color")}: #{$value};
   }
 
   @each $color, $value in $theme-colors {
-    --pgn-color-#{$color}: #{$value};
+    #{css-prop-name($color, "color")}: #{$value};
   }
 
   @each $color, $value in $theme-color-levels {
-    --pgn-color-#{$color}: #{$value};
+    #{css-prop-name($color, "color")}: #{$value};
   }
 
   @each $color, $value in $element-color-levels {
-    --pgn-color-#{$color}: #{$value};
+    #{css-prop-name($color, "color")}: #{$value};
   }
 
   @each $size, $length in $spacers {
-    --png-spacer-#{$size}: #{$length};
+    #{css-prop-name($size, "spacer")}: #{$length};
   }
 
   @each $size, $value in $font-sizes {
-    --pgn-font-size-#{$size}: #{$value};
+    #{css-prop-name($size, "font-size")}: #{$value};
   }
 
   @each $weight, $value in $font-sizes {
-    --pgn-font-weight-#{$weight}: #{$value};
+    #{css-prop-name($weight, "font-weight")}: #{$value};
   }
 
   --pgn-box-shadow-sm: #{$box-shadow-sm};


### PR DESCRIPTION
## Description

This commit exports commonly-used SCSS variables as CSS variables as well so
that they can be used by MFEs, or other consumers of Paragon, without needing to
be rebuilt each time a theme variable changes.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
