### PR TITLE
docs: add additional dependents for Usage Insights

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -191,6 +191,16 @@ jobs:
       with:
         repository: edx/studio-frontend
         path: dependent-usage-analyzer/.projects/studio-frontend
+    - name: Checkout edx/frontend-app-communications
+      uses: actions/checkout@v2
+      with:
+        repository: edx/frontend-app-communications
+        path: dependent-usage-analyzer/.projects/frontend-app-communications
+    - name: Checkout edx/frontend-app-learner-dashboard
+      uses: actions/checkout@v2
+      with:
+        repository: edx/frontend-app-learner-dashboard
+        path: dependent-usage-analyzer/.projects/frontend-app-learner-dashboard
     - name: Verify checkouts
       working-directory: dependent-usage-analyzer
       run: ls -la .projects

--- a/dependent-usage-analyzer/checkout-dependents.sh
+++ b/dependent-usage-analyzer/checkout-dependents.sh
@@ -38,4 +38,6 @@ mkdir .projects
   git clone git@github.com:openedx/frontend-template-application.git --depth 1
   git clone git@github.com:edx/prospectus.git --depth 1
   git clone git@github.com:openedx/studio-frontend.git --depth 1
+  git clone git@github.com:edx/frontend-app-communications --depth 1
+  git clone git@github.com:edx/frontend-app-learner-dashboard.git -- depth 1
 )


### PR DESCRIPTION
## Description

Adds 2 newer MFEs to the "Usage Insights" analyzer (https://paragon-openedx.netlify.app/insights)
* `edx/frontend-app-communications`
* `edx/frontend-app-learner-dashboard`

After this PR merges, I plan to kick off the `dependent-usage-analyzer` Github Action workflow to re-generate the `dependent-usage.json` file to include any `@edx/paragon` imports from these repos.

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
