### PR TITLE
[BD-46] docs: docs improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18449,12 +18449,12 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
@@ -21095,6 +21095,25 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/cheerio": {
+      "version": "0.22.31",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
+      "integrity": "sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/enzyme": {
+      "version": "3.10.12",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.12.tgz",
+      "integrity": "sha512-xryQlOEIe1TduDWAOphR0ihfebKFSWOXpIsk+70JskCfRfW+xALdnJ0r1ZOTo85F9Qsjk6vtlU7edTYHbls9tA==",
+      "dev": true,
+      "requires": {
+        "@types/cheerio": "*",
+        "@types/react": "*"
       }
     },
     "@types/eslint": {

--- a/src/Annotation/README.md
+++ b/src/Annotation/README.md
@@ -57,34 +57,38 @@ Display informative text related to an object on screen. Unlike the tooltip an a
 ## Referring to other elements
 
 ```jsx live
-<>
-  <div className="d-flex justify-content-around mb-4">
-    <div className="d-flex flex-column align-items-center">
-      <Annotation>
-        Annotation on top
-      </Annotation>
-      <Button>This is an example button</Button>
-    </div>
-    <div className="d-flex align-items-center">	
-      <Button>This is an example button</Button>
-      <Annotation arrowPlacement='left'>
-        Annotation on right
-      </Annotation>
-    </div>
-  </div>
-  <div className="d-flex justify-content-around">
-    <div className="d-flex align-items-center">
-      <Annotation arrowPlacement='right'>
-        Annotation on left
-      </Annotation>
-      <Button>This is an example button</Button>
-    </div>
-    <div className="d-flex flex-column align-items-center">
-      <Button>This is an example button</Button>
-      <Annotation arrowPlacement='top'>
-        Annotation on bottom
-      </Annotation>
-    </div>
-  </div>
-</>
+() => {
+  const [arrowPlacement, setArrowPlacement] = useState('left')
+  const wrapperClass = arrowPlacement === 'top' || arrowPlacement === 'bottom' ? 'flex-column' : '';
+  return (
+    <>
+      {/* start example form block */}
+      <ExamplePropsForm
+        inputs={[
+          { value: arrowPlacement, setValue: setArrowPlacement, options: [
+            { name: 'left', value: 'right' },
+            { name: 'top', value: 'bottom' },
+            { name: 'right', value: 'left' },
+            { name: 'bottom', value: 'top' }
+          ], name: 'arrowPlacement' },
+        ]}
+      />
+      {/* end example form block */}
+      <div className={`d-flex align-items-center justify-content-center ${wrapperClass}`}>
+        {(arrowPlacement === 'bottom' || arrowPlacement === 'right') && (
+          <Annotation arrowPlacement={arrowPlacement}>
+            Annotation on top
+          </Annotation>
+        )}
+        <Button>This is an example button</Button>
+        {(arrowPlacement === 'left' || arrowPlacement === 'top') && (
+          <Annotation arrowPlacement={arrowPlacement}>
+            Annotation on top
+          </Annotation>
+        )}
+      </div>
+    </>
+  )
+}
+
 ```

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -465,34 +465,14 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
   
   return (
     <>
-      {/* Example props form start */}
-      <Form.Group>
-        <Form.Label>Choose orientation</Form.Label>
-        <Form.RadioSet
-          name="orientation"
-          onChange={handleChangeOrientation}
-          value={orientation}
-        >
-          <Form.Radio value="vertical">Vertical</Form.Radio>
-          <Form.Radio value="horizontal">Horizontal</Form.Radio>
-        </Form.RadioSet>
-      </Form.Group>
-      <Form.Group>
-        <Form.Control
-          as="select"
-          name="variant"
-          onChange={handleChangeVariant}
-          value={variant}
-          floatingLabel="Variant"
-        >
-          <option value="">Select a variant</option>
-          <option value="primary">Primary</option>
-          <option value="warning">Warning</option>
-          <option value="danger">Danger</option>
-          <option value="success">Success</option>
-        </Form.Control>
-      </Form.Group>
-      {/* Example props form end */}
+      {/* start example form block */}
+      <ExamplePropsForm
+        inputs={[
+          { value: orientation, setValue: setOrientation, options: ['horizontal', 'vertical'], name: 'orientation' },
+          { value: variant, setValue: setVariant, options: ['primary', 'warning', 'danger', 'success'], name: 'variant' },
+        ]}
+      />
+      {/* end example form block */}
       
       <Card orientation={orientation} className={`flex-column ${isVertical ? 'w-50' : ''}`}>
         <Card.Header

--- a/src/Collapsible/README.md
+++ b/src/Collapsible/README.md
@@ -26,7 +26,7 @@ When to use:
 
 The `styling` prop at the top level `<Collapsible />` component determines if the collapsible has basic styling, card, or card with heading.
 
-### Basic Style `<Collapsible styling="basic" />`
+### Basic Style
 
 ```jsx live
 <Collapsible
@@ -37,41 +37,39 @@ The `styling` prop at the top level `<Collapsible />` component determines if th
 </Collapsible>
 ```
 
-### Card Style `<Collapsible styling="card" />`
+### Card Style
 
 This is the default style if no `styling` prop is supplied.
 
 ```jsx live
-<Collapsible
-  styling="card"
-  title={<p><strong>Toggle Collapsible</strong></p>}
->
-  <p>Your stuff goes here.</p>
-</Collapsible>
-```
-
-### Large Card Style `<Collapsible styling="card-lg" />`
-
-```jsx live
-<Collapsible
-  styling="card-lg"
-  title={<h4>Toggle Collapsible</h4>}
->
-  <p>Your stuff goes here.</p>
-</Collapsible>
-```
-
-### Card with custom icons `<Collapsible styling="card-lg" />`
-
-```jsx live
-<Collapsible
-  styling="card"
-  title={<p><strong>Toggle Collapsible</strong></p>}
-  iconWhenOpen={<span>CLOSE SESAME</span>}
-  iconWhenClosed={<span>OPEN SESAME</span>}
->
-  <p>Your stuff goes here.</p>
-</Collapsible>
+() => {
+  const [styling, setStyling] = useState('card');
+  const [withIcon, setWithIcon] = useState(false);
+  const iconProps = {
+    iconWhenOpen: <span>CLOSE SESAME</span>,
+    iconWhenClosed: <span>OPEN SESAME</span>,
+  };
+  
+  return (
+    <>
+      {/* start example form block */}
+      <ExamplePropsForm
+        inputs={[
+          { value: styling, setValue: setStyling, options: ['card', 'card-lg'], name: 'styling' },
+          { value: withIcon, setValue: () => setWithIcon(!withIcon), name: 'with icon' },
+        ]}
+      />
+      {/* end example form block */}
+      <Collapsible
+        styling={styling}
+        title={<p><strong>Toggle Collapsible</strong></p>}
+        {...withIcon ? iconProps : {}}
+      >
+        <p>Your stuff goes here.</p>
+      </Collapsible>
+    </>
+  );
+}
 ```
 
 ### Default Open

--- a/www/src/components/PropsTable.tsx
+++ b/www/src/components/PropsTable.tsx
@@ -93,7 +93,7 @@ export interface IPropsTable {
 const PropsTable = ({ props: componentProps, displayName, content }: IPropsTable) => (
   <Card className="mb-5" id={`props-api-table-${displayName}`}>
     <Card.Header as="h3" title={`${displayName} Props API`} className="pb-1" />
-    {content && <div className="small mb-3">{content}</div>}
+    {content && <p className="px-4 small">{content}</p>}
     {componentProps.length > 0 ? (
       <ul className="list-unstyled">
         {componentProps

--- a/www/src/components/Toc.tsx
+++ b/www/src/components/Toc.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 // @ts-ignore
 import { Sticky } from '~paragon-react'; // eslint-disable-line
 
@@ -12,10 +13,11 @@ interface IItems {
 export interface IToc {
   data: {
     items?: Array<IItems>
-  }
+  },
+  className?: string,
 }
 
-const Toc = ({ data }: IToc) => {
+const Toc = ({ data, className }: IToc) => {
   const generateTree = (headings: { items?: Array<IItems> }) => (headings?.items?.length
     ? (
       <ul className="pgn-doc__toc-list">
@@ -31,7 +33,10 @@ const Toc = ({ data }: IToc) => {
   const tocTree = generateTree(data);
 
   return tocTree ? (
-    <Sticky className="pgn-doc__toc">
+    <Sticky
+      offset={6}
+      className={classNames('pgn-doc__toc', className)}
+    >
       <p className="pgn-doc__toc-header">Contents</p>
       {tocTree}
     </Sticky>
@@ -49,6 +54,11 @@ Toc.propTypes = {
   data: PropTypes.shape({
     items: PropTypes.arrayOf(PropTypes.shape(itemsShape)),
   }).isRequired,
+  className: PropTypes.string,
+};
+
+Toc.defaultProps = {
+  className: undefined,
 };
 
 export default Toc;

--- a/www/src/components/exampleComponents/ExamplePropsForm.scss
+++ b/www/src/components/exampleComponents/ExamplePropsForm.scss
@@ -1,7 +1,7 @@
 .pgn-doc__example-props-form {
   background: $warning-100;
-  padding: 10px;
+  padding: map-get($spacers, 3) map-get($spacers, 3) 0 map-get($spacers, 3);
   border-radius: 10px;
   border: 2px dashed black;
-  margin-bottom: 10px;
+  margin-bottom: map-get($spacers, 3);
 }


### PR DESCRIPTION
## Description

- Add `ExamplePropsForm` for `Annotation`, `Card`, `Collapsible`
- Fix Table of Content
- Fix Props table text message padding

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
