### PR TITLE
[BD-46] fix: fixed skeletonHeight in Card component

### DIFF
--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -650,7 +650,7 @@ A fallback source is available for both the main `ImageCap` component image and 
   return (
     <Card isLoading orientation={isExtraSmall ? "vertical" : "horizontal"}>
       <Card.ImageCap
-        skeletonHeight={isExtraSmall ? 140 : undefined}
+        skeletonHeight={isExtraSmall ? 140 : null}
         src="https://source.unsplash.com/360x200/?nature,flower"
         srcAlt="Card image"
         logoSrc="https://via.placeholder.com/150"


### PR DESCRIPTION
## Description

On the Paragon documentation site in the [Card component](https://paragon-openedx.netlify.app/components/card/), fix the display of the skeleton on the horizontal version of the card.

![image](https://user-images.githubusercontent.com/93188219/200312985-43fdf56a-8917-46ff-a5bf-0b776a8cbf2b.png)

### Deploy Preview

[Card component](https://deploy-preview-1746--paragon-openedx.netlify.app/components/card/#with-loading-state)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
