### PR TITLE
[BD-46] feat: add Layout component

### DIFF
--- a/src/Layout/Layout.test.jsx
+++ b/src/Layout/Layout.test.jsx
@@ -5,11 +5,11 @@ import Layout from './index';
 function TestLayout(props) {
   return (
     <Layout
-      lg={{ span: [4, 4, 4], offset: [0, 0, 0] }}
-      md={{ span: ['auto', 'auto', 'auto'], offset: [0, 0, 0] }}
-      sm={{ span: [8, 4, 6], offset: [0, 0, 6] }}
-      xs={{ span: [4, 4, 4], offset: [0, 0, 0] }}
-      xl={{ span: [3, 6, 3] }}
+      lg={[{ span: 4, offset: 0 }, { span: 4, offset: 0 }, { span: 4, offset: 0 }]}
+      md={[{ span: 'auto', offset: 0 }, { span: 'auto', offset: 0 }, { span: 'auto', offset: 0 }]}
+      sm={[{ span: 8, offset: 0 }, { span: 4, offset: 0 }, { span: 6, offset: 6 }]}
+      xs={[{ span: 4, offset: 0 }, { span: 4, offset: 0 }, { span: 4, offset: 0 }]}
+      xl={[{ span: 3 }, { span: 6 }, { span: 3 }]}
       {...props}
     >
       <Layout.Element>first block</Layout.Element>
@@ -34,7 +34,7 @@ describe('<Layout />', () => {
       )).toEqual(true);
     });
     it('renders although dimensions are incorrect', () => {
-      const wrapper = mount(<TestLayout lg={{ span: [6, 6], offset: [0, 0] }} />);
+      const wrapper = mount(<TestLayout lg={[{ span: 6, offset: 0 }, { span: 6, offset: 0 }]} />);
       const children = wrapper.find('.row div');
       expect(children.length).not.toEqual(0);
     });

--- a/src/Layout/Layout.test.jsx
+++ b/src/Layout/Layout.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Layout from './index';
+
+function TestLayout(props) {
+  return (
+    <Layout
+      lg={{ span: [4, 4, 4], offset: [0, 0, 0] }}
+      md={{ span: ['auto', 'auto', 'auto'], offset: [0, 0, 0] }}
+      sm={{ span: [8, 4, 6], offset: [0, 0, 6] }}
+      xs={{ span: [4, 4, 4], offset: [0, 0, 0] }}
+      xl={{ span: [3, 6, 3] }}
+      {...props}
+    >
+      <Layout.Element>first block</Layout.Element>
+      <Layout.Element>second block</Layout.Element>
+      <Layout.Element>third block</Layout.Element>
+    </Layout>
+  );
+}
+
+describe('<Layout />', () => {
+  describe('correct rendering', () => {
+    it('renders correct number of children', () => {
+      const wrapper = mount(<TestLayout />);
+      const children = wrapper.find('.row div');
+      expect(children.length).toEqual(3);
+    });
+    it('renders correct number of children', () => {
+      const wrapper = mount(<TestLayout />);
+      const children = wrapper.find('.row div');
+      expect(children.at(0).hasClass(
+        'col-xl-3 col-lg-4 col-md-auto col-sm-8 col-4 offset-xl-0 offset-lg-0 offset-md-0 offset-sm-0 offset-0',
+      )).toEqual(true);
+    });
+    it('renders although dimensions are incorrect', () => {
+      const wrapper = mount(<TestLayout lg={{ span: [6, 6], offset: [0, 0] }} />);
+      const children = wrapper.find('.row div');
+      expect(children.length).not.toEqual(0);
+    });
+  });
+});

--- a/src/Layout/README.md
+++ b/src/Layout/README.md
@@ -16,11 +16,11 @@ A wrapper component that allows to control the size of child blocks on different
 
 ```jsx live
   <Layout
-    lg={{ span: [4, 4, 4], offset: [0, 0, 0] }}
-    md={{ span: ['auto', 'auto', 'auto'], offset: [0, 0, 0] }}
-    sm={{ span: [8, 4, 6], offset: [0, 0, 6] }}
-    xs={{ span: [4, 4, 4], offset: [0, 0, 0] }}
-    xl={{ span: [3, 6, 3] }}
+    lg={[{ span: 4, offset: 0 }, { span: 4, offset: 0 }, { span: 4, offset: 0 }]}
+    md={[{ span: 'auto', offset: 0 }, { span: 'auto', offset: 0 }, { span: 'auto', offset: 0 }]}
+    sm={[{ span: 8, offset: 0 }, { span: 4, offset: 0 }, { span: 6, offset: 6 }]}
+    xs={[{ span: 4, offset: 0 }, { span: 4, offset: 0 }, { span: 4, offset: 0 }]}
+    xl={[{ span: 3 }, { span: 6 }, { span: 3 }]}
   >
     <Layout.Element style={{ background: 'red' }}>first block</Layout.Element>
     <Layout.Element style={{ background: 'green' }}>second block</Layout.Element>

--- a/src/Layout/README.md
+++ b/src/Layout/README.md
@@ -1,0 +1,29 @@
+---
+title: 'Layout'
+type: 'component'
+components:
+- Layout
+categories:
+- Layout
+status: 'New'
+designStatus: 'Done'
+devStatus: 'Done'
+---
+
+A wrapper component that allows to control the size of child blocks on different screen sizes.
+
+## Basic usage
+
+```jsx live
+  <Layout
+    lg={{ span: [4, 4, 4], offset: [0, 0, 0] }}
+    md={{ span: ['auto', 'auto', 'auto'], offset: [0, 0, 0] }}
+    sm={{ span: [8, 4, 6], offset: [0, 0, 6] }}
+    xs={{ span: [4, 4, 4], offset: [0, 0, 0] }}
+    xl={{ span: [3, 6, 3] }}
+  >
+    <Layout.Element style={{ background: 'red' }}>first block</Layout.Element>
+    <Layout.Element style={{ background: 'green' }}>second block</Layout.Element>
+    <Layout.Element style={{ background: 'blue' }}>third block</Layout.Element>
+  </Layout>
+```

--- a/src/Layout/index.jsx
+++ b/src/Layout/index.jsx
@@ -17,18 +17,17 @@ const Layout = React.forwardRef(({ children, ...props }, ref) => {
   const layout = React.Children.map(children, (child, index) => {
     const newProps = { ...child.props };
     SIZES.forEach(size => {
-      const spanArray = props[size]?.span;
-      const offsetArray = props[size]?.offset;
+      const sizeProps = props[size];
+      const { span = 0, offset = 0 } = (sizeProps && sizeProps[index]) || {};
       if (errors[size] === undefined) {
         errors[size] = false;
-        if (!isValidDimensions(spanArray, childrenLength) || !isValidDimensions(offsetArray, childrenLength)) {
-          errors[size] = `Length of span and offset arrays for breakpoint ${size} must be equal to the number of children`;
+        if (!isValidDimensions(sizeProps, childrenLength)) {
+          errors[size] = `${size} prop accepts array which length must be equal to the number of children.`;
         }
       }
-      const sizeValue = (spanArray && spanArray[index]) || 0;
-      const offsetValue = (offsetArray && offsetArray[index]) || 0;
-      newProps[size] = { span: sizeValue, offset: offsetValue, ref: child.ref };
+      newProps[size] = { span, offset };
     });
+    newProps.ref = child.ref;
     return React.createElement(Col, newProps, child.props.children);
   });
 
@@ -56,26 +55,26 @@ Layout.defaultProps = {
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
-  xs: PropTypes.shape({
-    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
-    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
-  }),
-  sm: PropTypes.shape({
-    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
-    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
-  }),
-  md: PropTypes.shape({
-    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
-    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
-  }),
-  lg: PropTypes.shape({
-    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
-    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
-  }),
-  xl: PropTypes.shape({
-    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
-    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
-  }),
+  xs: PropTypes.arrayOf(PropTypes.shape({
+    span: PropTypes.oneOf(COL_VALUES).isRequired,
+    offset: PropTypes.oneOf(COL_VALUES),
+  })),
+  sm: PropTypes.arrayOf(PropTypes.shape({
+    span: PropTypes.oneOf(COL_VALUES).isRequired,
+    offset: PropTypes.oneOf(COL_VALUES),
+  })),
+  md: PropTypes.arrayOf(PropTypes.shape({
+    span: PropTypes.oneOf(COL_VALUES).isRequired,
+    offset: PropTypes.oneOf(COL_VALUES),
+  })),
+  lg: PropTypes.arrayOf(PropTypes.shape({
+    span: PropTypes.oneOf(COL_VALUES).isRequired,
+    offset: PropTypes.oneOf(COL_VALUES),
+  })),
+  xl: PropTypes.arrayOf(PropTypes.shape({
+    span: PropTypes.oneOf(COL_VALUES).isRequired,
+    offset: PropTypes.oneOf(COL_VALUES),
+  })),
 };
 
 const sizeDefaultProps = { span: [], offset: [] };

--- a/src/Layout/index.jsx
+++ b/src/Layout/index.jsx
@@ -1,2 +1,93 @@
-export { default as Col } from 'react-bootstrap/Col';
-export { default as Row } from 'react-bootstrap/Row';
+import React from 'react';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import PropTypes from 'prop-types';
+
+const COL_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 'auto'];
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+const LayoutElement = React.forwardRef((props, ref) => <div ref={ref} {...props} />);
+
+const Layout = React.forwardRef(({ children, ...props }, ref) => {
+  const childrenLength = children.length;
+
+  const isValidDimensions = (dataList, validLength) => !dataList || dataList.length === validLength;
+  const errors = {};
+
+  const layout = React.Children.map(children, (child, index) => {
+    const newProps = { ...child.props };
+    SIZES.forEach(size => {
+      const spanArray = props[size]?.span;
+      const offsetArray = props[size]?.offset;
+      if (errors[size] === undefined) {
+        errors[size] = false;
+        if (!isValidDimensions(spanArray, childrenLength) || !isValidDimensions(offsetArray, childrenLength)) {
+          errors[size] = `Length of span and offset arrays for breakpoint ${size} must be equal to the number of children`;
+        }
+      }
+      const sizeValue = (spanArray && spanArray[index]) || 0;
+      const offsetValue = (offsetArray && offsetArray[index]) || 0;
+      newProps[size] = { span: sizeValue, offset: offsetValue, ref: child.ref };
+    });
+    return React.createElement(Col, newProps, child.props.children);
+  });
+
+  Object.keys(errors).forEach(breakpoint => {
+    if (errors[breakpoint]) {
+      // eslint-disable-next-line no-console
+      console.error(errors[breakpoint]);
+    }
+  });
+
+  return (
+    <Row ref={ref}>
+      {layout}
+    </Row>
+  );
+});
+
+Layout.defaultProps = {
+  xs: undefined,
+  sm: undefined,
+  md: undefined,
+  lg: undefined,
+  xl: undefined,
+};
+
+Layout.propTypes = {
+  children: PropTypes.node.isRequired,
+  xs: PropTypes.shape({
+    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
+    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
+  }),
+  sm: PropTypes.shape({
+    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
+    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
+  }),
+  md: PropTypes.shape({
+    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
+    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
+  }),
+  lg: PropTypes.shape({
+    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
+    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
+  }),
+  xl: PropTypes.shape({
+    span: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)).isRequired,
+    offset: PropTypes.arrayOf(PropTypes.oneOf(COL_VALUES)),
+  }),
+};
+
+const sizeDefaultProps = { span: [], offset: [] };
+
+SIZES.forEach(size => {
+  // eslint-disable-next-line react/default-props-match-prop-types
+  Layout.defaultProps[size] = sizeDefaultProps;
+});
+
+export {
+  Col,
+  Row,
+};
+Layout.Element = LayoutElement;
+export default Layout;

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export { default as CheckBoxGroup } from './CheckBoxGroup';
 export { default as Chip } from './Chip';
 export { default as CloseButton } from './CloseButton';
 export { default as Container } from './Container';
-export { Col, Row } from './Layout';
+export { default as Layout, Col, Row } from './Layout';
 export { default as Collapse } from './Collapse';
 export { default as Collapsible } from './Collapsible';
 export { default as Scrollable } from './Scrollable';


### PR DESCRIPTION
## Description

Add `Layout` component that is wrapper for `Row` and `Col` from `react-bootstrap`. It provides interface to pass all breakpoints data to the `Layout` instead of to each component separately.

### Deploy Preview

https://deploy-preview-1659--paragon-openedx.netlify.app/components/layout/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
