### PR TITLE
feat: added accentB background for page banner

### DIFF
--- a/src/PageBanner/PageBanner.scss
+++ b/src/PageBanner/PageBanner.scss
@@ -28,6 +28,11 @@
   background-color: $accent-a;
   color: black;
 }
+// stylelint-disable-next-line selector-class-pattern
+.pgn__pageBanner__accentB {
+  background-color: $accent-b;
+  color: black;
+}
 
 // stylelint-disable-next-line selector-class-pattern
 .pgn__pageBanner__warning {

--- a/src/PageBanner/PageBanner.test.jsx
+++ b/src/PageBanner/PageBanner.test.jsx
@@ -10,6 +10,11 @@ describe('<PageBanner />', () => {
       const pageBanner = wrapper.find('.pgn__pageBanner-component');
       expect(pageBanner.hasClass('pgn__pageBanner__accentA')).toEqual(true);
     });
+    it('renders with correct class for default variant (accentB)', () => {
+      const wrapper = mount(<PageBanner variant="accentB" />);
+      const pageBanner = wrapper.find('.pgn__pageBanner-component');
+      expect(pageBanner.hasClass('pgn__pageBanner__accentB')).toEqual(true);
+    });
     it('renders with correct class for variant warning', () => {
       const wrapper = mount(<PageBanner variant="warning" />);
       const pageBanner = wrapper.find('.pgn__pageBanner-component');

--- a/src/PageBanner/README.md
+++ b/src/PageBanner/README.md
@@ -13,60 +13,64 @@ notes: |
 
 A ``Page Banner`` displays an important, succinct message, and provides actions for users to address (or dismiss the banner). It requires a user action to be dismissed.
 
-## Basic Usage
+## Basic Usage Variants
 
 ```jsx live
 () => {
-  const [show, setShow] = useState(true);
-  return (
-    <>
-      <PageBanner
-        show={show}
-        dismissible
-        onDismiss={() => {setShow(false)}}
-      >
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.
-      </PageBanner>
-      {!show && (<Button onClick={() => setShow(true)}>Show Page Banner</Button>)}
-    </>
-  )
+    const [showPageBanner, setShowPageBanner] = useState(true);
+    const [variant, setVariant] = useState('light');
+
+    return (
+        <>
+          <ExamplePropsForm
+            inputs={[
+              {
+                value: variant, setValue: setVariant, options: [
+                  {name: 'light', value: 'light'},
+                  {name: 'dark', value: 'dark'},
+                  {name: 'accentA', value: 'accentA'},
+                  {name: 'accentB', value: 'accentB'},
+                  {name: 'warning', value: 'warning'}
+                ], name: 'Banner Variants'
+              },
+            ]}
+          />
+
+            <div>
+              <PageBanner
+                show={showPageBanner}
+                variant={variant}
+                dismissible
+                onDismiss={() => setShowPageBanner(false)}
+              >
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.
+              </PageBanner>
+              {!showPageBanner && (
+                <Button className="my-2 mie-2" onClick={() => setShowPageBanner(true)}>Show Page Banner</Button>)}
+
+            </div>
+        </>
+    )
 }
 ```
 
-## Variants
+
+
+## Warning Banner
 
 The system warning banner is similar to the ``Alert Banner`` banner in styling, except that the text is always default body (14px) and padding has been modified in order to accommodate the ``Page Banner`` component. It cannot be dismissed.
 
 ```jsx live
 () => {
-  const [showLightVariant, setShowLightVariant] = useState(true);
-  const [showDarkVariant, setShowDarkVariant] = useState(true);
   return (
     <>
       <PageBanner
-        show={showLightVariant}
-        dismissible
-        onDismiss={() => setShowLightVariant(false)}
-        variant="light"
+         variant="warning"
       >
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.
-      </PageBanner>
-      {!showLightVariant && (<Button className="my-2 mie-2" onClick={() => setShowLightVariant(true)}>Show light variant</Button>)}
-      <PageBanner
-        show={showDarkVariant}
-        dismissible
-        onDismiss={() => setShowDarkVariant(false)}
-        variant="dark"
-      >
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.
-      </PageBanner>
-      {!showDarkVariant && (<Button className="my-2" onClick={() => setShowDarkVariant(true)}>Show dark variant</Button>)}
-      <PageBanner
-        variant="warning"
-      >
-        <Icon src={WarningFilled} className="mie-2" /> We will no longer support Internet Explorer 11.
+        <Icon src={WarningFilled} className="mie-2"/> We will no longer support Internet Explorer 11.
       </PageBanner>
     </>
   )
 }
 ```
+

--- a/src/PageBanner/index.jsx
+++ b/src/PageBanner/index.jsx
@@ -11,6 +11,7 @@ export const VARIANTS = {
   dark: 'dark',
   warning: 'warning',
   accentA: 'accentA',
+  accentB: 'accentB',
 };
 
 function PageBanner({
@@ -61,7 +62,7 @@ PageBanner.propTypes = {
   /** Boolean used to control whether the Page Banner shows. */
   show: PropTypes.bool,
   /** A string designating which color variant of the `Page Banner` to display */
-  variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark, VARIANTS.warning, VARIANTS.accentA]),
+  variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark, VARIANTS.warning, VARIANTS.accentA, VARIANTS.accentB]),
 };
 
 PageBanner.defaultProps = {


### PR DESCRIPTION
## Description

Feature Ticket: https://2u-internal.atlassian.net/browse/INF-599
Figma designs supporting required change: https://www.figma.com/file/LVFnO9oRHYiamoicZuXDAC/Discussions?node-id=6884%3A261359

Page banners do not accept background color classes hence we need to add a new variant that can help achieve a design requirement in discussion MFE. 

- accentB color background is added with variant name accentB.
- documentation is updated to state available variants
- test cases added to ensure the required color class is added in the background.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
