### PR TITLE
[BD-46] feat: Clickable steps in Stepper component

### DIFF
--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -109,7 +109,10 @@ The order of steps is dictated by the order of ``Stepper.Step`` components in th
 ```
 
 ## Clickable Header
+
 Using ``handleStepClick`` prop you can switch ``Stepper.Step`` components by clicking on ``Stepper.Header`` titles.
+
+### Basic usage
 
 ```jsx live
 () => {
@@ -160,6 +163,104 @@ Using ``handleStepClick`` prop you can switch ``Stepper.Step`` components by cli
           </Button>
           <Stepper.ActionRow.Spacer />
           <Button onClick={() => alert('Completed')}>Apply</Button>
+        </Stepper.ActionRow>
+      </div>
+    </Stepper>
+  )
+}
+```
+
+### With Error State
+
+If an error occurs or the step condition is not met, `Stepper.Header` titles becomes non-clickable.
+
+```jsx live
+() => {
+  const steps = ['checkbox', 'success'];
+  const [currentStep, setCurrentStep] = useState(steps[0]);
+  const [isChecked, check, uncheck, toggleChecked] = useToggle(false);
+  const [hasError, setError, removeError] = useToggle(false);
+  const [isAlertOpen, openAlert, closeAlert] = useToggle(false)
+
+  const evaluateCheckbox = () => {
+    if (isChecked) {
+      removeError();
+      setCurrentStep('success');
+    } else {
+      setError();
+    }
+  };
+
+  const resetCheckbox = () => {
+    closeAlert();
+    uncheck();
+    removeError();
+  };
+
+  const handleStepCheckboxChecked = () => isChecked && setCurrentStep;
+
+  return (
+    <Stepper activeKey={currentStep}>
+      <Stepper.Header handleStepClick={handleStepCheckboxChecked()} />
+
+      <AlertModal
+        title="Confirm reset"
+        isOpen={isAlertOpen}
+        onClose={closeAlert}
+        footerNode={(
+          <ActionRow>
+            <Button variant="tertiary" onClick={closeAlert}>Cancel</Button>
+            <Button variant="danger" onClick={resetCheckbox}>Confirm</Button>
+          </ActionRow>
+        )}
+      >
+        <p>
+          Are you sure you wish to reset the checkbox?
+        </p>
+      </AlertModal>
+
+      <Container size="sm" className="py-5">
+        <Stepper.Step
+          eventKey="checkbox"
+          title="Check the Box"
+          index={steps.indexOf('checkbox')}
+          description={hasError ? 'Please check the box to continue.' : ''}
+          hasError={hasError}
+        >
+          <h2>Check the box</h2>
+          <Form.Checkbox checked={isChecked} onChange={toggleChecked}>
+            Check me!
+          </Form.Checkbox>
+        </Stepper.Step>
+
+        <Stepper.Step
+          eventKey="success"
+          title="Success!"
+          index={steps.indexOf('success')}
+        >
+          <h2>Success!</h2>
+          <p>You may now complete this demo.</p>
+        </Stepper.Step>
+      </Container>
+
+      <div className="py-3">
+        <Stepper.ActionRow eventKey="checkbox">
+          <Button variant="outline-primary" onClick={openAlert}>
+            Reset
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => evaluateCheckbox()}>Next</Button>
+        </Stepper.ActionRow>
+
+        <Stepper.ActionRow eventKey="success">
+          <Button
+            variant="outline-primary"
+            onClick={() => setCurrentStep('checkbox')}
+          >
+            Previous
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => alert('Completed')}>Complete</Button>
         </Stepper.ActionRow>
       </div>
     </Stepper>

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -49,7 +49,6 @@ A ``Stepper`` must wrap a set of composed subcomponents:
 - ``Stepper.ActionRow``
 
 The order of steps is dictated by the order of ``Stepper.Step`` components in the code.
-Using ``isClickable`` prop you can switch ``Stepper.Step`` components by clicking on ``Stepper.Header`` titles.
 
 ``Stepper.Step`` and ``Stepper.ActionRow`` are hidden until their ``eventKey`` props match the ``activeKey`` on ``Stepper``.
 
@@ -60,7 +59,7 @@ Using ``isClickable`` prop you can switch ``Stepper.Step`` components by clickin
 
   return (
     <Stepper activeKey={currentStep}>
-      <Stepper.Header clickHandler={setCurrentStep} />
+      <Stepper.Header />
 
       <Container size="sm" className="py-5">
         <Stepper.Step eventKey="welcome" title="Welcome">
@@ -98,6 +97,65 @@ Using ``isClickable`` prop you can switch ``Stepper.Step`` components by clickin
 
         <Stepper.ActionRow eventKey="review">
           <Button variant="outline-primary" onClick={() => setCurrentStep('choose-cats')}>
+            Previous
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => alert('Completed')}>Apply</Button>
+        </Stepper.ActionRow>
+      </div>
+    </Stepper>
+  )
+}
+```
+
+## Clickable Header
+Using ``handleStepClick`` prop you can switch ``Stepper.Step`` components by clicking on ``Stepper.Header`` titles.
+
+```jsx live
+() => {
+  const steps = ['introduction', 'benefits', 'finally'];
+  const [currentStep, setCurrentStep] = useState(steps[0]);
+
+  return (
+    <Stepper activeKey={currentStep}>
+      <Stepper.Header handleStepClick={setCurrentStep} />
+
+      <Container size="sm" className="py-5">
+        <Stepper.Step eventKey="introduction" title="Introduction">
+          <h2>Introduction</h2>
+          <HipsterIpsum numParagraphs={1} />
+        </Stepper.Step>
+
+        <Stepper.Step eventKey="benefits" title="Benefits">
+          <h2>Benefits</h2>
+          <HipsterIpsum numParagraphs={1} />
+        </Stepper.Step>
+
+        <Stepper.Step eventKey="finally" title="Finally!">
+          <h2>Finally</h2>
+          <HipsterIpsum numParagraphs={1} />
+        </Stepper.Step>
+      </Container>
+
+      <div className="py-3">
+        <Stepper.ActionRow eventKey="introduction">
+          <Button variant="outline-primary" onClick={() => alert('Cancel')}>
+            Cancel
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => setCurrentStep('benefits')}>Next</Button>
+        </Stepper.ActionRow>
+
+        <Stepper.ActionRow eventKey="benefits">
+          <Button variant="outline-primary" onClick={() => setCurrentStep('introduction')}>
+            Previous
+          </Button>
+          <Stepper.ActionRow.Spacer />
+          <Button onClick={() => setCurrentStep('finally')}>Next</Button>
+        </Stepper.ActionRow>
+
+        <Stepper.ActionRow eventKey="finally">
+          <Button variant="outline-primary" onClick={() => setCurrentStep('benefits')}>
             Previous
           </Button>
           <Stepper.ActionRow.Spacer />

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -60,7 +60,7 @@ Using ``isClickable`` prop you can switch ``Stepper.Step`` components by clickin
 
   return (
     <Stepper activeKey={currentStep}>
-      <Stepper.Header isClickable={setCurrentStep} />
+      <Stepper.Header clickHandler={setCurrentStep} />
 
       <Container size="sm" className="py-5">
         <Stepper.Step eventKey="welcome" title="Welcome">

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -49,6 +49,7 @@ A ``Stepper`` must wrap a set of composed subcomponents:
 - ``Stepper.ActionRow``
 
 The order of steps is dictated by the order of ``Stepper.Step`` components in the code.
+Using ``isClickable`` prop you can switch ``Stepper.Step`` components by clicking on ``Stepper.Header`` titles.
 
 ``Stepper.Step`` and ``Stepper.ActionRow`` are hidden until their ``eventKey`` props match the ``activeKey`` on ``Stepper``.
 
@@ -59,7 +60,7 @@ The order of steps is dictated by the order of ``Stepper.Step`` components in th
 
   return (
     <Stepper activeKey={currentStep}>
-      <Stepper.Header />
+      <Stepper.Header isClickable={setCurrentStep} />
 
       <Container size="sm" className="py-5">
         <Stepper.Step eventKey="welcome" title="Welcome">

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -110,7 +110,10 @@ The order of steps is dictated by the order of ``Stepper.Step`` components in th
 
 ## Clickable Header
 
-Using ``handleStepClick`` prop you can switch ``Stepper.Step`` components by clicking on ``Stepper.Header`` titles.
+Use ``Stepper.Step``'s ``onClick`` prop to enable clickable behaviour for step's header. This should primarily be used to
+implement navigation between steps by clicking on their headers.
+
+**Note**: this prop takes effect (i.e., header becomes clickable) only after the step has been visited.
 
 ### Basic usage
 
@@ -121,20 +124,20 @@ Using ``handleStepClick`` prop you can switch ``Stepper.Step`` components by cli
 
   return (
     <Stepper activeKey={currentStep}>
-      <Stepper.Header handleStepClick={setCurrentStep} />
+      <Stepper.Header />
 
       <Container size="sm" className="py-5">
-        <Stepper.Step eventKey="introduction" title="Introduction">
+        <Stepper.Step onClick={() => setCurrentStep('introduction')} eventKey="introduction" title="Introduction">
           <h2>Introduction</h2>
           <HipsterIpsum numParagraphs={1} />
         </Stepper.Step>
 
-        <Stepper.Step eventKey="benefits" title="Benefits">
+        <Stepper.Step onClick={() => setCurrentStep('benefits')} eventKey="benefits" title="Benefits">
           <h2>Benefits</h2>
           <HipsterIpsum numParagraphs={1} />
         </Stepper.Step>
 
-        <Stepper.Step eventKey="finally" title="Finally!">
+        <Stepper.Step onClick={() => setCurrentStep('finally')} eventKey="finally" title="Finally!">
           <h2>Finally</h2>
           <HipsterIpsum numParagraphs={1} />
         </Stepper.Step>
@@ -172,8 +175,6 @@ Using ``handleStepClick`` prop you can switch ``Stepper.Step`` components by cli
 
 ### With Error State
 
-If an error occurs or the step condition is not met, `Stepper.Header` titles becomes non-clickable.
-
 ```jsx live
 () => {
   const steps = ['checkbox', 'success'];
@@ -197,17 +198,9 @@ If an error occurs or the step condition is not met, `Stepper.Header` titles bec
     removeError();
   };
 
-  const getStepClickHandler = () => {
-    if (isChecked) {
-      return setCurrentStep;
-    }
-
-    return undefined;
-  }
-
   return (
     <Stepper activeKey={currentStep}>
-      <Stepper.Header handleStepClick={getStepClickHandler()} />
+      <Stepper.Header />
 
       <AlertModal
         title="Confirm reset"
@@ -232,6 +225,7 @@ If an error occurs or the step condition is not met, `Stepper.Header` titles bec
           index={steps.indexOf('checkbox')}
           description={hasError ? 'Please check the box to continue.' : ''}
           hasError={hasError}
+          onClick={() => setCurrentStep('checkbox')}
         >
           <h2>Check the box</h2>
           <Form.Checkbox checked={isChecked} onChange={toggleChecked}>
@@ -243,6 +237,7 @@ If an error occurs or the step condition is not met, `Stepper.Header` titles bec
           eventKey="success"
           title="Success!"
           index={steps.indexOf('success')}
+          onClick={evaluateCheckbox}
         >
           <h2>Success!</h2>
           <p>You may now complete this demo.</p>

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -197,11 +197,17 @@ If an error occurs or the step condition is not met, `Stepper.Header` titles bec
     removeError();
   };
 
-  const handleStepCheckboxChecked = () => isChecked && setCurrentStep;
+  const getStepClickHandler = () => {
+    if (isChecked) {
+      return setCurrentStep;
+    }
+
+    return undefined;
+  }
 
   return (
     <Stepper activeKey={currentStep}>
-      <Stepper.Header handleStepClick={handleStepCheckboxChecked()} />
+      <Stepper.Header handleStepClick={getStepClickHandler()} />
 
       <AlertModal
         title="Confirm reset"

--- a/src/Stepper/Stepper.jsx
+++ b/src/Stepper/Stepper.jsx
@@ -6,6 +6,7 @@ import StepperActionRow from './StepperActionRow';
 import { StepperContextProvider } from './StepperContext';
 
 function Stepper({ children, activeKey }) {
+  // console.log('activeKey', activeKey);
   return (
     <StepperContextProvider activeKey={activeKey}>
       {children}

--- a/src/Stepper/Stepper.jsx
+++ b/src/Stepper/Stepper.jsx
@@ -6,7 +6,6 @@ import StepperActionRow from './StepperActionRow';
 import { StepperContextProvider } from './StepperContext';
 
 function Stepper({ children, activeKey }) {
-  // console.log('activeKey', activeKey);
   return (
     <StepperContextProvider activeKey={activeKey}>
       {children}

--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -1,13 +1,3 @@
-.pgn__stepper-header-step-list {
-  list-style: none;
-  padding: .25rem 0;
-  display: flex;
-  align-items: center;
-  margin: 0;
-  flex-grow: 1;
-  justify-content: center;
-}
-
 .pgn__stepper-header {
   display: flex;
   justify-content: center;
@@ -15,59 +5,83 @@
   background: $white;
   padding: .75rem 1rem;
   min-height: 5.13rem;
-}
 
-.pgn__stepper-header-step {
-  display: flex;
-  align-items: center;
-  color: $primary;
-  flex-shrink: 1;
-  min-width: 0;
+  .pgn__stepper-header-step-list {
+    list-style: none;
+    padding: .25rem 0;
+    display: flex;
+    align-items: center;
+    margin: 0;
+    flex-grow: 1;
+    justify-content: center;
 
-  .pgn__bubble {
-    margin-inline-end: .5rem;
-    flex-shrink: 0;
+    .pgn__stepper-header-line {
+      display: block;
+      height: 1px;
+      background: $light;
+      flex-basis: 80px;
+      margin: 0 .5rem;
+    }
   }
 
-  .pgn__stepper-header-step-title-description {
+  .pgn__stepper-header-step {
+    display: flex;
+    align-items: center;
+    color: $primary;
+    flex-shrink: 1;
     min-width: 0;
-  }
+    padding: .75rem 1rem;
 
-  .pgn__stepper-header-step-title {
-    white-space: nowrap;
-    overflow: hidden;
-    min-width: 0;
-    text-overflow: ellipsis;
-  }
-
-  .pgn__stepper-header-step-description {
-    font-size: $x-small-font-size;
-  }
-
-  &.pgn__stepper-header-step-active ~ .pgn__stepper-header-step {
-    color: $gray-500;
-  }
-
-  &.pgn__stepper-header-step-has-error {
     .pgn__bubble {
-      background: transparent;
-      box-shadow: inset 0 0 0 3px $danger;
+      margin-inline-end: .5rem;
+      flex-shrink: 0;
+    }
 
-      * {
+    .pgn__stepper-header-step-title-description {
+      min-width: 0;
+    }
+
+    .pgn__stepper-header-step-title {
+      white-space: nowrap;
+      overflow: hidden;
+      min-width: 0;
+      text-overflow: ellipsis;
+    }
+
+    .pgn__stepper-header-step-description {
+      font-size: $x-small-font-size;
+    }
+
+    &.pgn__stepper-header-step-active ~ .pgn__stepper-header-step {
+      color: $gray-500;
+    }
+
+    &.pgn__stepper-header-step-has-error {
+      .pgn__bubble {
+        background: transparent;
+        box-shadow: inset 0 0 0 3px $danger;
+
+        * {
+          color: $danger;
+        }
+      }
+
+      .pgn__stepper-header-step-description {
         color: $danger;
       }
     }
 
-    .pgn__stepper-header-step-description {
-      color: $danger;
+    &.pgn__stepper-header-step-clickable {
+      cursor: pointer;
+
+      &:hover,
+      &:focus {
+        color: $primary;
+
+        .pgn__bubble {
+          background-color: $primary;
+        }
+      }
     }
   }
-}
-
-.pgn__stepper-header-line {
-  display: block;
-  height: 1px;
-  background: $light;
-  flex-basis: 80px;
-  margin: 0 .5rem;
 }

--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -70,18 +70,5 @@
         color: $danger;
       }
     }
-
-    &.pgn__stepper-header-step-clickable {
-      cursor: pointer;
-
-      &:hover,
-      &:focus {
-        color: $primary;
-
-        .pgn__bubble {
-          background-color: $primary;
-        }
-      }
-    }
   }
 }

--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -22,6 +22,11 @@
       flex-basis: 80px;
       margin: 0 .5rem;
     }
+
+    button.pgn__stepper-header-step {
+      border: none;
+      background-color: transparent;
+    }
   }
 
   .pgn__stepper-header-step {

--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -30,7 +30,7 @@
     color: $primary;
     flex-shrink: 1;
     min-width: 0;
-    padding: .75rem 1rem;
+    padding: .25rem;
 
     .pgn__bubble {
       margin-inline-end: .5rem;

--- a/src/Stepper/StepperContext.jsx
+++ b/src/Stepper/StepperContext.jsx
@@ -12,11 +12,9 @@ const stepsReducer = (stepsState, action) => {
   switch (action.type) {
     case 'remove':
       return stepsState.filter(step => step.eventKey !== action.eventKey);
-    case 'checked':
-      return;
     case 'register':
     default:
-      // If is existing step
+      // If it is existing step
       if (stepsState.some(step => step.eventKey === action.step.eventKey)) {
         newStepsState = stepsState.map(step => {
           if (step.eventKey === action.step.eventKey) {
@@ -40,19 +38,16 @@ const stepsReducer = (stepsState, action) => {
 
 export function StepperContextProvider({ children, activeKey }) {
   const [steps, dispatch] = useReducer(stepsReducer, []);
-  const [checked, setChecked] = useState([]);
+  const [currentBoundary, setCurrentBoundary] = useState(0);
   const registerStep = useCallback((step) => dispatch({ step, type: 'register' }), []);
   const removeStep = useCallback((eventKey) => dispatch({ eventKey, type: 'remove' }), []);
-  const getIsChecked = (index) => checked.includes(index + 1);
-  const getIsComplete = (eventKey) => {
+
+  const getIsViewed = (index) => index <= currentBoundary;
+
+  useEffect(() => {
     const activeIndex = steps.findIndex(step => step.eventKey === activeKey);
-    const thisIndex = steps.findIndex(step => step.eventKey === eventKey);
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => setChecked([...checked, activeIndex]), [activeIndex]);
-
-    return thisIndex < activeIndex;
-  };
+    setCurrentBoundary((prevState) => (activeIndex >= prevState ? activeIndex : prevState));
+  }, [activeKey, steps]);
 
   return (
     <StepperContext.Provider
@@ -61,8 +56,7 @@ export function StepperContextProvider({ children, activeKey }) {
         registerStep,
         steps,
         removeStep,
-        getIsComplete,
-        getIsChecked,
+        getIsViewed,
       }}
     >
       {children}

--- a/src/Stepper/StepperContext.jsx
+++ b/src/Stepper/StepperContext.jsx
@@ -41,7 +41,7 @@ export function StepperContextProvider({ children, activeKey }) {
   const getIsComplete = (eventKey) => {
     const activeIndex = steps.findIndex(step => step.eventKey === activeKey);
     const thisIndex = steps.findIndex(step => step.eventKey === eventKey);
-    return thisIndex < activeIndex;
+    return thisIndex <= activeIndex;
   };
 
   return (

--- a/src/Stepper/StepperContext.jsx
+++ b/src/Stepper/StepperContext.jsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useReducer } from 'react';
+import React, {
+  useCallback, useEffect, useReducer, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 
 export const StepperContext = React.createContext({
@@ -10,6 +12,8 @@ const stepsReducer = (stepsState, action) => {
   switch (action.type) {
     case 'remove':
       return stepsState.filter(step => step.eventKey !== action.eventKey);
+    case 'checked':
+      return;
     case 'register':
     default:
       // If is existing step
@@ -36,12 +40,18 @@ const stepsReducer = (stepsState, action) => {
 
 export function StepperContextProvider({ children, activeKey }) {
   const [steps, dispatch] = useReducer(stepsReducer, []);
+  const [checked, setChecked] = useState([]);
   const registerStep = useCallback((step) => dispatch({ step, type: 'register' }), []);
   const removeStep = useCallback((eventKey) => dispatch({ eventKey, type: 'remove' }), []);
+  const getIsChecked = (index) => checked.includes(index + 1);
   const getIsComplete = (eventKey) => {
     const activeIndex = steps.findIndex(step => step.eventKey === activeKey);
     const thisIndex = steps.findIndex(step => step.eventKey === eventKey);
-    return thisIndex <= activeIndex;
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => setChecked([...checked, activeIndex]), [activeIndex]);
+
+    return thisIndex < activeIndex;
   };
 
   return (
@@ -52,6 +62,7 @@ export function StepperContextProvider({ children, activeKey }) {
         steps,
         removeStep,
         getIsComplete,
+        getIsChecked,
       }}
     >
       {children}

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -9,34 +9,30 @@ function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
 }
 
-function StepList({ steps, activeKey, isClickable }) {
+function StepList({ steps, activeKey, clickHandler }) {
   return (
     <ul className="pgn__stepper-header-step-list">
-      {steps.map(({ label, ...stepProps }, index) => {
-        const handleClick = () => isClickable(stepProps.eventKey);
+      {steps.map(({ label, ...stepProps }, index) => (
+        <React.Fragment key={stepProps.eventKey}>
 
-        return (
-          <React.Fragment key={stepProps.eventKey}>
-
-            {index !== 0 && <StepListSeparator />}
-            <StepperHeaderStep
-              {...stepProps}
-              index={index}
-              isActive={activeKey === stepProps.eventKey}
-              onClick={isClickable && handleClick}
-            >
-              {label}
-            </StepperHeaderStep>
-          </React.Fragment>
-        );
-      })}
+          {index !== 0 && <StepListSeparator />}
+          <StepperHeaderStep
+            {...stepProps}
+            index={index}
+            isActive={activeKey === stepProps.eventKey}
+            onClick={clickHandler ? () => clickHandler(stepProps.eventKey) : undefined}
+          >
+            {label}
+          </StepperHeaderStep>
+        </React.Fragment>
+      ))}
     </ul>
   );
 }
 
 const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex + 1} of ${totalSteps}`;
 
-function StepperHeader({ className, PageCountComponent, isClickable }) {
+function StepperHeader({ className, PageCountComponent, clickHandler }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
   // assume about 200px per step
@@ -66,7 +62,7 @@ function StepperHeader({ className, PageCountComponent, isClickable }) {
   // Show all steps
   return (
     <div className={classNames('pgn__stepper-header', className)}>
-      <StepList steps={steps} isClickable={isClickable} activeKey={activeKey} />
+      <StepList steps={steps} clickHandler={clickHandler} activeKey={activeKey} />
     </div>
   );
 }
@@ -78,13 +74,13 @@ StepperHeader.propTypes = {
   PageCountComponent: PropTypes.elementType,
   /** Specifies whether the `Stepper` headers is clickable, if `true` appropriate `hover` and `focus` styling
    * will be added and opportunities toggle content. */
-  isClickable: PropTypes.func,
+  clickHandler: PropTypes.func,
 };
 
 StepperHeader.defaultProps = {
   className: null,
   PageCountComponent: PageCount,
-  isClickable: null,
+  clickHandler: null,
 };
 
 StepList.propTypes = {
@@ -95,12 +91,12 @@ StepList.propTypes = {
     hasError: PropTypes.bool,
   })),
   activeKey: PropTypes.string.isRequired,
-  isClickable: PropTypes.func,
+  clickHandler: PropTypes.func,
 };
 
 StepList.defaultProps = {
   steps: [],
-  isClickable: null,
+  clickHandler: null,
 };
 
 StepperHeader.Step = StepperHeaderStep;

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -96,7 +96,7 @@ StepList.propTypes = {
 
 StepList.defaultProps = {
   steps: [],
-  clickHandler: null,
+  clickHandler: undefined,
 };
 
 StepperHeader.Step = StepperHeaderStep;

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -9,7 +9,7 @@ function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
 }
 
-function StepList({ steps, activeKey, handleStepClick }) {
+function StepList({ steps, activeKey }) {
   return (
     <ul className="pgn__stepper-header-step-list">
       {steps.map(({ label, ...stepProps }, index) => (
@@ -19,8 +19,6 @@ function StepList({ steps, activeKey, handleStepClick }) {
             {...stepProps}
             index={index}
             isActive={activeKey === stepProps.eventKey}
-            onClick={handleStepClick && steps.every((step) => !step.hasError)
-              ? () => handleStepClick(stepProps.eventKey) : undefined}
           >
             {label}
           </StepperHeaderStep>
@@ -32,7 +30,7 @@ function StepList({ steps, activeKey, handleStepClick }) {
 
 const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex + 1} of ${totalSteps}`;
 
-function StepperHeader({ className, PageCountComponent, handleStepClick }) {
+function StepperHeader({ className, PageCountComponent }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
   // assume about 200px per step
@@ -62,7 +60,7 @@ function StepperHeader({ className, PageCountComponent, handleStepClick }) {
   // Show all steps
   return (
     <div className={classNames('pgn__stepper-header', className)}>
-      <StepList steps={steps} handleStepClick={handleStepClick} activeKey={activeKey} />
+      <StepList steps={steps} activeKey={activeKey} />
     </div>
   );
 }
@@ -72,15 +70,11 @@ StepperHeader.propTypes = {
   className: PropTypes.string,
   /** A component that receives `activeStepIndex` and `totalSteps` props to display them. */
   PageCountComponent: PropTypes.elementType,
-  /** Specifies whether the `Stepper` headers is clickable, if `true` appropriate `hover` and `focus` styling
-   * will be added and opportunities toggle content. */
-  handleStepClick: PropTypes.func,
 };
 
 StepperHeader.defaultProps = {
   className: null,
   PageCountComponent: PageCount,
-  handleStepClick: undefined,
 };
 
 StepList.propTypes = {
@@ -91,12 +85,10 @@ StepList.propTypes = {
     hasError: PropTypes.bool,
   })),
   activeKey: PropTypes.string.isRequired,
-  handleStepClick: PropTypes.func,
 };
 
 StepList.defaultProps = {
   steps: [],
-  handleStepClick: undefined,
 };
 
 StepperHeader.Step = StepperHeaderStep;

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -1,30 +1,47 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import StepperHeaderStep from './StepperHeaderStep';
 import { StepperContext } from './StepperContext';
 import { useWindowSize } from '..';
+import { constructChildren } from '../Truncate/utils';
 
 function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
 }
 
 function StepList({ steps, activeKey }) {
+  // const [state, setState] = useState(steps);
+  console.log('steps', steps);
+  console.log('activeKey', activeKey);
+
   return (
     <ul className="pgn__stepper-header-step-list">
-      {steps.map(({ label, ...stepProps }, index) => (
-        <React.Fragment key={stepProps.eventKey}>
+      {steps.map(({ label, ...stepProps }, index) => {
+        console.log('index', index);
 
-          {index !== 0 && <StepListSeparator />}
-          <StepperHeaderStep
-            {...stepProps}
-            index={index}
-            isActive={activeKey === stepProps.eventKey}
-          >
-            {label}
-          </StepperHeaderStep>
-        </React.Fragment>
-      ))}
+        const handleClick = () => {
+          console.log('I am Click!', stepProps.eventKey);
+          // if (stepProps.eventKey !== activeKey) {
+
+          // }
+        };
+
+        return (
+          <React.Fragment key={stepProps.eventKey}>
+
+            {index !== 0 && <StepListSeparator />}
+            <StepperHeaderStep
+              {...stepProps}
+              index={index}
+              isActive={activeKey === stepProps.eventKey}
+              onClick={handleClick}
+            >
+              {label}
+            </StepperHeaderStep>
+          </React.Fragment>
+        );
+      })}
     </ul>
   );
 }

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -14,13 +14,13 @@ function StepList({ steps, activeKey, handleStepClick }) {
     <ul className="pgn__stepper-header-step-list">
       {steps.map(({ label, ...stepProps }, index) => (
         <React.Fragment key={stepProps.eventKey}>
-
           {index !== 0 && <StepListSeparator />}
           <StepperHeaderStep
             {...stepProps}
             index={index}
             isActive={activeKey === stepProps.eventKey}
-            onClick={handleStepClick ? () => handleStepClick(stepProps.eventKey) : undefined}
+            onClick={handleStepClick && steps.every((step) => !step.hasError)
+              ? () => handleStepClick(stepProps.eventKey) : undefined}
           >
             {label}
           </StepperHeaderStep>

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -9,7 +9,7 @@ function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
 }
 
-function StepList({ steps, activeKey, clickHandler }) {
+function StepList({ steps, activeKey, handleStepClick }) {
   return (
     <ul className="pgn__stepper-header-step-list">
       {steps.map(({ label, ...stepProps }, index) => (
@@ -20,7 +20,7 @@ function StepList({ steps, activeKey, clickHandler }) {
             {...stepProps}
             index={index}
             isActive={activeKey === stepProps.eventKey}
-            onClick={clickHandler ? () => clickHandler(stepProps.eventKey) : undefined}
+            onClick={handleStepClick ? () => handleStepClick(stepProps.eventKey) : undefined}
           >
             {label}
           </StepperHeaderStep>
@@ -32,7 +32,7 @@ function StepList({ steps, activeKey, clickHandler }) {
 
 const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex + 1} of ${totalSteps}`;
 
-function StepperHeader({ className, PageCountComponent, clickHandler }) {
+function StepperHeader({ className, PageCountComponent, handleStepClick }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
   // assume about 200px per step
@@ -62,7 +62,7 @@ function StepperHeader({ className, PageCountComponent, clickHandler }) {
   // Show all steps
   return (
     <div className={classNames('pgn__stepper-header', className)}>
-      <StepList steps={steps} clickHandler={clickHandler} activeKey={activeKey} />
+      <StepList steps={steps} handleStepClick={handleStepClick} activeKey={activeKey} />
     </div>
   );
 }
@@ -74,13 +74,13 @@ StepperHeader.propTypes = {
   PageCountComponent: PropTypes.elementType,
   /** Specifies whether the `Stepper` headers is clickable, if `true` appropriate `hover` and `focus` styling
    * will be added and opportunities toggle content. */
-  clickHandler: PropTypes.func,
+  handleStepClick: PropTypes.func,
 };
 
 StepperHeader.defaultProps = {
   className: null,
   PageCountComponent: PageCount,
-  clickHandler: null,
+  handleStepClick: undefined,
 };
 
 StepList.propTypes = {
@@ -91,12 +91,12 @@ StepList.propTypes = {
     hasError: PropTypes.bool,
   })),
   activeKey: PropTypes.string.isRequired,
-  clickHandler: PropTypes.func,
+  handleStepClick: PropTypes.func,
 };
 
 StepList.defaultProps = {
   steps: [],
-  clickHandler: undefined,
+  handleStepClick: undefined,
 };
 
 StepperHeader.Step = StepperHeaderStep;

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -1,31 +1,19 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import StepperHeaderStep from './StepperHeaderStep';
 import { StepperContext } from './StepperContext';
 import { useWindowSize } from '..';
-import { constructChildren } from '../Truncate/utils';
 
 function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
 }
 
-function StepList({ steps, activeKey }) {
-  // const [state, setState] = useState(steps);
-  console.log('steps', steps);
-  console.log('activeKey', activeKey);
-
+function StepList({ steps, activeKey, isClickable }) {
   return (
     <ul className="pgn__stepper-header-step-list">
       {steps.map(({ label, ...stepProps }, index) => {
-        console.log('index', index);
-
-        const handleClick = () => {
-          console.log('I am Click!', stepProps.eventKey);
-          // if (stepProps.eventKey !== activeKey) {
-
-          // }
-        };
+        const handleClick = () => isClickable(stepProps.eventKey);
 
         return (
           <React.Fragment key={stepProps.eventKey}>
@@ -35,7 +23,7 @@ function StepList({ steps, activeKey }) {
               {...stepProps}
               index={index}
               isActive={activeKey === stepProps.eventKey}
-              onClick={handleClick}
+              onClick={isClickable && handleClick}
             >
               {label}
             </StepperHeaderStep>
@@ -48,7 +36,7 @@ function StepList({ steps, activeKey }) {
 
 const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex + 1} of ${totalSteps}`;
 
-function StepperHeader({ className, PageCountComponent }) {
+function StepperHeader({ className, PageCountComponent, isClickable }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
   // assume about 200px per step
@@ -78,7 +66,7 @@ function StepperHeader({ className, PageCountComponent }) {
   // Show all steps
   return (
     <div className={classNames('pgn__stepper-header', className)}>
-      <StepList steps={steps} activeKey={activeKey} />
+      <StepList steps={steps} isClickable={isClickable} activeKey={activeKey} />
     </div>
   );
 }
@@ -88,11 +76,15 @@ StepperHeader.propTypes = {
   className: PropTypes.string,
   /** A component that receives `activeStepIndex` and `totalSteps` props to display them. */
   PageCountComponent: PropTypes.elementType,
+  /** Specifies whether the `Stepper` headers is clickable, if `true` appropriate `hover` and `focus` styling
+   * will be added and opportunities toggle content. */
+  isClickable: PropTypes.func,
 };
 
 StepperHeader.defaultProps = {
   className: null,
   PageCountComponent: PageCount,
+  isClickable: null,
 };
 
 StepList.propTypes = {
@@ -103,10 +95,12 @@ StepList.propTypes = {
     hasError: PropTypes.bool,
   })),
   activeKey: PropTypes.string.isRequired,
+  isClickable: PropTypes.func,
 };
 
 StepList.defaultProps = {
   steps: [],
+  isClickable: null,
 };
 
 StepperHeader.Step = StepperHeaderStep;

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -15,27 +15,28 @@ function StepperHeaderStep({
   index,
   onClick,
 }) {
-  const { getIsComplete } = useContext(StepperContext);
+  const { getIsComplete, getIsChecked } = useContext(StepperContext);
   const isComplete = getIsComplete(eventKey);
-  const stepIcon = isComplete ? <Icon src={Check} /> : <span>{index + 1}</span>;
+  const isChecked = getIsChecked(index);
+  const stepIcon = isComplete || isChecked ? <Icon src={Check} /> : <span>{index + 1}</span>;
   const errorIcon = <Icon src={Error} />;
 
   return (
-  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <li
       /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
       tabIndex={onClick && isComplete ? 0 : -1}
+      role="presentation"
       className={classNames(
         'pgn__stepper-header-step',
         {
           'pgn__stepper-header-step-active': isActive,
           'pgn__stepper-header-step-has-error': hasError,
           'pgn__stepper-header-step-complete': isComplete,
-          'pgn__stepper-header-step-clickable': onClick && isComplete && !hasError,
+          'pgn__stepper-header-step-clickable': onClick && (isComplete || isChecked),
         },
       )}
-      onClick={isComplete ? onClick : null}
-      onKeyPress={isComplete ? onClick : null}
+      onClick={isChecked ? onClick : undefined}
+      onKeyPress={isChecked ? onClick : undefined}
     >
       <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
         {hasError ? errorIcon : stepIcon}
@@ -73,7 +74,7 @@ StepperHeaderStep.defaultProps = {
   hasError: false,
   description: undefined,
   index: 0,
-  onClick: null,
+  onClick: undefined,
 };
 
 export default StepperHeaderStep;

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -21,12 +21,35 @@ function StepperHeaderStep({
   const errorIcon = <Icon src={Error} />;
   const isClickable = onClick && isViewed && !isActive;
 
+  if (isClickable) {
+    return (
+      <button
+        type="button"
+        aria-label={`${title} step`}
+        className={classNames(
+          'pgn__stepper-header-step',
+          {
+            'pgn__stepper-header-step-active': isActive,
+            'pgn__stepper-header-step-has-error': hasError,
+            'pgn__stepper-header-step-complete': isComplete,
+          },
+        )}
+        onClick={isClickable ? onClick : undefined}
+        onKeyPress={isClickable ? onClick : undefined}
+      >
+        <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
+          {hasError ? errorIcon : stepIcon}
+        </Bubble>
+        <div className="pgn__stepper-header-step-title-description">
+          <div className="pgn__stepper-header-step-title">{title}</div>
+          <div className="pgn__stepper-header-step-description">{description}</div>
+        </div>
+      </button>
+    );
+  }
+
   return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <li
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={isClickable ? 0 : -1}
-      role={isClickable ? 'button' : undefined}
       className={classNames(
         'pgn__stepper-header-step',
         {
@@ -35,8 +58,6 @@ function StepperHeaderStep({
           'pgn__stepper-header-step-complete': isComplete,
         },
       )}
-      onClick={isClickable ? onClick : undefined}
-      onKeyPress={isClickable ? onClick : undefined}
     >
       <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
         {hasError ? errorIcon : stepIcon}
@@ -50,7 +71,7 @@ function StepperHeaderStep({
 }
 
 StepperHeaderStep.propTypes = {
-  /** A number that will be display in the icon of the `HeaderStep`.  */
+  /** A number that will be display in the icon of the `HeaderStep`. */
   index: PropTypes.number.isRequired,
   /** A text of the `HeaderStep`. */
   title: PropTypes.string.isRequired,

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -25,7 +25,8 @@ function StepperHeaderStep({
     <li
       /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
       tabIndex={isClickable ? 0 : -1}
-      role="presentation"
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role */
+      role="button"
       className={classNames(
         'pgn__stepper-header-step',
         {

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -29,15 +29,14 @@ function StepperHeaderStep({
         className={classNames(
           'pgn__stepper-header-step',
           {
-            'pgn__stepper-header-step-active': isActive,
             'pgn__stepper-header-step-has-error': hasError,
             'pgn__stepper-header-step-complete': isComplete,
           },
         )}
-        onClick={isClickable ? onClick : undefined}
-        onKeyPress={isClickable ? onClick : undefined}
+        onClick={onClick}
+        onKeyPress={onClick}
       >
-        <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
+        <Bubble variant={hasError ? 'error' : 'primary'} disabled>
           {hasError ? errorIcon : stepIcon}
         </Bubble>
         <div className="pgn__stepper-header-step-title-description">

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -13,14 +13,19 @@ function StepperHeaderStep({
   hasError,
   description,
   index,
+  onClick,
 }) {
   const { getIsComplete } = useContext(StepperContext);
   const isComplete = getIsComplete(eventKey);
   const stepIcon = isComplete ? <Icon src={Check} /> : <span>{index + 1}</span>;
   const errorIcon = <Icon src={Error} />;
 
+  if (onClick) {
+    onClick();
+  }
+
   return (
-    <li
+    <button
       className={classNames(
         'pgn__stepper-header-step',
         {
@@ -29,6 +34,8 @@ function StepperHeaderStep({
           'pgn__stepper-header-step-complete': isComplete,
         },
       )}
+      onClick={onClick}
+      type="button"
     >
       <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
         {hasError ? errorIcon : stepIcon}
@@ -37,7 +44,7 @@ function StepperHeaderStep({
         <div className="pgn__stepper-header-step-title">{title}</div>
         <div className="pgn__stepper-header-step-description">{description}</div>
       </div>
-    </li>
+    </button>
   );
 }
 
@@ -57,6 +64,7 @@ StepperHeaderStep.propTypes = {
   description: PropTypes.string,
   /** A number that will be display in the icon of the `HeaderStep`.  */
   index: PropTypes.number,
+  onClick: PropTypes.func,
 };
 
 StepperHeaderStep.defaultProps = {
@@ -64,6 +72,7 @@ StepperHeaderStep.defaultProps = {
   hasError: false,
   description: undefined,
   index: 0,
+  onClick: null,
 };
 
 export default StepperHeaderStep;

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -20,22 +20,22 @@ function StepperHeaderStep({
   const stepIcon = isComplete ? <Icon src={Check} /> : <span>{index + 1}</span>;
   const errorIcon = <Icon src={Error} />;
 
-  if (onClick) {
-    onClick();
-  }
-
   return (
-    <button
+  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <li
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+      tabIndex={onClick && isComplete ? 0 : -1}
       className={classNames(
         'pgn__stepper-header-step',
         {
           'pgn__stepper-header-step-active': isActive,
           'pgn__stepper-header-step-has-error': hasError,
           'pgn__stepper-header-step-complete': isComplete,
+          'pgn__stepper-header-step-clickable': onClick && isComplete && !hasError,
         },
       )}
-      onClick={onClick}
-      type="button"
+      onClick={isComplete ? onClick : null}
+      onKeyPress={isComplete ? onClick : null}
     >
       <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
         {hasError ? errorIcon : stepIcon}
@@ -44,7 +44,7 @@ function StepperHeaderStep({
         <div className="pgn__stepper-header-step-title">{title}</div>
         <div className="pgn__stepper-header-step-description">{description}</div>
       </div>
-    </button>
+    </li>
   );
 }
 
@@ -64,6 +64,7 @@ StepperHeaderStep.propTypes = {
   description: PropTypes.string,
   /** A number that will be display in the icon of the `HeaderStep`.  */
   index: PropTypes.number,
+  /** Callback fired when element gets clicked. */
   onClick: PropTypes.func,
 };
 

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -22,18 +22,17 @@ function StepperHeaderStep({
   const isClickable = onClick && isViewed && !isActive;
 
   return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <li
-      /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={isClickable ? 0 : -1}
-      /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role */
-      role="button"
+      role={isClickable ? 'button' : undefined}
       className={classNames(
         'pgn__stepper-header-step',
         {
           'pgn__stepper-header-step-active': isActive,
           'pgn__stepper-header-step-has-error': hasError,
           'pgn__stepper-header-step-complete': isComplete,
-          'pgn__stepper-header-step-clickable': isClickable,
         },
       )}
       onClick={isClickable ? onClick : undefined}

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -7,7 +7,6 @@ import { StepperContext } from './StepperContext';
 import { Icon, Bubble } from '..';
 
 function StepperHeaderStep({
-  eventKey,
   title,
   isActive,
   hasError,
@@ -15,16 +14,17 @@ function StepperHeaderStep({
   index,
   onClick,
 }) {
-  const { getIsComplete, getIsChecked } = useContext(StepperContext);
-  const isComplete = getIsComplete(eventKey);
-  const isChecked = getIsChecked(index);
-  const stepIcon = isComplete || isChecked ? <Icon src={Check} /> : <span>{index + 1}</span>;
+  const { getIsViewed } = useContext(StepperContext);
+  const isComplete = getIsViewed(index + 1);
+  const isViewed = getIsViewed(index);
+  const stepIcon = isComplete ? <Icon src={Check} /> : <span>{index + 1}</span>;
   const errorIcon = <Icon src={Error} />;
+  const isClickable = onClick && isViewed && !isActive;
 
   return (
     <li
       /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
-      tabIndex={onClick && isComplete ? 0 : -1}
+      tabIndex={isClickable ? 0 : -1}
       role="presentation"
       className={classNames(
         'pgn__stepper-header-step',
@@ -32,11 +32,11 @@ function StepperHeaderStep({
           'pgn__stepper-header-step-active': isActive,
           'pgn__stepper-header-step-has-error': hasError,
           'pgn__stepper-header-step-complete': isComplete,
-          'pgn__stepper-header-step-clickable': onClick && (isComplete || isChecked),
+          'pgn__stepper-header-step-clickable': isClickable,
         },
       )}
-      onClick={isChecked ? onClick : undefined}
-      onKeyPress={isChecked ? onClick : undefined}
+      onClick={isClickable ? onClick : undefined}
+      onKeyPress={isClickable ? onClick : undefined}
     >
       <Bubble variant={hasError ? 'error' : 'primary'} disabled={!isActive}>
         {hasError ? errorIcon : stepIcon}
@@ -50,11 +50,8 @@ function StepperHeaderStep({
 }
 
 StepperHeaderStep.propTypes = {
-  /**
-   * An identifier of the `HeaderStep`. When `activeKey` on the
-   * `Stepper` equals to the `eventKey`, the `HeaderStep` will be displayed.
-   */
-  eventKey: PropTypes.string.isRequired,
+  /** A number that will be display in the icon of the `HeaderStep`.  */
+  index: PropTypes.number.isRequired,
   /** A text of the `HeaderStep`. */
   title: PropTypes.string.isRequired,
   /** Specifies that this `HeaderStep` is active. */
@@ -63,8 +60,6 @@ StepperHeaderStep.propTypes = {
   hasError: PropTypes.bool,
   /** A text under the `title`. */
   description: PropTypes.string,
-  /** A number that will be display in the icon of the `HeaderStep`.  */
-  index: PropTypes.number,
   /** Callback fired when element gets clicked. */
   onClick: PropTypes.func,
 };
@@ -73,7 +68,6 @@ StepperHeaderStep.defaultProps = {
   isActive: false,
   hasError: false,
   description: undefined,
-  index: 0,
   onClick: undefined,
 };
 

--- a/src/Stepper/StepperStep.jsx
+++ b/src/Stepper/StepperStep.jsx
@@ -11,6 +11,7 @@ export default function StepperStep({
   index,
   description,
   hasError,
+  onClick,
 }) {
   const { activeKey, registerStep, removeStep } = useContext(StepperContext);
 
@@ -21,9 +22,10 @@ export default function StepperStep({
       eventKey,
       description,
       hasError,
+      onClick,
     });
     return () => removeStep(eventKey);
-  }, [title, eventKey, description, hasError, index, registerStep, removeStep]);
+  }, [title, eventKey, description, hasError, index, registerStep, removeStep, onClick]);
 
   const isActive = activeKey === eventKey;
 
@@ -59,6 +61,11 @@ StepperStep.propTypes = {
    * or conditionally rendering steps.
    * */
   index: PropTypes.number,
+  /**
+   * Click handler for the `Step`. Takes effect only after the `Step` has been visited, making it clickable
+   * and invoking this function on click. Should be used to provide navigation between steps.
+   */
+  onClick: PropTypes.func,
 };
 
 StepperStep.defaultProps = {
@@ -66,4 +73,5 @@ StepperStep.defaultProps = {
   description: undefined,
   hasError: false,
   index: undefined,
+  onClick: undefined,
 };

--- a/src/Stepper/tests/Stepper.test.jsx
+++ b/src/Stepper/tests/Stepper.test.jsx
@@ -8,11 +8,13 @@ const mockWindowSize = { width: 1000, height: 1000 };
 
 jest.mock('../../hooks/useWindowSize', () => () => mockWindowSize);
 
+function Example({
 // eslint-disable-next-line react/prop-types
-function Example({ activeKey, hasStepWithError, hasFourthStep }) {
+  activeKey, hasStepWithError, hasFourthStep, handleStepClick,
+}) {
   return (
     <Stepper activeKey={activeKey}>
-      <Stepper.Header />
+      <Stepper.Header handleStepClick={handleStepClick} />
 
       <Stepper.Step eventKey="welcome" title="Welcome" index={0}>
         <span id="welcome-content">Welcome content</span>
@@ -74,6 +76,32 @@ describe('Stepper', () => {
     expect(wrapper.exists('#welcome-actions')).toBe(false);
     expect(wrapper.exists('#cats-actions')).toBe(true);
     expect(wrapper.exists('#review-actions')).toBe(false);
+  });
+
+  describe('handleStepClick usage', () => {
+    it('function call and render button tag', () => {
+      wrapper.setProps({ activeKey: 'welcome', handleStepClick: jest.fn() });
+      wrapper.update();
+      expect(wrapper.exists('#welcome-content')).toBe(true);
+
+      wrapper.setProps({ activeKey: 'cats' });
+      expect(wrapper.exists('#welcome-content')).toBe(false);
+
+      const headerStepTitle = wrapper.find('button');
+      expect(headerStepTitle.exists('.pgn__stepper-header-step')).toEqual(true);
+    });
+
+    it('undefined function and the absence of a button tag', () => {
+      wrapper.setProps({ activeKey: 'welcome', handleStepClick: undefined });
+      wrapper.update();
+      expect(wrapper.exists('#welcome-content')).toBe(true);
+
+      wrapper.setProps({ activeKey: 'cats' });
+      expect(wrapper.exists('#welcome-content')).toBe(false);
+
+      const headerStepTitle = wrapper.find('button');
+      expect(headerStepTitle.exists('.pgn__stepper-header-step')).toBe(false);
+    });
   });
 
   describe('tab updates', () => {


### PR DESCRIPTION
## Description

Make steps clickable after the user visits them, clicking should navigate the user to clicked step.

### Deploy Preview

[Stepper component](https://deploy-preview-1712--paragon-openedx.netlify.app/components/stepper/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
