### PR TITLE
[BD-46] docs: added container width options in the Settings sheet

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -50,7 +50,6 @@
 a .pgn__card {
   color: $gray-700;
   display: inline-block;
-  margin-right: 100%;
 }
 
 .pgn__card-grid {

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -19,7 +19,7 @@ import Header from './Header';
 import Menu from './Menu';
 import Settings from './Settings';
 import Toc from './Toc';
-import SettingsContext from '../context/SettingsContext';
+import { SettingsContext } from '../context/SettingsContext';
 
 if (process.env.NODE_ENV === 'development') {
   /* eslint-disable-next-line global-require */

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, Link } from 'gatsby';
 import {
@@ -18,6 +19,7 @@ import Header from './Header';
 import Menu from './Menu';
 import Settings from './Settings';
 import Toc from './Toc';
+import SettingsContext from '../context/SettingsContext';
 
 if (process.env.NODE_ENV === 'development') {
   /* eslint-disable-next-line global-require */
@@ -39,6 +41,7 @@ function Layout({
   isMdx,
   tocData,
 }: ILayout) {
+  const { settings } = useContext(SettingsContext);
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
       site {
@@ -55,13 +58,13 @@ function Layout({
         siteTitle={data.site.siteMetadata?.title || 'Title'}
         showMinimizedTitle={showMinimizedTitle}
       />
-      <Settings />
+      <Settings showMinimizedTitle={showMinimizedTitle} />
       {isMdx ? (
         <Container fluid>
           <Row className="flex-xl-nowrap">
-            <Col className="d-none d-xl-block" xl={2} />
+            <Col className="d-none d-xl-block" xl={settings.containerWidth === 'xl' ? 1 : 2} />
             <Col
-              xl={8}
+              xl={settings.containerWidth === 'xl' ? 10 : 8}
               lg={9}
               md={12}
               as="main"
@@ -70,7 +73,7 @@ function Layout({
               {children}
             </Col>
             <Col
-              xl={2}
+              xl={settings.containerWidth === 'xl' ? 1 : 2}
               lg={3}
               as={Toc}
               data={tocData}

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -60,9 +60,9 @@ function Layout({
       />
       <Settings showMinimizedTitle={showMinimizedTitle} />
       {isMdx ? (
-        <Container fluid>
+        <Container size={settings.containerWidth} fluid>
           <Row className="flex-xl-nowrap">
-            <Col className="d-none d-xl-block" xl={settings.containerWidth === 'xl' ? 1 : 2} />
+            <Col className="d-none d-xl-block" xl={settings.containerWidth === 'xl' ? 'auto' : 2} />
             <Col
               xl={settings.containerWidth === 'xl' ? 10 : 8}
               lg={9}
@@ -73,7 +73,7 @@ function Layout({
               {children}
             </Col>
             <Col
-              xl={settings.containerWidth === 'xl' ? 1 : 2}
+              xl={2}
               lg={3}
               as={Toc}
               data={tocData}

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -60,7 +60,7 @@ function Layout({
       />
       <Settings showMinimizedTitle={showMinimizedTitle} />
       {isMdx ? (
-        <Container size={settings.containerWidth} fluid>
+        <Container fluid>
           <Row className="flex-xl-nowrap">
             <Col className="d-none d-xl-block" xl={settings.containerWidth === 'xl' ? 'auto' : 2} />
             <Col

--- a/www/src/components/Settings.tsx
+++ b/www/src/components/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import {
   Sheet,
   Form,
@@ -13,7 +14,11 @@ import { LANGUAGES } from '../config';
 import SettingsContext from '../context/SettingsContext';
 import { THEMES } from '../../theme-config';
 
-function Settings() {
+export interface ISetting {
+  showMinimizedTitle?: string,
+}
+
+function Settings({ showMinimizedTitle }: ISetting) {
   const {
     settings,
     handleSettingsChange,
@@ -84,9 +89,31 @@ function Settings() {
             ))}
           </Form.Control>
         </Form.Group>
+        {!showMinimizedTitle && (
+          <Form.Group>
+            <Form.Control
+              as="select"
+              value={settings.containerWidth}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleSettingsChange('containerWidth', e.target.value)}
+              floatingLabel="Container width"
+            >
+              <option value="xl">xl</option>
+              <option value="lg">lg</option>
+              <option value="md">md</option>
+            </Form.Control>
+          </Form.Group>
+        )}
       </Stack>
     </Sheet>
   );
 }
+
+Settings.propTypes = {
+  showMinimizedTitle: PropTypes.bool,
+};
+
+Settings.defaultProps = {
+  showMinimizedTitle: false,
+};
 
 export default Settings;

--- a/www/src/components/Settings.tsx
+++ b/www/src/components/Settings.tsx
@@ -89,6 +89,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
             ))}
           </Form.Control>
         </Form.Group>
+        {!showMinimizedTitle && (
           <Form.Group>
             <Form.Control
               as="select"
@@ -103,6 +104,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
               <option value="xl">xl</option>
             </Form.Control>
           </Form.Group>
+        )}
       </Stack>
     </Sheet>
   );

--- a/www/src/components/Settings.tsx
+++ b/www/src/components/Settings.tsx
@@ -15,7 +15,7 @@ import SettingsContext from '../context/SettingsContext';
 import { THEMES } from '../../theme-config';
 
 export interface ISetting {
-  showMinimizedTitle?: string,
+  showMinimizedTitle?: boolean,
 }
 
 function Settings({ showMinimizedTitle }: ISetting) {
@@ -89,20 +89,20 @@ function Settings({ showMinimizedTitle }: ISetting) {
             ))}
           </Form.Control>
         </Form.Group>
-        {!showMinimizedTitle && (
           <Form.Group>
             <Form.Control
               as="select"
               value={settings.containerWidth}
               onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleSettingsChange('containerWidth', e.target.value)}
-              floatingLabel="Container width"
+              floatingLabel="Container Width"
             >
-              <option value="xl">xl</option>
-              <option value="lg">lg</option>
+              <option value="xs">xs</option>
+              <option value="sm">sm</option>
               <option value="md">md</option>
+              <option value="lg">lg</option>
+              <option value="xl">xl</option>
             </Form.Control>
           </Form.Group>
-        )}
       </Stack>
     </Sheet>
   );

--- a/www/src/components/Settings.tsx
+++ b/www/src/components/Settings.tsx
@@ -98,7 +98,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
             >
               <option value="xs">xs</option>
               <option value="sm">sm</option>
-              <option value="md">md</option>
+              <option value="md">md (default)</option>
               <option value="lg">lg</option>
               <option value="xl">xl</option>
             </Form.Control>

--- a/www/src/context/SettingsContext.tsx
+++ b/www/src/context/SettingsContext.tsx
@@ -34,7 +34,7 @@ function SettingsContextProvider({ children }) {
     theme: DEFAULT_THEME,
     direction: 'ltr',
     language: 'en',
-    containerWidth: 'md',
+    containerWidth: undefined,
   });
   const [showSettings, setShowSettings] = useState(false);
 

--- a/www/src/context/SettingsContext.tsx
+++ b/www/src/context/SettingsContext.tsx
@@ -11,6 +11,7 @@ export interface IDefaultValue {
     theme?: string,
     direction?: string,
     language?: string,
+    containerWidth?: string,
   },
   theme?: string,
   handleSettingsChange: Function,
@@ -33,6 +34,7 @@ function SettingsContextProvider({ children }) {
     theme: DEFAULT_THEME,
     direction: 'ltr',
     language: 'en',
+    containerWidth: 'md',
   });
   const [showSettings, setShowSettings] = useState(false);
 

--- a/www/src/templates/component-page-template.tsx
+++ b/www/src/templates/component-page-template.tsx
@@ -112,7 +112,7 @@ export default function PageTemplate({
     >
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title={mdx.frontmatter.title} />
-      <Container size="md" className="py-5">
+      <Container size={settings.containerWidth} className="py-5">
         {isDeprecated && (
           <Alert variant="warning">
             <Alert.Heading>This component will be removed soon.</Alert.Heading>


### PR DESCRIPTION
## Description

- expose the Container width option in the Settings sheet;
- allow previewing components at different container widths.

### Deploy Preview

[Paragon site](https://deploy-preview-1726--paragon-openedx.netlify.app/components/card/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
