### PR TITLE
[BD-46] fix: move hooks to utils in the usage insights

### DIFF
--- a/www/src/utils/getParagonComponentsTypes.js
+++ b/www/src/utils/getParagonComponentsTypes.js
@@ -11,7 +11,7 @@ const getParagonComponentsTypes = (components) => {
       case typeof component === 'string' || typeof component === 'number':
         componentType = 'Text';
         break;
-      case component.name?.startsWith('use'):
+      case componentName.startsWith('use'):
         componentType = 'Hook';
         break;
       case isFunctionComponent || isObjectComponent || isContext:


### PR DESCRIPTION
## Description

Hooks are displayed in the production mode. `component?.name` always give undefined in production mode and replaced by `componentName`

### Deploy Preview

https://deploy-preview-1715--paragon-openedx.netlify.app/insights

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
