### PR TITLE
[BD-46] feat: Added fallback props to Card component

### DIFF
--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -22,7 +22,6 @@ const CardImageCap = React.forwardRef(({
   className,
 }, ref) => {
   const { orientation, isLoading } = useContext(CardContext);
-  const [errorFlag, setErrorFlag] = useState(true);
   const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
 
   if (isLoading) {
@@ -45,11 +44,10 @@ const CardImageCap = React.forwardRef(({
     );
   }
 
-  const hasFallbackSrc = (currentTarget, altSrc) => {
-    if (errorFlag) {
-      // This flag breaks the infinite loop if the fallback source src fails.
-      setErrorFlag(false);
-      currentTarget.src = altSrc; // eslint-disable-line no-param-reassign
+  const handleSrcFallback = (currentTarget, altSrc) => {
+    const tagImg = currentTarget;
+    if (tagImg.src !== altSrc) {
+      tagImg.src = altSrc;
     }
   };
 
@@ -58,18 +56,17 @@ const CardImageCap = React.forwardRef(({
       <img
         className="pgn__card-image-cap"
         src={src}
-        onError={(e) => hasFallbackSrc(e.currentTarget, fallbackSrc)}
+        onError={(e) => handleSrcFallback(e.currentTarget, fallbackSrc)}
         alt={srcAlt}
       />
-      {!!logoSrc
-          && (
-          <img
-            className="pgn__card-logo-cap"
-            src={logoSrc}
-            onError={(e) => hasFallbackSrc(e.currentTarget, fallbackLogoSrc)}
-            alt={logoAlt}
-          />
-          )}
+      {!!logoSrc && (
+        <img
+          className="pgn__card-logo-cap"
+          src={logoSrc}
+          onError={(e) => handleSrcFallback(e.currentTarget, fallbackLogoSrc)}
+          alt={logoAlt}
+        />
+      )}
     </div>
   );
 });

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -45,9 +45,8 @@ const CardImageCap = React.forwardRef(({
   }
 
   const handleSrcFallback = (currentTarget, altSrc) => {
-    const tagImg = currentTarget;
-    if (tagImg.src !== altSrc) {
-      tagImg.src = altSrc;
+    if (currentTarget.src !== altSrc) {
+      currentTarget.src = altSrc;
     }
   };
 

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -26,7 +26,7 @@ const CardImageCap = React.forwardRef(({
 
   if (isLoading) {
     return (
-      <div className={classNames(className, wrapperClassName)}>
+      <div className={classNames(className, wrapperClassName)} data-testid="image-loader-wrapper">
         <Skeleton
           containerClassName="pgn__card-image-cap-loader"
           height={skeletonHeight}
@@ -44,7 +44,8 @@ const CardImageCap = React.forwardRef(({
     );
   }
 
-  const handleSrcFallback = (currentTarget, altSrc) => {
+  const handleSrcFallback = (event, altSrc) => {
+    const { currentTarget } = event;
     if (currentTarget.src !== altSrc) {
       currentTarget.src = altSrc;
     }
@@ -55,14 +56,14 @@ const CardImageCap = React.forwardRef(({
       <img
         className="pgn__card-image-cap"
         src={src}
-        onError={(e) => handleSrcFallback(e.currentTarget, fallbackSrc)}
+        onError={(event) => handleSrcFallback(event, fallbackSrc)}
         alt={srcAlt}
       />
       {!!logoSrc && (
         <img
           className="pgn__card-logo-cap"
           src={logoSrc}
-          onError={(e) => handleSrcFallback(e.currentTarget, fallbackLogoSrc)}
+          onError={(event) => handleSrcFallback(event, fallbackLogoSrc)}
           alt={logoAlt}
         />
       )}

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -9,8 +9,10 @@ const LOGO_SKELETON_HEIGHT_VALUE = 41;
 
 const CardImageCap = React.forwardRef(({
   src,
+  fallbackSrc,
   srcAlt,
   logoSrc,
+  fallbackLogoSrc,
   logoAlt,
   skeletonHeight,
   skeletonWidth,
@@ -20,6 +22,7 @@ const CardImageCap = React.forwardRef(({
   className,
 }, ref) => {
   const { orientation, isLoading } = useContext(CardContext);
+  const [errorFlag, setErrorFlag] = useState(true);
   const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
 
   if (isLoading) {
@@ -42,10 +45,31 @@ const CardImageCap = React.forwardRef(({
     );
   }
 
+  const hasFallbackSrc = (currentTarget, altSrc) => {
+    if (errorFlag) {
+      // This flag breaks the infinite loop if the fallback source src fails.
+      setErrorFlag(false);
+      currentTarget.src = altSrc; // eslint-disable-line no-param-reassign
+    }
+  };
+
   return (
     <div className={classNames(className, wrapperClassName)} ref={ref}>
-      <img className="pgn__card-image-cap" src={src} alt={srcAlt} />
-      {!!logoSrc && <img className="pgn__card-logo-cap" src={logoSrc} alt={logoAlt} />}
+      <img
+        className="pgn__card-image-cap"
+        src={src}
+        onError={(e) => hasFallbackSrc(e.currentTarget, fallbackSrc)}
+        alt={srcAlt}
+      />
+      {!!logoSrc
+          && (
+          <img
+            className="pgn__card-logo-cap"
+            src={logoSrc}
+            onError={(e) => hasFallbackSrc(e.currentTarget, fallbackLogoSrc)}
+            alt={logoAlt}
+          />
+          )}
     </div>
   );
 });
@@ -55,10 +79,14 @@ CardImageCap.propTypes = {
   className: PropTypes.string,
   /** Specifies image src. */
   src: PropTypes.string,
+  /** Specifies fallback image src. */
+  fallbackSrc: PropTypes.string,
   /** Specifies image alt text. */
   srcAlt: PropTypes.string,
   /** Specifies logo src to put on top of the image. */
   logoSrc: PropTypes.string,
+  /** Specifies fallback image logo src. */
+  fallbackLogoSrc: PropTypes.string,
   /** Specifies logo image alt text. */
   logoAlt: PropTypes.string,
   /** Specifies height of Image skeleton in loading state. */
@@ -75,7 +103,9 @@ CardImageCap.propTypes = {
 
 CardImageCap.defaultProps = {
   src: undefined,
+  fallbackSrc: undefined,
   logoSrc: undefined,
+  fallbackLogoSrc: undefined,
   className: undefined,
   srcAlt: undefined,
   logoAlt: undefined,

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -587,36 +587,85 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
 ```
 
 ## With Fallback Image
-If your main `src` fails to was loaded, the `fallbackSrc` will allow the user to show fallback the image. 
+If your main `src` fails to was loaded, the `fallbackSrc` will allow the user to show fallback the image.
 A fallback source is available for both the main `ImageCap` component image and the logo.
 
 ```jsx live
 () => {
-  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.small.maxWidth});
 
   return (
-    <Card style={{ width: isExtraSmall ? "100%" : "40%" }}>
+    <Card style={{width: isExtraSmall ? "100%" : "40%"}}>
+        <Card.ImageCap
+            src="https://source.unsplash.com/360x200/?nature,flower"
+            fallbackSrc="https://source.unsplash.com/360x200/?ocean"
+            srcAlt="Card image"
+            logoSrc="https://via.placeholder.com/150"
+            fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
+            logoAlt="Card logo"
+        />
+        <Card.Header title="Title" subtitle="Subtitle" />
+        <Card.Section title="Section title">
+            This is a card section. It can contain anything but usually text, a list, or list of links.
+            Multiple sections have a card divider between them.
+        </Card.Section>
+        <Card.Footer>
+            <Button>Action 1</Button>
+        </Card.Footer>
+    </Card>
+)}
+```
+
+## With loading state
+### Vertical variant
+
+```jsx live
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Card isLoading style={{ width: isExtraSmall ? "100%" : "18rem" }}>
       <Card.ImageCap
         src="https://source.unsplash.com/360x200/?nature,flower"
-        fallbackSrc="https://source.unsplash.com/360x200/?ocean"
         srcAlt="Card image"
-        logoSrc="https://via.placeholder.com/150"
-        fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
-        logoAlt="Card logo"
       />
-      <Card.Header
-        title="Title"
-        subtitle="Subtitle"
-      />
-      <Card.Section 
-        title="Section title"
-      >
-        This is a card section. It can contain anything but usually text, a list, or list of links. 
-        Multiple sections have a card divider between them.
+      <Card.Header title="Card Title" />
+      <Card.Section>
+        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
       </Card.Section>
       <Card.Footer>
         <Button>Action 1</Button>
       </Card.Footer>
+    </Card>
+)}
+```
+
+### Horizontal variant
+
+```jsx live
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Card isLoading orientation={isExtraSmall ? "vertical" : "horizontal"}>
+      <Card.ImageCap
+        skeletonHeight={isExtraSmall && 140}
+        src="https://source.unsplash.com/360x200/?nature,flower"
+        srcAlt="Card image"
+        logoSrc="https://via.placeholder.com/150"
+        logoAlt="Card logo"
+      />
+      <Card.Body>
+        <Card.Header title="Title" />
+        <Card.Section title="Section title">
+          This is a special case where we want to have Footer with vertical 
+          orientation in the Card with horizontal orientation.
+        </Card.Section>
+        <Card.Footer orientation="vertical" textElement="Some footer text">
+          <Button>Action 1</Button>
+          <Button>Action 2</Button>
+        </Card.Footer>
+      </Card.Body>
     </Card>
 )}
 ```

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -649,7 +649,7 @@ A fallback source is available for both the main `ImageCap` component image and 
   return (
     <Card isLoading orientation={isExtraSmall ? "vertical" : "horizontal"}>
       <Card.ImageCap
-        skeletonHeight={isExtraSmall && 140}
+        skeletonHeight={isExtraSmall ? 140 : undefined}
         src="https://source.unsplash.com/360x200/?nature,flower"
         srcAlt="Card image"
         logoSrc="https://via.placeholder.com/150"

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -399,7 +399,8 @@ When using horizontal variant Paragon provides additional component `Card.Body` 
           <Card.Section 
             title="Section title"
           >
-            Here we want to display both Header and Section between ImageCap and Footer components, so we use Card.Body to accomplish that. 
+            Here we want to display both Header and Section between ImageCap and Footer components, so we use Card.
+            Body to accomplish that. 
           </Card.Section>
         </Card.Body>
         <Card.Footer orientation={isExtraSmall ? "horizontal" : "vertical"}>
@@ -585,56 +586,37 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
 )}
 ```
 
-## With loading state
-### Vertical variant
+## With Fallback Image
+If your main `src` fails to was loaded, the `fallbackSrc` will allow the user to show fallback the image. 
+A fallback source is available for both the main `ImageCap` component image and the logo.
 
 ```jsx live
 () => {
-  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
 
   return (
-    <Card isLoading style={{ width: isExtraSmall ? "100%" : "18rem" }}>
+    <Card style={{ width: isExtraSmall ? "100%" : "40%" }}>
       <Card.ImageCap
         src="https://source.unsplash.com/360x200/?nature,flower"
+        fallbackSrc="https://source.unsplash.com/360x200/?ocean"
         srcAlt="Card image"
+        logoSrc="https://via.placeholder.com/150"
+        fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
+        logoAlt="Card logo"
       />
-      <Card.Header title="Card Title" />
-      <Card.Section>
-        This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
+      <Card.Header
+        title="Title"
+        subtitle="Subtitle"
+      />
+      <Card.Section 
+        title="Section title"
+      >
+        This is a card section. It can contain anything but usually text, a list, or list of links. 
+        Multiple sections have a card divider between them.
       </Card.Section>
       <Card.Footer>
         <Button>Action 1</Button>
       </Card.Footer>
-    </Card>
-)}
-```
-
-### Horizontal variant
-
-```jsx live
-() => {
-  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
-
-  return (
-    <Card isLoading orientation={isExtraSmall ? "vertical" : "horizontal"}>
-      <Card.ImageCap
-        skeletonHeight={isExtraSmall && 140}
-        src="https://source.unsplash.com/360x200/?nature,flower"
-        srcAlt="Card image"
-        logoSrc="https://via.placeholder.com/150"
-        logoAlt="Card logo"
-      />
-      <Card.Body>
-        <Card.Header title="Title" />
-        <Card.Section title="Section title">
-          This is a special case where we want to have Footer with vertical 
-          orientation in the Card with horizontal orientation.
-        </Card.Section>
-        <Card.Footer orientation="vertical" textElement="Some footer text">
-          <Button>Action 1</Button>
-          <Button>Action 2</Button>
-        </Card.Footer>
-      </Card.Body>
     </Card>
 )}
 ```

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -587,7 +587,7 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
 ```
 
 ## With Fallback Image
-If your main `src` fails to was loaded, the `fallbackSrc` will allow the user to show fallback the image.
+You can specify `fallbackSrc` image to show in case your main `src` fails to load.
 A fallback source is available for both the main `ImageCap` component image and the logo.
 
 ```jsx live

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -17,15 +17,9 @@ describe('<CardImageCap />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders with src, logoSrc, logoAlt, fallbackSrc, fallbackLogoSrc props', () => {
+  it('renders with src, logoSrc and logoAlt props', () => {
     const tree = renderer.create((
-      <CardImageCapWrapper
-        src="http://fake.image"
-        fallbackSrc="http://fake.image"
-        logoSrc="http://fake.image"
-        fallbackLogoSrc="http://fake.image"
-        logoAlt="Logo alt"
-      />
+      <CardImageCapWrapper src="http://fake.image" logoSrc="http://fake.image" logoAlt="Logo alt" />
     )).toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -37,15 +31,9 @@ describe('<CardImageCap />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders with src, logoSrc, fallbackSrc, fallbackLogoSrc prop in horizontal orientation', () => {
+  it('renders with src and logoSrc prop in horizontal orientation', () => {
     const tree = renderer.create((
-      <CardImageCapWrapper
-        orientation="horizontal"
-        src="http://fake.image"
-        fallbackSrc="http://fake.image"
-        logoSrc="http://fake.image"
-        fallbackLogoSrc="http://fake.image"
-      />
+      <CardImageCapWrapper orientation="horizontal" src="http://fake.image" logoSrc="http://fake.image" />
     )).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -17,9 +17,15 @@ describe('<CardImageCap />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders with src, logoSrc and logoAlt props', () => {
+  it('renders with src, logoSrc, logoAlt, fallbackSrc, fallbackLogoSrc props', () => {
     const tree = renderer.create((
-      <CardImageCapWrapper src="http://fake.image" logoSrc="http://fake.image" logoAlt="Logo alt" />
+      <CardImageCapWrapper
+        src="http://fake.image"
+        fallbackSrc="http://fake.image"
+        logoSrc="http://fake.image"
+        fallbackLogoSrc="http://fake.image"
+        logoAlt="Logo alt"
+      />
     )).toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -31,9 +37,15 @@ describe('<CardImageCap />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders with src and logoSrc prop in horizontal orientation', () => {
+  it('renders with src, logoSrc, fallbackSrc, fallbackLogoSrc prop in horizontal orientation', () => {
     const tree = renderer.create((
-      <CardImageCapWrapper orientation="horizontal" src="http://fake.image" logoSrc="http://fake.image" />
+      <CardImageCapWrapper
+        orientation="horizontal"
+        src="http://fake.image"
+        fallbackSrc="http://fake.image"
+        logoSrc="http://fake.image"
+        fallbackLogoSrc="http://fake.image"
+      />
     )).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
         >
           <img
             className="pgn__card-image-cap"
+            onError={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -72,6 +73,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            onError={[Function]}
             src="http://fake.image"
           />
         </div>

--- a/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`<CardImageCap /> renders with scr prop and srcAlt 1`] = `
   <img
     alt="Alt text"
     className="pgn__card-image-cap"
+    onError={[Function]}
     src="http://fake.image"
   />
 </div>
@@ -18,6 +19,7 @@ exports[`<CardImageCap /> renders with scr prop in horizontal orientation 1`] = 
 >
   <img
     className="pgn__card-image-cap"
+    onError={[Function]}
     src="http://fake.image"
   />
 </div>
@@ -29,26 +31,47 @@ exports[`<CardImageCap /> renders with src and logoSrc prop in horizontal orient
 >
   <img
     className="pgn__card-image-cap"
+    onError={[Function]}
     src="http://fake.image"
   />
   <img
     className="pgn__card-logo-cap"
+    onError={[Function]}
     src="http://fake.image"
   />
 </div>
 `;
 
-exports[`<CardImageCap /> renders with src, logoSrc and logoAlt props 1`] = `
+exports[`<CardImageCap /> renders with src, logoSrc, fallbackSrc, fallbackLogoSrc prop in horizontal orientation 1`] = `
+<div
+  className="pgn__card-wrapper-image-cap horizontal"
+>
+  <img
+    className="pgn__card-image-cap"
+    onError={[Function]}
+    src="http://fake.image"
+  />
+  <img
+    className="pgn__card-logo-cap"
+    onError={[Function]}
+    src="http://fake.image"
+  />
+</div>
+`;
+
+exports[`<CardImageCap /> renders with src, logoSrc, logoAlt, fallbackSrc, fallbackLogoSrc props 1`] = `
 <div
   className="pgn__card-wrapper-image-cap vertical"
 >
   <img
     className="pgn__card-image-cap"
+    onError={[Function]}
     src="http://fake.image"
   />
   <img
     alt="Logo alt"
     className="pgn__card-logo-cap"
+    onError={[Function]}
     src="http://fake.image"
   />
 </div>

--- a/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
@@ -42,24 +42,7 @@ exports[`<CardImageCap /> renders with src and logoSrc prop in horizontal orient
 </div>
 `;
 
-exports[`<CardImageCap /> renders with src, logoSrc, fallbackSrc, fallbackLogoSrc prop in horizontal orientation 1`] = `
-<div
-  className="pgn__card-wrapper-image-cap horizontal"
->
-  <img
-    className="pgn__card-image-cap"
-    onError={[Function]}
-    src="http://fake.image"
-  />
-  <img
-    className="pgn__card-logo-cap"
-    onError={[Function]}
-    src="http://fake.image"
-  />
-</div>
-`;
-
-exports[`<CardImageCap /> renders with src, logoSrc, logoAlt, fallbackSrc, fallbackLogoSrc props 1`] = `
+exports[`<CardImageCap /> renders with src, logoSrc and logoAlt props 1`] = `
 <div
   className="pgn__card-wrapper-image-cap vertical"
 >

--- a/src/Form/tests/FormGroup.test.jsx
+++ b/src/Form/tests/FormGroup.test.jsx
@@ -7,7 +7,7 @@ import FormLabel from '../FormLabel';
 import FormControlFeedback from '../FormControlFeedback';
 
 /* eslint-disable react/prop-types */
-jest.mock('react-bootstrap/FormControl', () => function (props) {
+jest.mock('react-bootstrap/FormControl', () => function MockFormControl(props) {
   const { children, ...otherProps } = props;
   return (
     <form-control {...otherProps}>

--- a/src/Modal/ModalLayer.test.jsx
+++ b/src/Modal/ModalLayer.test.jsx
@@ -5,7 +5,7 @@ import ModalLayer, { ModalBackdrop } from './ModalLayer';
 import { ModalContextProvider } from './ModalContext';
 
 /* eslint-disable react/prop-types */
-jest.mock('./Portal', () => function (props) {
+jest.mock('./Portal', () => function PortalMock(props) {
   const { children, ...otherProps } = props;
   return (
     <paragon-portal {...otherProps}>

--- a/src/Modal/ModalPopup.test.jsx
+++ b/src/Modal/ModalPopup.test.jsx
@@ -6,7 +6,7 @@ import { ModalContextProvider } from './ModalContext';
 import Portal from './Portal';
 
 /* eslint-disable react/prop-types */
-jest.mock('./Portal', () => function (props) {
+jest.mock('./Portal', () => function PortalMock(props) {
   const { children, ...otherProps } = props;
   return (
     <paragon-portal {...otherProps}>

--- a/src/Modal/tests/ModalDialog.test.jsx
+++ b/src/Modal/tests/ModalDialog.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import ModalDialog from '../ModalDialog';
 
 /* eslint-disable react/prop-types */
-jest.mock('../ModalLayer', () => function (props) {
+jest.mock('../ModalLayer', () => function ModalLayerMock(props) {
   const { children, ...otherProps } = props;
   return (
     <modal-layer {...otherProps}>

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 import Sheet, { POSITIONS, VARIANTS } from './index';
 
 /* eslint-disable react/prop-types */
-jest.mock('./SheetContainer', () => function (props) {
+jest.mock('./SheetContainer', () => function SheetContainerMock(props) {
   const { children, ...otherProps } = props;
   return (
     <sheet-container {...otherProps}>

--- a/src/utils/propTypes/greaterThan.js
+++ b/src/utils/propTypes/greaterThan.js
@@ -1,5 +1,5 @@
 const isGreaterThan = (lowerBound) => (
-  function (props, propName, componentName) {
+  function greaterThan(props, propName, componentName) {
     const value = props[propName];
 
     if (typeof value === 'number' && !Number.isNaN(value) && value > lowerBound) {

--- a/www/src/components/exampleComponents/ExamplePropsForm.jsx
+++ b/www/src/components/exampleComponents/ExamplePropsForm.jsx
@@ -3,65 +3,70 @@ import PropTypes from 'prop-types';
 import { Form, Badge } from '~paragon-react'; // eslint-disable-line
 
 const ExamplePropsForm = ({ inputs }) => (
-    <div className="pgn-doc__example-props-form">
-      <h4>Props panel</h4>
-      {inputs.map(input => {
-        if (input.options) {
-          return (
-              <Form.Group>
-                <Form.Label>
-                  <Badge variant="light">{input.name}</Badge>
-                </Form.Label>
-                <Form.RadioSet
-                    isInline
-                    name={input.name}
-                    onChange={(e) => input.setValue(e.target.value)}
-                    value={input.value}
-                >
-                  {input.options.map(option => (
-                      <Form.Radio value={option.value || option}>{option.name || option.value || option}</Form.Radio>
-                  ))}
-                </Form.RadioSet>
-              </Form.Group>
-          );
-        }
-        if (input.range) {
-          return (
-              <Form.Group>
-                <Form.Label>
-                  <Badge variant="light">{input.name}: {input.value}</Badge>
-                </Form.Label>
-                <div className="d-flex align-items-center">
-                  <Form.Label>{input.range.min}</Form.Label>
-                  <Form.Control
-                      type="range"
-                      className="mx-2"
-                      min={input.range.min}
-                      step={input.range.step || 1}
-                      max={input.range.max}
-                      value={input.value}
-                      onChange={e => input.setValue(e.target.value)}
-                  />
-                  <Form.Label>{input.range.max}</Form.Label>
-                </div>
-              </Form.Group>
-          );
-        }
+  <div className="pgn-doc__example-props-form">
+    <h4>Props panel</h4>
+    {inputs.map(input => {
+      if (input.options) {
         return (
-            <Form.Group>
-              <Form.Switch
-                  checked={input.value}
-                  onChange={(e) => input.setValue(e.target.value)}
-                  name={input.name}
-              >
-                <Badge variant="light">
-                  {input.name}: {(!!input.value).toString()}
-                </Badge>
-              </Form.Switch>
-            </Form.Group>
+          <Form.Group key={input.name}>
+            <Form.Label>
+              <Badge variant="light">{input.name}</Badge>
+            </Form.Label>
+            <Form.RadioSet
+              isInline
+              name={input.name}
+              onChange={(e) => input.setValue(e.target.value)}
+              value={input.value}
+            >
+              {input.options.map(option => (
+                <Form.Radio
+                  value={option.value || option}
+                  key={option.value || option}
+                >
+                  {option.name || option.value || option}
+                </Form.Radio>
+              ))}
+            </Form.RadioSet>
+          </Form.Group>
         );
-      })}
-    </div>
+      }
+      if (input.range) {
+        return (
+          <Form.Group key={input.name}>
+            <Form.Label>
+              <Badge variant="light">{input.name}: {input.value}</Badge>
+            </Form.Label>
+            <div className="d-flex align-items-center">
+              <Form.Label>{input.range.min}</Form.Label>
+              <Form.Control
+                type="range"
+                className="mx-2"
+                min={input.range.min}
+                step={input.range.step || 1}
+                max={input.range.max}
+                value={input.value}
+                onChange={e => input.setValue(e.target.value)}
+              />
+              <Form.Label>{input.range.max}</Form.Label>
+            </div>
+          </Form.Group>
+        );
+      }
+      return (
+        <Form.Group key={input.name}>
+          <Form.Switch
+            checked={input.value}
+            onChange={(e) => input.setValue(e.target.value)}
+            name={input.name}
+          >
+            <Badge variant="light">
+              {input.name}: {(!!input.value).toString()}
+            </Badge>
+          </Form.Switch>
+        </Form.Group>
+      );
+    })}
+  </div>
 );
 
 ExamplePropsForm.propTypes = {

--- a/www/src/components/exampleComponents/ExamplePropsForm.jsx
+++ b/www/src/components/exampleComponents/ExamplePropsForm.jsx
@@ -3,65 +3,65 @@ import PropTypes from 'prop-types';
 import { Form, Badge } from '~paragon-react'; // eslint-disable-line
 
 const ExamplePropsForm = ({ inputs }) => (
-  <div className="pgn-doc__example-props-form">
-    <h4>Props panel</h4>
-    {inputs.map(input => {
-      if (input.options) {
+    <div className="pgn-doc__example-props-form">
+      <h4>Props panel</h4>
+      {inputs.map(input => {
+        if (input.options) {
+          return (
+              <Form.Group>
+                <Form.Label>
+                  <Badge variant="light">{input.name}</Badge>
+                </Form.Label>
+                <Form.RadioSet
+                    isInline
+                    name={input.name}
+                    onChange={(e) => input.setValue(e.target.value)}
+                    value={input.value}
+                >
+                  {input.options.map(option => (
+                      <Form.Radio value={option.value || option}>{option.name || option.value || option}</Form.Radio>
+                  ))}
+                </Form.RadioSet>
+              </Form.Group>
+          );
+        }
+        if (input.range) {
+          return (
+              <Form.Group>
+                <Form.Label>
+                  <Badge variant="light">{input.name}: {input.value}</Badge>
+                </Form.Label>
+                <div className="d-flex align-items-center">
+                  <Form.Label>{input.range.min}</Form.Label>
+                  <Form.Control
+                      type="range"
+                      className="mx-2"
+                      min={input.range.min}
+                      step={input.range.step || 1}
+                      max={input.range.max}
+                      value={input.value}
+                      onChange={e => input.setValue(e.target.value)}
+                  />
+                  <Form.Label>{input.range.max}</Form.Label>
+                </div>
+              </Form.Group>
+          );
+        }
         return (
-          <Form.Group>
-            <Form.Label>
-              <Badge variant="light">{input.name}</Badge>
-            </Form.Label>
-            <Form.RadioSet
-              isInline
-              name={input.name}
-              onChange={(e) => input.setValue(e.target.value)}
-              value={input.value}
-            >
-              {input.options.map(option => (
-                <Form.Radio value={option.value || option}>{option.name || option.value || option}</Form.Radio>
-              ))}
-            </Form.RadioSet>
-          </Form.Group>
+            <Form.Group>
+              <Form.Switch
+                  checked={input.value}
+                  onChange={(e) => input.setValue(e.target.value)}
+                  name={input.name}
+              >
+                <Badge variant="light">
+                  {input.name}: {(!!input.value).toString()}
+                </Badge>
+              </Form.Switch>
+            </Form.Group>
         );
-      }
-      if (input.range) {
-        return (
-          <Form.Group>
-            <Form.Label>
-              <Badge variant="light">{input.name}: {input.value}</Badge>
-            </Form.Label>
-            <div className="d-flex align-items-center">
-              <Form.Label>{input.range.min}</Form.Label>
-              <Form.Control
-                type="range"
-                className="mx-2"
-                min={input.range.min}
-                step={input.range.step || 1}
-                max={input.range.max}
-                value={input.value}
-                onChange={e => input.setValue(e.target.value)}
-              />
-              <Form.Label>{input.range.max}</Form.Label>
-            </div>
-          </Form.Group>
-        );
-      }
-      return (
-        <Form.Group>
-          <Form.Switch
-            checked={input.value}
-            onChange={(e) => input.setValue(e.target.value)}
-            name={input.name}
-          >
-            <Badge variant="light">
-              {input.name}: {(!!input.value).toString()}
-            </Badge>
-          </Form.Switch>
-        </Form.Group>
-      );
-    })}
-  </div>
+      })}
+    </div>
 );
 
 ExamplePropsForm.propTypes = {


### PR DESCRIPTION
## Description

- add `fallbackSrc` prop to the `Card.ImageCap` component, use this `url` for image if image from the src prop does not load;
- add `fallbackLogoSrc` prop to Card.ImageCap component, use this `url` for logo if image from the `logoSrc` prop does not load;
- add tests for these changes and examples on the component's page;
- fixed key error in `ExamplePropsForm.jsx`.

### Deploy Preview

[Cards component](https://deploy-preview-1682--paragon-openedx.netlify.app/components/card/#with-fallback-image)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
