### PR TITLE
[BD-46] feat: added translations English strings in FormAutosuggest component

### DIFF
--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -2,10 +2,12 @@ import React, {
   useEffect, useState,
 } from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
 import { KeyboardArrowUp, KeyboardArrowDown } from '../../icons';
 import Icon from '../Icon';
 import { Form, IconButton, Spinner } from '../index';
 import useArrowKeyNavigation from '../hooks/useArrowKeyNavigation';
+import messages from './messages';
 
 function FormAutosuggest({
   children,
@@ -20,6 +22,7 @@ function FormAutosuggest({
   helpMessage,
   ...props
 }) {
+  const intl = useIntl();
   const parentRef = useArrowKeyNavigation({
     selectors: arrowKeyNavigationSelector,
     ignoredKeys: ignoredArrowKeysNames,
@@ -103,7 +106,9 @@ function FormAutosuggest({
       iconAs={Icon}
       size="sm"
       variant="secondary"
-      alt={isMenuClosed ? 'Open the options menu' : 'Close the options menu'}
+      alt={isMenuClosed
+        ? intl.formatMessage(messages.iconButtonOpened)
+        : intl.formatMessage(messages.iconButtonClosed)}
       onClick={(e) => handleExpand(e, isMenuClosed)}
     />
   );

--- a/src/Form/messages.js
+++ b/src/Form/messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  iconButtonOpened: {
+    id: 'pgn.FormAutosuggest.iconButtonOpened',
+    defaultMessage: 'Open the options menu',
+    description: 'A message shown in case when the autosuggest menu is closed.',
+  },
+  iconButtonClosed: {
+    id: 'pgn.FormAutosuggest.iconButtonClosed',
+    defaultMessage: 'Close the options menu',
+    description: 'A message shown in case when the autosuggest menu is opened.',
+  },
+});
+
+export default messages;

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
+import { IntlProvider } from 'react-intl';
 import FormAutosuggest from '../FormAutosuggest';
 import FormAutosuggestOption from '../FormAutosuggestOption';
 
@@ -16,33 +17,39 @@ const createDocumentListenersMock = () => {
   };
 };
 
-const props = {
-  name: 'FormAutosuggest',
-  floatingLabel: 'floatingLabel text',
-  helpMessage: 'Example help message',
-  errorMessageText: 'Example error message',
-};
+function FormAutosuggestWrapper(props) {
+  return (
+    <IntlProvider locale="en" messages={{}}>
+      <FormAutosuggest {...props} />
+    </IntlProvider>
+  );
+}
 
 describe('FormAutosuggest', () => {
   it('renders component without error', () => {
-    mount(<FormAutosuggest {...props} />);
+    mount(<FormAutosuggestWrapper />);
   });
 
   const container = mount(
-    <FormAutosuggest {...props}>
+    <FormAutosuggestWrapper
+      name="FormAutosuggest"
+      floatingLabel="floatingLabel text"
+      helpMessage="Example help message"
+      errorMessageText="Example error message"
+    >
       <FormAutosuggestOption>Option 1</FormAutosuggestOption>
       <FormAutosuggestOption>Option 2</FormAutosuggestOption>
       <FormAutosuggestOption>Learn from more than 160 member universities</FormAutosuggestOption>
-    </FormAutosuggest>,
+    </FormAutosuggestWrapper>,
   );
 
   it('render without loading state', () => {
     expect(container.exists('.pgn__form-autosuggest__dropdown-loading')).toBe(false);
-    expect(container.props().isLoading).toBe(false);
+    expect(container.props().isLoading).toBeUndefined();
   });
 
   it('render with loading state', () => {
-    const wrapper = mount(<FormAutosuggest isLoading />);
+    const wrapper = mount(<FormAutosuggestWrapper isLoading />);
 
     expect(wrapper.exists('.pgn__form-autosuggest__dropdown-loading')).toBe(true);
     expect(wrapper.props().isLoading).toBe(true);

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "افتح قائمة الخيارات",
-  "pgn.FormAutosuggest.iconButtonClosed": "أغلق قائمة الخيارات"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "افتح قائمة الخيارات",
+  "pgn.FormAutosuggest.iconButtonClosed": "أغلق قائمة الخيارات"
 }

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "Obriu el menú d'opcions",
-  "pgn.FormAutosuggest.iconButtonClosed": "Tanqueu el menú d'opcions"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Obriu el menú d'opcions",
+  "pgn.FormAutosuggest.iconButtonClosed": "Tanqueu el menú d'opcions"
 }

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Arrastre y suelte su archivo aquí o haga clic para cargarlo.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancelar",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Subiendo {filename}.",
-  "pgn.Toast.closeLabel": "Cerrar"
+  "pgn.Toast.closeLabel": "Cerrar",
+  "pgn.FormAutosuggest.iconButtonOpened": "Abre el menú de opciones",
+  "pgn.FormAutosuggest.iconButtonClosed": "Cerrar el menú de opciones"
 }

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancelar",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Subiendo {filename}.",
   "pgn.Toast.closeLabel": "Cerrar",
-  "pgn.FormAutosuggest.iconButtonOpened": "Abre el menú de opciones",
-  "pgn.FormAutosuggest.iconButtonClosed": "Cerrar el menú de opciones"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Ouvrir le menu des options",
+  "pgn.FormAutosuggest.iconButtonClosed": "Fermer le menu des options"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "Ouvrir le menu des options",
-  "pgn.FormAutosuggest.iconButtonClosed": "Fermer le menu des options"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "פתח את תפריט האפשרויות",
+  "pgn.FormAutosuggest.iconButtonClosed": "סגור את תפריט האפשרויות"
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "פתח את תפריט האפשרויות",
-  "pgn.FormAutosuggest.iconButtonClosed": "סגור את תפריט האפשרויות"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "Buka menu opsi",
-  "pgn.FormAutosuggest.iconButtonClosed": "Tutup menu opsi"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Buka menu opsi",
+  "pgn.FormAutosuggest.iconButtonClosed": "Tutup menu opsi"
 }

--- a/src/i18n/messages/ko_KR.json
+++ b/src/i18n/messages/ko_KR.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Zamknij",
-  "pgn.FormAutosuggest.iconButtonOpened": "Otwórz menu opcji",
-  "pgn.FormAutosuggest.iconButtonClosed": "Zamknij menu opcji"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Zamknij"
+  "pgn.Toast.closeLabel": "Zamknij",
+  "pgn.FormAutosuggest.iconButtonOpened": "Otwórz menu opcji",
+  "pgn.FormAutosuggest.iconButtonClosed": "Zamknij menu opcji"
 }

--- a/src/i18n/messages/pt_BR.json
+++ b/src/i18n/messages/pt_BR.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "เปิดเมนูตัวเลือก",
+  "pgn.FormAutosuggest.iconButtonClosed": "ปิดเมนูตัวเลือก"
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "เปิดเมนูตัวเลือก",
-  "pgn.FormAutosuggest.iconButtonClosed": "ปิดเมนูตัวเลือก"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/uk.json
+++ b/src/i18n/messages/uk.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "Відкрити меню параметрів",
-  "pgn.FormAutosuggest.iconButtonClosed": "Закрити меню параметрів"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/uk.json
+++ b/src/i18n/messages/uk.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "Відкрити меню параметрів",
+  "pgn.FormAutosuggest.iconButtonClosed": "Закрити меню параметрів"
 }

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -23,6 +23,6 @@
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.Toast.closeLabel": "Close",
-  "pgn.FormAutosuggest.iconButtonOpened": "打開選項菜單",
-  "pgn.FormAutosuggest.iconButtonClosed": "關閉選項菜單"
+  "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
+  "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu"
 }

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -22,5 +22,7 @@
   "pgn.Dropzone.DefaultContent.label": "Drag and drop your file here or click to upload.",
   "pgn.Dropzone.UploadProgress.cancelLabel": "Cancel",
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.FormAutosuggest.iconButtonOpened": "打開選項菜單",
+  "pgn.FormAutosuggest.iconButtonClosed": "關閉選項菜單"
 }


### PR DESCRIPTION
## Description

Paragon supports i18n, we should ensure all default English strings in the Form autosuggest component are marked for translation with react-intl.

### Deploy Preview

[FormAutosuggest component](https://deploy-preview-1711--paragon-openedx.netlify.app/components/form/form-autosuggest/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
