### PR TITLE
chore: add test and example for button

### DIFF
--- a/src/Button/Button.test.jsx
+++ b/src/Button/Button.test.jsx
@@ -36,5 +36,40 @@ describe('<Button />', () => {
       )).toJSON();
       expect(tree).toMatchSnapshot();
     });
+    describe('renders as a link', () => {
+      test('with href', () => {
+        const tree = renderer.create((
+          <Button href="https://edx.org">Button</Button>
+        )).toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+      test('disable with href', () => {
+        const tree = renderer.create((
+          <Button as="a" href="https://edx.org" disabled>Button</Button>
+        )).toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+      test('cannot click if disabled', () => {
+        const onClick = jest.fn();
+        const wrapper = mount((
+          <Button as="a" href="https://edx.org" disabled onClick={onClick}>Button</Button>
+        ));
+        wrapper.simulate('click');
+        expect(onClick).not.toHaveBeenCalled();
+      });
+      test('invalid disabled if without href', () => {
+        const onClick = jest.fn();
+        const noHref = mount((
+          <Button as="a" disabled onClick={onClick}>Button</Button>
+        ));
+        noHref.simulate('click');
+        expect(onClick).toHaveBeenCalled();
+        const emptyHref = mount((
+          <Button as="a" href="" disabled onClick={onClick}>Button</Button>
+        ));
+        emptyHref.simulate('click');
+        expect(onClick).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -107,6 +107,25 @@ Use inline size buttons for when a button sits with a line of text.
 </>
 ```
 
+### Disabled
+
+```jsx live
+<>
+  <Button variant="primary" disabled>Primary disabled</Button>
+  <Button variant="secondary" disabled>Secondary disabled</Button>
+  <Button as="a" href="https://edx.org" disabled>Link disabled</Button>
+</>
+```
+
+For link to be `disabled`, it must have href defined with some value.
+
+```jsx live
+<>
+  <Button as='a' disabled>No href</Button>
+  <Button as='a' href='' disabled>Empty string href</Button>
+</>
+```
+
 ### With Icons before or after
 ```jsx live
 <>

--- a/src/Button/__snapshots__/Button.test.jsx.snap
+++ b/src/Button/__snapshots__/Button.test.jsx.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Button /> correct rendering renders as a link disable with href 1`] = `
+<a
+  aria-disabled={true}
+  className="btn btn-primary disabled"
+  href="https://edx.org"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  tabIndex={-1}
+>
+  Button
+</a>
+`;
+
+exports[`<Button /> correct rendering renders as a link with href 1`] = `
+<a
+  className="btn btn-primary"
+  href="https://edx.org"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+>
+  Button
+</a>
+`;
+
 exports[`<Button /> correct rendering renders with props iconAfter 1`] = `
 <button
   className="btn btn-primary"


### PR DESCRIPTION
## Description

- add unit test to Button
- add example for disable Button 
<img width="827" alt="Screen Shot 2022-10-07 at 3 03 46 PM" src="https://user-images.githubusercontent.com/83240113/194635851-a1e1d275-3e7c-4c49-9a12-90adf692c85a.png">


### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
