### PR TITLE
docs: update fallback image src example for Card component

### DIFF
--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -15,9 +15,9 @@ categories:
 - Content
 status: 'Stable'
 designStatus: 'Done'
-devStatus: 'In Progress'
+devStatus: 'Done'
 notes: |
-  A pass through from react-bootstrap
+  Partially a pass-thru from react-bootstrap, with custom subcomponents.
 ---
 
 `Card` is a box of related content usually describing a single object. It can be composed of several subcomponents, we give full overview of those subcomponents below.
@@ -587,6 +587,7 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
 ```
 
 ## With Fallback Image
+
 You can specify `fallbackSrc` image to show in case your main `src` fails to load.
 A fallback source is available for both the main `ImageCap` component image and the logo.
 
@@ -596,23 +597,23 @@ A fallback source is available for both the main `ImageCap` component image and 
 
   return (
     <Card style={{width: isExtraSmall ? "100%" : "40%"}}>
-        <Card.ImageCap
-            src="https://source.unsplash.com/360x200/?nature,flower"
-            fallbackSrc="https://source.unsplash.com/360x200/?ocean"
-            srcAlt="Card image"
-            logoSrc="https://via.placeholder.com/150"
-            fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
-            logoAlt="Card logo"
-        />
-        <Card.Header title="Title" subtitle="Subtitle" />
-        <Card.Section title="Section title">
-            This is a card section. It can contain anything but usually text, a list, or list of links.
-            Multiple sections have a card divider between them.
-        </Card.Section>
-        <Card.Footer>
-            <Button>Action 1</Button>
-        </Card.Footer>
-    </Card>
+      <Card.ImageCap
+          src="fakeURL"
+          fallbackSrc="https://source.unsplash.com/360x200/?ocean"
+          srcAlt="Card image"
+          logoSrc="fakeURL"
+          fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
+          logoAlt="Card logo"
+      />
+      <Card.Header title="Title" subtitle="Subtitle" />
+      <Card.Section title="Section title">
+          This is a card section. It can contain anything but usually text, a list, or list of links.
+          Multiple sections have a card divider between them.
+      </Card.Section>
+      <Card.Footer>
+          <Button>Action 1</Button>
+      </Card.Footer>
+  </Card>
 )}
 ```
 


### PR DESCRIPTION
## Description

Small cleanup to force the fallback image src `Card` example to use the fallback src instead of the default image src by providing invalid image URLs.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
