### PR TITLE
fix: fixes the direction of product tour button for RTL #1634

### DIFF
--- a/src/ProductTour/Checkpoint.scss
+++ b/src/ProductTour/Checkpoint.scss
@@ -24,6 +24,9 @@ $checkpoint-arrow-transparent: solid $checkpoint-arrow-width transparent;
     justify-content: flex-end;
   }
 
+  [dir="rtl"] .pgn__checkpoint-action-row{
+    justify-content: flex-start;
+}
   #pgn__checkpoint-arrow,
   #pgn__checkpoint-arrow::before,
   #pgn__checkpoint-arrow::after {


### PR DESCRIPTION

## Description

  This propose a fix for #1634 issue 1.
  It just simply add a new CSS/SCSS for RTL, to use flex-start

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
