### PR TITLE
[BD-46] fix: fixed close button in the Modal components

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -72,7 +72,7 @@
 .pgn__modal-close-container {
   position: absolute;
   z-index: 10;
-  top: $modal-header-padding-y;
+  top: $modal-close-container-top;
   inset-inline-end: $modal-header-padding-y;
 }
 

--- a/src/Modal/_variables.scss
+++ b/src/Modal/_variables.scss
@@ -29,6 +29,7 @@ $modal-header-border-width:         $modal-content-border-width !default;
 $modal-footer-border-width:         $modal-header-border-width !default;
 $modal-header-padding-y:            1rem !default;
 $modal-header-padding-x:            1.5rem !default;
+$modal-close-container-top:         .625rem !default;
 
 // Keep this for backwards compatibility
 $modal-header-padding:              $modal-header-padding-y $modal-header-padding-x !default;


### PR DESCRIPTION
## Description

- update the FullscreenModal component to have proper alignment in its header component;
- check other Modal components and verify they don't have the same issue.

<img width="1431" alt="Screenshot 2022-11-03 at 02 23 13" src="https://user-images.githubusercontent.com/93188219/199772457-e6c8037b-bd41-4dd5-a2da-ffa4d8171ef0.png">
<img width="920" alt="Screenshot 2022-11-03 at 18 02 35" src="https://user-images.githubusercontent.com/93188219/199772502-6838019d-80ec-4c77-ad4e-4446411353f9.png">
<img width="1680" alt="Screenshot 2022-11-03 at 18 03 02" src="https://user-images.githubusercontent.com/93188219/199772512-dcb0eb04-1229-46d2-9c82-f9c0195b3da4.png">


### Deploy Preview

[FullscreenModal component](https://deploy-preview-1733--paragon-openedx.netlify.app/components/modal/fullscreen-modal/)
[StandartModal component](https://deploy-preview-1733--paragon-openedx.netlify.app/components/modal/standard-modal/)
[ModalDialog component](https://deploy-preview-1733--paragon-openedx.netlify.app/components/modal/modal-dialog/)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
