### PR TITLE
[BD-46] docs: highlight table of content elements while scrolling

### DIFF
--- a/www/src/components/Toc.scss
+++ b/www/src/components/Toc.scss
@@ -30,13 +30,9 @@
     color: $gray-500;
 
     &:hover,
-    &:focus {
-      font-weight: 500;
-      color: $primary-500;
-    }
-
+    &:focus,
     &.active {
-      font-weight: 500;
+      font-weight: $font-weight-semi-bold;
       color: $primary-500;
     }
   }

--- a/www/src/components/Toc.scss
+++ b/www/src/components/Toc.scss
@@ -34,5 +34,10 @@
       font-weight: 500;
       color: $primary-500;
     }
+
+    &.active {
+      font-weight: 500;
+      color: $primary-500;
+    }
   }
 }

--- a/www/src/components/Toc.tsx
+++ b/www/src/components/Toc.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 // @ts-ignore
@@ -17,13 +17,35 @@ export interface IToc {
   className?: string,
 }
 
-const Toc = ({ data, className }: IToc) => {
+function Toc({ data, className }: IToc) {
+  const [active, setActive] = useState('');
+  const observer = useRef<IntersectionObserver>();
+
+  useEffect(() => {
+    const handleObserver = (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].intersectionRatio >= 0.5) {
+        setActive(entries[0].target.id);
+      }
+    };
+
+    observer.current = new IntersectionObserver(handleObserver, { rootMargin: '-50px 0px -80% 0px', threshold: 0.5 });
+    const elements = document.querySelectorAll('main h2, main h3, main h4, main h5, main h6');
+    elements.forEach((elem) => observer.current?.observe(elem));
+
+    return () => observer.current?.disconnect();
+  }, [data]);
+
   const generateTree = (headings: { items?: Array<IItems> }) => (headings?.items?.length
     ? (
       <ul className="pgn-doc__toc-list">
         {headings.items.map(heading => (
           <li key={heading.url}>
-            <a href={heading.url}>{heading.title}</a>
+            <a
+              href={heading.url}
+              className={classNames({ active: `#${active}` === heading.url })}
+            >
+              {heading.title}
+            </a>
             {!!heading.items && generateTree(heading)}
           </li>
         ))}
@@ -41,7 +63,7 @@ const Toc = ({ data, className }: IToc) => {
       {tocTree}
     </Sticky>
   ) : null;
-};
+}
 
 const itemsShape = {
   url: PropTypes.string,


### PR DESCRIPTION
## Description

Table of content items are highlighted while user scrolls the page. Values inside `IntersectionObserver` was chosen by testing user experience. Clicking on anchors or table of content items can be not caught by observer because of component remount. Gatsby router thinks that it is like page reloading.

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
