### PR TITLE
[BD-46] feat: Resolved annotation placement message

### DIFF
--- a/src/Annotation/README.md
+++ b/src/Annotation/README.md
@@ -74,19 +74,29 @@ Display informative text related to an object on screen. Unlike the tooltip an a
         ]}
       />
       {/* end example form block */}
-      <div className={`d-flex align-items-center justify-content-center ${wrapperClass}`}>
-        {(arrowPlacement === 'bottom' || arrowPlacement === 'right') && (
-          <Annotation arrowPlacement={arrowPlacement}>
-            Annotation on top
-          </Annotation>
-        )}
-        <Button>This is an example button</Button>
-        {(arrowPlacement === 'left' || arrowPlacement === 'top') && (
-          <Annotation arrowPlacement={arrowPlacement}>
-            Annotation on top
-          </Annotation>
-        )}
-      </div>
+        <div className={`d-flex align-items-center justify-content-center ${wrapperClass}`}>
+            {(arrowPlacement === 'bottom') && (
+                <Annotation arrowPlacement={arrowPlacement}>
+                    Annotation on top
+                </Annotation>
+            )}
+            {(arrowPlacement === 'right') && (
+                <Annotation arrowPlacement={arrowPlacement}>
+                    Annotation on left
+                </Annotation>
+            )}
+            <Button>This is an example button</Button>
+            {(arrowPlacement === 'left') && (
+                <Annotation arrowPlacement={arrowPlacement}>
+                    Annotation on right
+                </Annotation>
+            )}
+            {(arrowPlacement === 'top') && (
+                <Annotation arrowPlacement={arrowPlacement}>
+                    Annotation on bottom
+                </Annotation>
+            )}
+        </div>
     </>
   )
 }


### PR DESCRIPTION
## Description

- in the [example](https://paragon-openedx.netlify.app/components/annotation/#referring-to-other-elements) on the docs site the contents of Annotation should change depending on the `arrowPlacement` prop.

Github issue - https://github.com/openedx/paragon/issues/1667

### Deploy Preview

[Annotation component page](https://deploy-preview-1681--paragon-openedx.netlify.app/components/annotation/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
