### PR TITLE
[BD-46] feat: truncate v2 supports inner tags

### DIFF
--- a/src/Truncate/README.md
+++ b/src/Truncate/README.md
@@ -85,7 +85,7 @@ A Truncate component can help you crop multiline text. There will be three dots 
 
 ```jsx live
 <Truncate lines={1}>
-  <a href="#">Learners</a>, course teams, researchers, developers: the edX community includes groups with a range of reasons 
-  for using the <b>platform</b> and objectives to accomplish.
+  <a href="#">Learners</a>, course teams, researchers, developers: the edX community includes <strong>groups with a range of reasons</strong>
+  for using the platform and objectives to accomplish.
 </Truncate>
 ```

--- a/src/Truncate/README.md
+++ b/src/Truncate/README.md
@@ -85,7 +85,6 @@ A Truncate component can help you crop multiline text. There will be three dots 
 
 ```jsx live
 <Truncate lines={1}>
-  <a href="#">Learners</a>, course teams, researchers, developers: the edX community includes <strong>groups with a range of reasons</strong>
-  for using the platform and objectives to accomplish.
+  <a href="#">Learners</a>, course teams, researchers, developers: the edX community includes <strong>groups with a range of reasons</strong> for using the platform and objectives to accomplish.
 </Truncate>
 ```

--- a/src/Truncate/README.md
+++ b/src/Truncate/README.md
@@ -10,7 +10,7 @@ devStatus: 'Done'
 
 A Truncate component can help you crop multiline text. There will be three dots at the end of the text.
 
-### Basic Usage
+## Basic Usage
 
 ```jsx live
   <Truncate lines={2}>
@@ -79,4 +79,13 @@ A Truncate component can help you crop multiline text. There will be three dots 
     </Card>
   )
 }
+```
+
+### HTML markdown support
+
+```jsx live
+<Truncate lines={1}>
+  <a href="#">Learners</a>, course teams, researchers, developers: the edX community includes groups with a range of reasons 
+  for using the <b>platform</b> and objectives to accomplish.
+</Truncate>
 ```

--- a/src/Truncate/Truncate.test.js
+++ b/src/Truncate/Truncate.test.js
@@ -1,4 +1,16 @@
-import { constructString, cropText, truncateLines } from './utils';
+import { constructChildren, cropText, truncateLines } from './utils';
+
+const createElementMock = {
+  parentNode: {
+    removeChild: () => {},
+  },
+  scrollHeight: 220,
+  setAttribute: () => {},
+  appendChild: () => {},
+  set innerHTML(val) {
+    this.scrollHeight -= 60;
+  },
+};
 
 describe('utils', () => {
   describe('cropText', () => {
@@ -10,12 +22,12 @@ describe('utils', () => {
     });
   });
 
-  describe('constructString', () => {
+  describe('constructChildren', () => {
     it('return new string text after constructed', () => {
       const string = 'Learners, course teams, researchers, developers';
       const whiteSpace = true;
       const ellipsis = '...';
-      const finalString = constructString(string, whiteSpace, ellipsis);
+      const finalString = constructChildren(string, whiteSpace, ellipsis);
       expect(finalString[0].textContent).toEqual('Learners, course teams, researchers, developers ...');
     });
     it('return new string text after constructed', () => {
@@ -30,7 +42,7 @@ describe('utils', () => {
           type: 'a', props: { href: 'https://test.com', children: 'test' }, start: 10, end: 47,
         },
       ];
-      const finalString = constructString(string, whiteSpace, ellipsis, childrenData);
+      const finalString = constructChildren(string, whiteSpace, ellipsis, childrenData);
       expect(finalString.length).toEqual(3);
     });
   });
@@ -38,17 +50,7 @@ describe('utils', () => {
   describe('truncateLines', () => {
     it('returned truncate lines', () => {
       const element = document.createElement('div');
-      jest.spyOn(document, 'createElement').mockReturnValue({
-        parentNode: {
-          removeChild: () => {},
-        },
-        scrollHeight: 220,
-        setAttribute: () => {},
-        appendChild: () => {},
-        set innerHTML(val) {
-          this.scrollHeight -= 60;
-        },
-      });
+      jest.spyOn(document, 'createElement').mockReturnValue(createElementMock);
 
       const text = 'Learners, course teams, researchers, developers: the edX community includes groups with '
         + 'a range of reasons for using the platform and objectives to accomplish.';
@@ -61,6 +63,27 @@ describe('utils', () => {
         ellipsis,
       })[0].textContent).toEqual('Learners, course teams, researchers, developers: the edX community'
         + ' includes groups with a range of reasons for using the platform and objectives to accomp___');
+    });
+    it('truncate text with inner tags', () => {
+      const element = document.createElement('div');
+      jest.spyOn(document, 'createElement').mockReturnValue(createElementMock);
+
+      const text = [
+        { type: 'a', props: { children: 'Learners', href: '#' } },
+        ' course teams, researchers, developers: the edX community includes groups with',
+        {
+          type: 'strong',
+          props: { children: ' a range of reasons for using the platform and objectives to accomplish.' },
+        },
+      ];
+      const lines = 2;
+      const whiteSpace = false;
+      const ellipsis = '___';
+      expect(truncateLines(text, element, {
+        lines,
+        whiteSpace,
+        ellipsis,
+      }).length).toEqual(4);
     });
   });
 });

--- a/src/Truncate/Truncate.test.js
+++ b/src/Truncate/Truncate.test.js
@@ -16,7 +16,22 @@ describe('utils', () => {
       const whiteSpace = true;
       const ellipsis = '...';
       const finalString = constructString(string, whiteSpace, ellipsis);
-      expect(finalString).toEqual('Learners, course teams, researchers, developers ...');
+      expect(finalString[0].textContent).toEqual('Learners, course teams, researchers, developers ...');
+    });
+    it('return new string text after constructed', () => {
+      const string = 'Learners, course teams, researchers, developers';
+      const whiteSpace = true;
+      const ellipsis = '...';
+      const childrenData = [
+        {
+          type: null, props: undefined, start: 0, end: 10,
+        },
+        {
+          type: 'a', props: { href: 'https://test.com', children: 'test' }, start: 10, end: 47,
+        },
+      ];
+      const finalString = constructString(string, whiteSpace, ellipsis, childrenData);
+      expect(finalString.length).toEqual(3);
     });
   });
 
@@ -29,6 +44,7 @@ describe('utils', () => {
         },
         scrollHeight: 220,
         setAttribute: () => {},
+        appendChild: () => {},
         set innerHTML(val) {
           this.scrollHeight -= 60;
         },
@@ -43,8 +59,8 @@ describe('utils', () => {
         lines,
         whiteSpace,
         ellipsis,
-      })).toEqual('Learners, course teams, researchers, developers: the edX community includes groups with a range of '
-        + 'reasons for using the platform and objectives to accompl___');
+      })[0].textContent).toEqual('Learners, course teams, researchers, developers: the edX community'
+        + ' includes groups with a range of reasons for using the platform and objectives to accomp___');
     });
   });
 });

--- a/src/Truncate/Truncate.test.js
+++ b/src/Truncate/Truncate.test.js
@@ -6,6 +6,7 @@ const createElementMock = {
   },
   scrollHeight: 220,
   setAttribute: () => {},
+  append: () => {},
   appendChild: () => {},
   set innerHTML(val) {
     this.scrollHeight -= 60;
@@ -83,7 +84,7 @@ describe('utils', () => {
         lines,
         whiteSpace,
         ellipsis,
-      }).length).toEqual(4);
+      }).length).toEqual(3);
     });
   });
 });

--- a/src/Truncate/index.jsx
+++ b/src/Truncate/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useLayoutEffect, useRef, useState,
+  useLayoutEffect, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import { truncateLines } from './utils';
@@ -12,7 +12,6 @@ const DEFAULT_TRUNCATE_ELEMENT_TYPE = 'div';
 function Truncate({
   children, lines, ellipsis, elementType, className, whiteSpace, onTruncate,
 }) {
-  const [truncateText, setTruncateText] = useState('');
   const textContainer = useRef();
   const { width } = useWindowSize();
 
@@ -22,16 +21,20 @@ function Truncate({
       whiteSpace,
       lines,
     });
-    setTruncateText(newTruncateText);
+
+    textContainer.current.innerHTML = '';
+    newTruncateText.forEach(el => {
+      textContainer.current.appendChild(el);
+    });
     if (onTruncate) {
-      onTruncate(truncateText);
+      onTruncate(newTruncateText);
     }
-  }, [children, ellipsis, lines, onTruncate, truncateText, whiteSpace, width]);
+  }, [children, ellipsis, lines, onTruncate, whiteSpace, width]);
 
   return React.createElement(elementType, {
     ref: textContainer,
     className,
-  }, truncateText);
+  });
 }
 
 Truncate.propTypes = {

--- a/src/Truncate/index.jsx
+++ b/src/Truncate/index.jsx
@@ -16,18 +16,19 @@ function Truncate({
   const { width } = useWindowSize();
 
   useLayoutEffect(() => {
-    const newTruncateText = truncateLines(children, textContainer.current, {
-      ellipsis,
-      whiteSpace,
-      lines,
-    });
-
-    textContainer.current.innerHTML = '';
-    newTruncateText.forEach(el => {
-      textContainer.current.appendChild(el);
-    });
-    if (onTruncate) {
-      onTruncate(newTruncateText);
+    if (textContainer.current) {
+      const newTruncateText = truncateLines(children, textContainer.current, {
+        ellipsis,
+        whiteSpace,
+        lines,
+      });
+      textContainer.current.innerHTML = '';
+      newTruncateText.forEach(el => {
+        textContainer.current.appendChild(el);
+      });
+      if (onTruncate) {
+        onTruncate(newTruncateText);
+      }
     }
   }, [children, ellipsis, lines, onTruncate, whiteSpace, width]);
 

--- a/src/Truncate/utils.js
+++ b/src/Truncate/utils.js
@@ -12,12 +12,13 @@ const createCopyElement = (element) => {
 
 const constructString = (text, whiteSpace, ellipsis, childrenData = []) => {
   const spacer = whiteSpace ? ' ' : '';
+  const contentEnd = `${spacer}${ellipsis}`;
   if (childrenData.length) {
     const newChildren = [];
     childrenData.forEach((el, index) => {
       let content = text.slice(el.start, el.end);
       if (index === childrenData.length - 1) {
-        content = content.trim();
+        content = content.trimEnd();
       }
       if (el.type) {
         const element = document.createElement(el.type);
@@ -33,10 +34,10 @@ const constructString = (text, whiteSpace, ellipsis, childrenData = []) => {
       }
       newChildren.push(document.createTextNode(content));
     });
-    newChildren.push(document.createTextNode(`${spacer}${ellipsis}`));
+    newChildren.push(document.createTextNode(contentEnd));
     return newChildren;
   }
-  return [document.createTextNode(`${text.trim()}${spacer}${ellipsis}`)];
+  return [document.createTextNode(`${text.trim()}${contentEnd}`)];
 };
 
 const cropText = (text, cropDecrement) => {

--- a/src/Truncate/utils.js
+++ b/src/Truncate/utils.js
@@ -10,9 +10,33 @@ const createCopyElement = (element) => {
   return newElement;
 };
 
-const constructString = (text, whiteSpace, ellipsis) => {
+const constructString = (text, whiteSpace, ellipsis, childrenData = []) => {
   const spacer = whiteSpace ? ' ' : '';
-  return `${text.trim()}${spacer}${ellipsis}`;
+  if (childrenData.length) {
+    const newChildren = [];
+    childrenData.forEach((el, index) => {
+      let content = text.slice(el.start, el.end);
+      if (index === childrenData.length - 1) {
+        content = content.trim();
+      }
+      if (el.type) {
+        const element = document.createElement(el.type);
+        element.appendChild(document.createTextNode(content));
+        Object.keys(el.props || {}).forEach(prop => {
+          if (prop === 'children') {
+            return;
+          }
+          element.setAttribute(prop, el.props[prop]);
+        });
+        newChildren.push(element);
+        return;
+      }
+      newChildren.push(document.createTextNode(content));
+    });
+    newChildren.push(document.createTextNode(`${spacer}${ellipsis}`));
+    return newChildren;
+  }
+  return [document.createTextNode(`${text.trim()}${spacer}${ellipsis}`)];
 };
 
 const cropText = (text, cropDecrement) => {
@@ -26,27 +50,49 @@ const cropText = (text, cropDecrement) => {
 const truncateLines = (text, element, { lines, whiteSpace, ellipsis }) => {
   const visibilityArea = LINE_HEIGHT_VALUE * Number(lines);
   const newElement = createCopyElement(element);
-  let truncateText = text;
+  const childrenData = [];
+  let initialText = '';
+  if (typeof text === 'string') {
+    initialText = text;
+  } else {
+    text.forEach(child => {
+      const isString = typeof child === 'string';
+      const start = initialText.length;
+      initialText += isString ? child : child.props.children;
+      const end = initialText.length;
+      childrenData.push({
+        type: isString ? null : child.type, props: child?.props, start, end,
+      });
+    });
+  }
+  let truncateText = initialText;
   let cropDecrement = 1;
 
   element.append(newElement);
-  newElement.innerHTML = constructString(text, whiteSpace, ellipsis);
+  const initialChildren = constructString(initialText, whiteSpace, ellipsis, childrenData);
+  for (let i = 0; i < initialChildren.length; i++) {
+    newElement.appendChild(initialChildren[i]);
+  }
   let newElementTextHeight = newElement.scrollHeight;
 
   if (visibilityArea >= newElementTextHeight) {
     newElement.parentNode.removeChild(newElement);
-    return truncateText;
+    return [document.createTextNode(truncateText)];
   }
 
   while (newElementTextHeight > visibilityArea) {
     cropDecrement -= CROP_DECREMENT_STEP;
-    truncateText = cropText(text, cropDecrement);
-    newElement.innerHTML = constructString(truncateText, whiteSpace, ellipsis);
+    truncateText = cropText(initialText, cropDecrement);
+    const childrenArray = constructString(truncateText, whiteSpace, ellipsis, childrenData);
+    newElement.innerHTML = '';
+    for (let i = 0; i < childrenArray.length; i++) {
+      newElement.appendChild(childrenArray[i]);
+    }
     newElementTextHeight = newElement.scrollHeight;
   }
 
   newElement.parentNode.removeChild(newElement);
-  return constructString(truncateText, whiteSpace, ellipsis);
+  return constructString(truncateText, whiteSpace, ellipsis, childrenData);
 };
 
 module.exports = {

--- a/src/Truncate/utils.js
+++ b/src/Truncate/utils.js
@@ -10,7 +10,7 @@ const createCopyElement = (element) => {
   return newElement;
 };
 
-const constructString = (text, whiteSpace, ellipsis, childrenData = []) => {
+const constructChildren = (text, whiteSpace = false, ellipsis = '', childrenData = []) => {
   const spacer = whiteSpace ? ' ' : '';
   const contentEnd = `${spacer}${ellipsis}`;
   if (childrenData.length) {
@@ -34,7 +34,9 @@ const constructString = (text, whiteSpace, ellipsis, childrenData = []) => {
       }
       newChildren.push(document.createTextNode(content));
     });
-    newChildren.push(document.createTextNode(contentEnd));
+    if (contentEnd) {
+      newChildren.push(document.createTextNode(contentEnd));
+    }
     return newChildren;
   }
   return [document.createTextNode(`${text.trim()}${contentEnd}`)];
@@ -70,7 +72,7 @@ const truncateLines = (text, element, { lines, whiteSpace, ellipsis }) => {
   let cropDecrement = 1;
 
   element.append(newElement);
-  const initialChildren = constructString(initialText, whiteSpace, ellipsis, childrenData);
+  const initialChildren = constructChildren(initialText, whiteSpace, ellipsis, childrenData);
   for (let i = 0; i < initialChildren.length; i++) {
     newElement.appendChild(initialChildren[i]);
   }
@@ -78,13 +80,13 @@ const truncateLines = (text, element, { lines, whiteSpace, ellipsis }) => {
 
   if (visibilityArea >= newElementTextHeight) {
     newElement.parentNode.removeChild(newElement);
-    return [document.createTextNode(truncateText)];
+    return constructChildren(truncateText, false, '', childrenData);
   }
 
   while (newElementTextHeight > visibilityArea) {
     cropDecrement -= CROP_DECREMENT_STEP;
     truncateText = cropText(initialText, cropDecrement);
-    const childrenArray = constructString(truncateText, whiteSpace, ellipsis, childrenData);
+    const childrenArray = constructChildren(truncateText, whiteSpace, ellipsis, childrenData);
     newElement.innerHTML = '';
     for (let i = 0; i < childrenArray.length; i++) {
       newElement.appendChild(childrenArray[i]);
@@ -93,12 +95,12 @@ const truncateLines = (text, element, { lines, whiteSpace, ellipsis }) => {
   }
 
   newElement.parentNode.removeChild(newElement);
-  return constructString(truncateText, whiteSpace, ellipsis, childrenData);
+  return constructChildren(truncateText, whiteSpace, ellipsis, childrenData);
 };
 
 module.exports = {
   cropText,
   truncateLines,
-  constructString,
+  constructChildren,
   createCopyElement,
 };


### PR DESCRIPTION
## Description

Add processing not only plain text but also inner tags

### Deploy Preview

https://deploy-preview-1642--paragon-openedx.netlify.app/components/truncate/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
