### PR TITLE
[BD-46] docs: fix propstable always displaying 'required' badge

### DIFF
--- a/www/src/components/PropType.tsx
+++ b/www/src/components/PropType.tsx
@@ -82,7 +82,7 @@ PropType.defaultProps = {
   name: 'any',
   value: null,
   raw: '',
-  required: true,
+  required: false,
 };
 
 export interface ISimplePropType {


### PR DESCRIPTION
## Description

Currently `PropsTable` adds `required` badge for every prop of the component, even if it is actually not required, see [Card](https://paragon-openedx.netlify.app/components/card/) for example
![image](https://user-images.githubusercontent.com/52399399/198581295-c5e02ad6-8e07-45e2-9f42-4694ba8f597a.png)


### Deploy Preview

linking `Card` as an eamaple but it affects all components https://deploy-preview-1721--paragon-openedx.netlify.app/components/card/
![image](https://user-images.githubusercontent.com/52399399/198582495-4cf46c42-33da-4659-ae75-38059b9f5d89.png)



## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
