### PR TITLE
[BD-46] fix: remove body width jumping on open

### DIFF
--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -2,6 +2,10 @@
 @import "~bootstrap/scss/modal";
 @import "ModalDialog";
 
+.pgn__hidden-scroll-padding-right {
+  padding-right: 0;
+}
+
 .pgn__modal-layer {
   height: 100%;
   left: 0;

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { FocusOn } from 'react-focus-on';
@@ -41,6 +41,17 @@ ModalContentContainer.defaultProps = {
 function ModalLayer({
   children, onClose, isOpen, isBlocking, zIndex,
 }) {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add('pgn__hidden-scroll-padding-right');
+    } else {
+      document.body.classList.remove('pgn__hidden-scroll-padding-right');
+    }
+    return () => {
+      document.body.classList.remove('pgn__hidden-scroll-padding-right');
+    };
+  }, [isOpen]);
+
   if (!isOpen) {
     return null;
   }


### PR DESCRIPTION
## Description

Due to some reason `react-remove-scroll-bar` library (child of `react-focus-on`) adds `padding-right` on modal open that equals to the scroll bar width. But there is already `margin-right` that also equals the same value. As result the library adds 2x scrollbar width to the `body` that creates width jumping and unwanted behavior.
As fix I provided `className` that is added to the `body` on modal open and sets `padding-right` to `0px`.

### Deploy Preview

https://deploy-preview-1644--paragon-openedx.netlify.app/components/modal/marketing-modal/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
