### PR TITLE
[BD-46] fix: fixed onToggle prop

### DIFF
--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -41,6 +41,7 @@ const Dropdown = React.forwardRef(
     const handleToggle = (isOpen, event, metadata) => {
       if (isOpen) {
         setInternalShow(true);
+        onToggle?.(isOpen, event, metadata);
         return;
       }
       let { source } = { ...metadata };


### PR DESCRIPTION
## Description

- verify onToggle is called both on open and on close, with the appropriate function arguments (e.g., isOpen should be false is the dropdown was just closed);
- ensure onToggle is part of the props API on the documentation website.

### Deploy Preview

[Dropdown component](https://deploy-preview-1719--paragon-openedx.netlify.app/components/dropdown/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
