### PR TITLE
fix: throw non-tab component error for development env

### DIFF
--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -72,7 +72,7 @@ function Tabs({
   const tabsChildren = useMemo(() => {
     const indexOfOverflowStart = indexOfLastVisibleChild + 1;
     const childrenList = React.Children.map(children, (child, index) => {
-      if (child?.type?.name !== 'Tab') {
+      if (child?.type?.name !== 'Tab' && process.env.NODE_ENV === 'development') {
         // eslint-disable-next-line no-console
         console.error(
           `Tabs children can only be of type Tab. ${children[index]} was passed instead.`,


### PR DESCRIPTION
## Description

Details: https://github.com/openedx/paragon/issues/1790
For non-tab component failures, added a check to conditionally throw the `console.error` for development environment only. 

### Deploy Preview

https://deploy-preview-1792--paragon-openedx.netlify.app/components/tabs/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
