### PR TITLE
feat: DataTable selections clean up and improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "glob": "^8.0.3",
         "lodash.uniqby": "^4.7.0",
         "mailto-link": "^2.0.0",
-        "nanoid": "^4.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
         "react-dropzone": "^14.2.1",
@@ -32,7 +31,8 @@
         "react-table": "^7.7.0",
         "react-transition-group": "^4.4.2",
         "tabbable": "^5.3.3",
-        "uncontrollable": "^7.2.1"
+        "uncontrollable": "^7.2.1",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.8",
@@ -11713,17 +11713,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17969,6 +17958,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -27131,11 +27128,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -31561,6 +31553,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "glob": "^8.0.3",
         "lodash.uniqby": "^4.7.0",
         "mailto-link": "^2.0.0",
+        "nanoid": "^4.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
         "react-dropzone": "^14.2.1",
@@ -11713,15 +11714,14 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/natural-compare": {
@@ -15160,6 +15160,18 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -27120,10 +27132,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -29416,6 +29427,14 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+          "dev": true
+        }
       }
     },
     "postcss-media-query-parser": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "glob": "^8.0.3",
     "lodash.uniqby": "^4.7.0",
     "mailto-link": "^2.0.0",
-    "nanoid": "^4.0.0",
     "prop-types": "^15.8.1",
     "react-bootstrap": "^1.6.5",
     "react-dropzone": "^14.2.1",
@@ -70,7 +69,8 @@
     "react-table": "^7.7.0",
     "react-transition-group": "^4.4.2",
     "tabbable": "^5.3.3",
-    "uncontrollable": "^7.2.1"
+    "uncontrollable": "^7.2.1",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "glob": "^8.0.3",
     "lodash.uniqby": "^4.7.0",
     "mailto-link": "^2.0.0",
+    "nanoid": "^4.0.0",
     "prop-types": "^15.8.1",
     "react-bootstrap": "^1.6.5",
     "react-dropzone": "^14.2.1",

--- a/src/AvatarButton/README.md
+++ b/src/AvatarButton/README.md
@@ -20,13 +20,13 @@ A button that contains the user’s Avatar.
 ```jsx live
 <>
   <div>
-    <AvatarButton size="lg" src="https://source.unsplash.com/128x128/?dog,portrait">Casey</AvatarButton>
+    <AvatarButton size="lg" src="https://picsum.photos/128/128/">Casey</AvatarButton>
   </div>
   <div>
-    <AvatarButton size="md" src="https://source.unsplash.com/128x128/?dog,portrait">Casey</AvatarButton>
+    <AvatarButton size="md" src="https://picsum.photos/128/128/">Casey</AvatarButton>
   </div>
   <div>
-    <AvatarButton size="sm" src="https://source.unsplash.com/128x128/?dog,portrait">Casey</AvatarButton>
+    <AvatarButton size="sm" src="https://picsum.photos/128/128/">Casey</AvatarButton>
   </div>
 </>
 ```
@@ -36,7 +36,7 @@ A button that contains the user’s Avatar.
 
 ```jsx live
 <Dropdown>
-  <Dropdown.Toggle as={AvatarButton} src="https://source.unsplash.com/128x128/?dog,portrait">
+  <Dropdown.Toggle as={AvatarButton} src="https://picsum.photos/128/128">
     Casey
   </Dropdown.Toggle>
 
@@ -55,7 +55,7 @@ Props set on Dropdown.Toggle get passed through to the "as" component
 
 ```jsx live
 <Dropdown>
-  <Dropdown.Toggle as={AvatarButton} size="sm" src="https://source.unsplash.com/128x128/?dog,portrait">
+  <Dropdown.Toggle as={AvatarButton} size="sm" src="https://picsum.photos/128/128/">
     Casey
   </Dropdown.Toggle>
 
@@ -77,17 +77,17 @@ For use in mobile viewports or constrained views.
 ```jsx live
 <>
   <div>
-    <AvatarButton showLabel={false} size="lg" src="https://source.unsplash.com/128x128/?dog,portrait">Casey</AvatarButton>
+    <AvatarButton showLabel={false} size="lg" src="https://picsum.photos/128/128/">Casey</AvatarButton>
   </div>
   <div>
-    <AvatarButton showLabel={false} size="md" src="https://source.unsplash.com/128x128/?dog,portrait">Casey</AvatarButton>
+    <AvatarButton showLabel={false} size="md" src="https://picsum.photos/128/128/">Casey</AvatarButton>
   </div>
   <div>
-    <AvatarButton showLabel={false} size="sm" src="https://source.unsplash.com/128x128/?dog,portrait">Casey</AvatarButton>
+    <AvatarButton showLabel={false} size="sm" src="https://picsum.photos/128/128/">Casey</AvatarButton>
   </div>
 
   <Dropdown>
-    <Dropdown.Toggle  showLabel={false} as={AvatarButton} src="https://source.unsplash.com/128x128/?dog,portrait">
+    <Dropdown.Toggle  showLabel={false} as={AvatarButton} src="https://picsum.photos/128/128/">
       Casey
     </Dropdown.Toggle>
 

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -4,7 +4,6 @@
 .pgn__card,
 .pgn__card-body {
   width: 100%;
-  height: 100%;
 
   &.is-muted {
     background-color: $light-200;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -4,6 +4,7 @@
 .pgn__card,
 .pgn__card-body {
   width: 100%;
+  height: 100%;
 
   &.is-muted {
     background-color: $light-200;
@@ -264,7 +265,6 @@ a .pgn__card {
   height: $card-logo-height;
   border-radius: $card-logo-border-radius;
   box-shadow: $level-1-box-shadow;
-  z-index: 1;
   padding: map_get($spacers, 2);
   background-color: $white;
 }

--- a/src/Card/CardFooter.jsx
+++ b/src/Card/CardFooter.jsx
@@ -42,7 +42,7 @@ const CardFooter = React.forwardRef(({
 
 CardFooter.propTypes = {
   /** Specifies contents of the component. */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /** Specifies class name to append to the base element. */
   className: PropTypes.string,
   /** Optional node to display near actions. Should be either a plain text or an element containing text (e.g. link). */
@@ -58,6 +58,7 @@ CardFooter.propTypes = {
 };
 
 CardFooter.defaultProps = {
+  children: null,
   className: undefined,
   textElement: undefined,
   isStacked: false,

--- a/src/Card/CardSection.jsx
+++ b/src/Card/CardSection.jsx
@@ -45,7 +45,7 @@ CardSection.propTypes = {
   /** Specifies class name to append to the base element. */
   className: PropTypes.string,
   /** Specifies contents of the component. */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /** Specifies title of the `Section`. */
   title: PropTypes.node,
   /** Specifies node to render on the bottom right of the `Section` (i.e. `ActionRow`). */
@@ -59,6 +59,7 @@ CardSection.propTypes = {
 };
 
 CardSection.defaultProps = {
+  children: null,
   className: undefined,
   title: undefined,
   actions: undefined,

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -35,7 +35,7 @@ This component uses a `Card` from react-bootstrap as a base component and extend
   return (
     <Card style={{ width: isExtraSmall ? "100%" : "18rem" }}>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
       />
       <Card.Header
@@ -62,7 +62,7 @@ Use `muted` prop to show `Card` in inactive state.
   return (
     <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} muted>
       <Card.ImageCap 
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
       />
       <Card.Header
@@ -89,7 +89,7 @@ You use `isClickable` prop to add additional `hover` and `focus` styling to the 
   return (
     <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} isClickable>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
       />
       <Card.Header
@@ -117,7 +117,7 @@ link styling to make its content appear as a regular text.
     <Hyperlink destination="https://www.edx.org">
       <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} isClickable>
         <Card.ImageCap
-          src="https://source.unsplash.com/360x200/?nature,flower"
+          src="https://picsum.photos/360/200/"
           srcAlt="Card image"
         />
         <Card.Header title="Card Title"/>
@@ -348,7 +348,7 @@ Note that `Card.Footer` has a separate `orientation` prop which will override th
   return (
     <Card style={{ width: isExtraSmall ? "100%" : "40%" }}>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
         logoSrc="https://via.placeholder.com/150"
         logoAlt="Card logo"
@@ -386,7 +386,7 @@ When using horizontal variant Paragon provides additional component `Card.Body` 
         orientation={isSmall ? "vertical" : "horizontal"}
       >
         <Card.ImageCap
-          src="https://source.unsplash.com/360x200/?nature,flower"
+          src="https://picsum.photos/360/200/"
           srcAlt="Card image"
           logoSrc="https://via.placeholder.com/150"
           logoAlt="Card logo"
@@ -410,7 +410,7 @@ When using horizontal variant Paragon provides additional component `Card.Body` 
       </Card>
       <Card className="mb-4" orientation={isSmall ? "vertical" : "horizontal"}>
         <Card.ImageCap
-          src="https://source.unsplash.com/360x200/?nature,flower"
+          src="https://picsum.photos/360/200/"
           srcAlt="Card image"
           logoSrc="https://via.placeholder.com/150"
           logoAlt="Card logo"
@@ -427,7 +427,7 @@ When using horizontal variant Paragon provides additional component `Card.Body` 
       </Card>
       <Card orientation={isSmall ? "vertical" : "horizontal"}>
         <Card.ImageCap
-          src="https://source.unsplash.com/360x200/?nature,flower"
+          src="https://picsum.photos/360/200/"
           srcAlt="Card image"
           logoSrc="https://via.placeholder.com/150"
           logoAlt="Card logo"
@@ -512,7 +512,7 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
   return (
     <Card style={{ width: isExtraSmall ? "100%" : "25rem" }}>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower" 
+        src="https://picsum.photos/360/200/" 
         srcAlt="Card image"
       />
       <Card.Section className="text-center">
@@ -551,7 +551,7 @@ Note that in the example below, the content of `Card` is wrapped inside `Card.Bo
   return (
     <Card orientation={isSmall ? "vertical" : "horizontal"}>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower" 
+        src="https://picsum.photos/360/200/" 
         srcAlt="Card image"
       />
       <Card.Body>
@@ -599,7 +599,7 @@ A fallback source is available for both the main `ImageCap` component image and 
     <Card style={{width: isExtraSmall ? "100%" : "40%"}}>
       <Card.ImageCap
           src="fakeURL"
-          fallbackSrc="https://source.unsplash.com/360x200/?ocean"
+          fallbackSrc="https://picsum.photos/360/200/"
           srcAlt="Card image"
           logoSrc="fakeURL"
           fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
@@ -627,7 +627,7 @@ A fallback source is available for both the main `ImageCap` component image and 
   return (
     <Card isLoading style={{ width: isExtraSmall ? "100%" : "18rem" }}>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
       />
       <Card.Header title="Card Title" />
@@ -651,7 +651,7 @@ A fallback source is available for both the main `ImageCap` component image and 
     <Card isLoading orientation={isExtraSmall ? "vertical" : "horizontal"}>
       <Card.ImageCap
         skeletonHeight={isExtraSmall ? 140 : null}
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
         logoSrc="https://via.placeholder.com/150"
         logoAlt="Card logo"
@@ -687,7 +687,7 @@ behavior.
 >
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -706,7 +706,7 @@ behavior.
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -724,7 +724,7 @@ behavior.
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -743,7 +743,7 @@ behavior.
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -762,7 +762,7 @@ behavior.
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -780,7 +780,7 @@ behavior.
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -811,7 +811,7 @@ it is meant to be used as a single horizontal row of Cards, not as a grid. See C
 <CardDeck>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -830,7 +830,7 @@ it is meant to be used as a single horizontal row of Cards, not as a grid. See C
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header
@@ -848,7 +848,7 @@ it is meant to be used as a single horizontal row of Cards, not as a grid. See C
   </Card>
   <Card>
     <Card.ImageCap
-      src="https://source.unsplash.com/360x200/?nature,flower"
+      src="https://picsum.photos/360/200/"
       srcAlt="Card image"
     />
     <Card.Header

--- a/src/Carousel/README.md
+++ b/src/Carousel/README.md
@@ -28,7 +28,7 @@ notes: |
   <Carousel.Item>
     <img
       className="d-block w-100"
-      src="https://source.unsplash.com/1600x800/?nature,flower"
+      src="https://picsum.photos/1600/800/"
       alt="First slide"
     />
     <Carousel.Caption>
@@ -39,7 +39,7 @@ notes: |
   <Carousel.Item>
     <img
       className="d-block w-100"
-      src="https://source.unsplash.com/1600x800/?nature,plants"
+      src="https://picsum.photos/1600/800/"
       alt="Third slide"
     />
 
@@ -51,7 +51,7 @@ notes: |
   <Carousel.Item>
     <img
       className="d-block w-100"
-      src="https://source.unsplash.com/1600x800/?nature,fruit"
+      src="https://picsum.photos/1600/800/"
       alt="Third slide"
     />
 

--- a/src/DataTable/CardView.jsx
+++ b/src/DataTable/CardView.jsx
@@ -40,7 +40,7 @@ function CardItem({
 
 function DefaultSkeletonCardComponent() {
   return (
-    <Card isLoading>
+    <Card isLoading data-testid="default-skeleton-card-component">
       <Card.ImageCap logoSkeleton />
       <Card.Section className="pgn__data-table-card-view-default-skeleton-card-section" />
       <Card.Footer />
@@ -48,12 +48,15 @@ function DefaultSkeletonCardComponent() {
   );
 }
 
+export const DEFAULT_SKELETON_CARD_COUNT = 8;
+
 function CardView({
   columnSizes,
   CardComponent,
   className,
   selectionPlacement,
   SkeletonCardComponent = DefaultSkeletonCardComponent,
+  skeletonCardCount,
 }) {
   const {
     getTableProps, prepareRow, displayRows,
@@ -78,7 +81,7 @@ function CardView({
         className={classNames('pgn__data-table-card-view', className)}
         columnSizes={columnSizes}
       >
-        {[...new Array(8)].map(() => <SkeletonCardComponent key={uuidv4()} />)}
+        {[...new Array(skeletonCardCount)].map(() => <SkeletonCardComponent key={uuidv4()} />)}
       </CardGrid>
     );
   }
@@ -128,6 +131,7 @@ CardView.defaultProps = {
   className: undefined,
   selectionPlacement: 'right',
   SkeletonCardComponent: undefined,
+  skeletonCardCount: 8,
 };
 
 CardView.propTypes = {
@@ -151,6 +155,8 @@ CardView.propTypes = {
   selectionPlacement: PropTypes.oneOf(['left', 'right']),
   /** Overrides default skeleton card component for loading state in CardView */
   SkeletonCardComponent: PropTypes.func,
+  /** Customize the number of loading skeleton cards to display in CardView */
+  skeletonCardCount: PropTypes.number,
 };
 
 export default CardView;

--- a/src/DataTable/CardView.jsx
+++ b/src/DataTable/CardView.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { nanoid } from 'nanoid';
+import { v4 as uuidv4 } from 'uuid';
 import DataTableContext from './DataTableContext';
 import { useRows } from './hooks';
 import { selectColumn } from './utils/getVisibleColumns';
@@ -78,7 +78,7 @@ function CardView({
         className={classNames('pgn__data-table-card-view', className)}
         columnSizes={columnSizes}
       >
-        {[...new Array(8)].map(() => <SkeletonCardComponent key={nanoid()} />)}
+        {[...new Array(8)].map(() => <SkeletonCardComponent key={uuidv4()} />)}
       </CardGrid>
     );
   }

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -295,6 +295,10 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   align-items: flex-start;
   flex-grow: 1;
 
+  > :first-child {
+    height: 100%; // ensure Card stretches full height of column
+  }
+
   &.is-selected {
     > :first-child {
       @extend %pgn__card-focused;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -261,6 +261,10 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 
 .pgn__data-table-card-view {
   padding: 0 $data-table-padding-x;
+
+  .pgn__data-table-card-view-default-skeleton-card-section {
+    margin-top: map_get($spacers, 2);
+  }
 }
 
 .pgn__data-table__action-btn {
@@ -299,12 +303,11 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 
   &.selection-right {
     > :first-child {
+      margin-right: map_get($spacers, 2);
+
       [dir="rtl"] & {
         margin-left: map_get($spacers, 2);
-      }
-
-      [dir="ltr"] & {
-        margin-right: map_get($spacers, 2);
+        margin-right: 0;
       }
     }
   }

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -320,7 +320,7 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
 
     return (
       <Card className={className}>
-        <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image" />
+        <Card.ImageCap src="https://picsum.photos/360/200/" srcAlt="Card image" />
         <Card.Header title={name} />
         <Card.Section>
           <dl>
@@ -1073,7 +1073,7 @@ Use `columnSizes` prop of `CardView` component to define how many `Cards` are sh
 		
     return (
       <Card className={className}>
-        <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image" />
+        <Card.ImageCap src="https://picsum.photos/360/200/" srcAlt="Card image" />
         <Card.Body>
           <Card.Header title={name} />
           <Card.Section>
@@ -1157,7 +1157,7 @@ You can also display `Cards` with horizontal view. If the table is selectable co
 
     return (
       <Card className={className} orientation="horizontal">
-        <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image" />
+        <Card.ImageCap src="https://picsum.photos/360/200/" srcAlt="Card image" />
         <Card.Body>
           <Card.Header title={name} />
           <Card.Section>

--- a/src/DataTable/SmartStatus.jsx
+++ b/src/DataTable/SmartStatus.jsx
@@ -8,7 +8,12 @@ const SMART_STATUS_CLASS = 'pgn__smart-status';
 
 function SmartStatus() {
   const {
-    state, selectedFlatRows, SelectionStatusComponent, FilterStatusComponent, RowStatusComponent, showFiltersInSidebar,
+    state,
+    selectedFlatRows,
+    SelectionStatusComponent,
+    FilterStatusComponent,
+    RowStatusComponent,
+    showFiltersInSidebar,
   } = useContext(DataTableContext);
   const numSelectedRows = selectedFlatRows?.length;
   const SelectionStatus = SelectionStatusComponent || SelectionStatusDefault;

--- a/src/DataTable/TableFooter.jsx
+++ b/src/DataTable/TableFooter.jsx
@@ -1,12 +1,15 @@
-/* eslint-disable react/require-default-props */
-import React from 'react';
+import React, { useContext } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import RowStatus from './RowStatus';
+import DataTableContext from './DataTableContext';
+import RowStatusDefault from './RowStatus';
 import TablePagination from './TablePagination';
 import TablePaginationMinimal from './TablePaginationMinimal';
 
 function TableFooter({ className, children }) {
+  const { RowStatusComponent } = useContext(DataTableContext);
+  const RowStatus = RowStatusComponent || RowStatusDefault;
+
   return (
     <div className={classNames(className, 'pgn__data-table-footer')}>
       {children || (

--- a/src/DataTable/TableFooter.jsx
+++ b/src/DataTable/TableFooter.jsx
@@ -9,7 +9,13 @@ import TablePaginationMinimal from './TablePaginationMinimal';
 function TableFooter({ className, children }) {
   return (
     <div className={classNames(className, 'pgn__data-table-footer')}>
-      {children}
+      {children || (
+        <>
+          <RowStatus />
+          <TablePagination />
+          <TablePaginationMinimal />
+        </>
+      )}
     </div>
   );
 }
@@ -26,14 +32,8 @@ TableFooter.propTypes = {
 };
 
 TableFooter.defaultProps = {
-  children: (
-    <>
-      <RowStatus />
-      <TablePagination />
-      <TablePaginationMinimal />
-    </>
-  ),
-  className: null,
+  children: null,
+  className: undefined,
 };
 
 export default TableFooter;

--- a/src/DataTable/dataviews.mdx
+++ b/src/DataTable/dataviews.mdx
@@ -341,7 +341,7 @@ const MiyazakiCard = ({ className, original  }) => {
 
   return (
     <Card className={className}>
-      <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image" />
+      <Card.ImageCap src="https://picsum.photos/360/200/" srcAlt="Card image" />
       <Card.Section title={title}>
         <dl>
           <dt>Director</dt><dd>{director}</dd>

--- a/src/DataTable/hooks.jsx
+++ b/src/DataTable/hooks.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable import/prefer-default-export */
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import DataTableContext from './DataTableContext';
 import { clearSelectionAction } from './selection/data/actions';
 
@@ -27,14 +26,15 @@ export const useSelectionActions = (
 ) => {
   const [{ selectedRows, isEntireTableSelected }, dispatch] = controlledTableSelections;
 
-  const clearSelection = () => {
+  const clearSelection = useCallback(() => {
     // if using controlled selection component DataTable.ControlledSelectionStatus
     if (selectedRows.length > 0 || isEntireTableSelected) {
       dispatch(clearSelectionAction());
     } else {
       toggleAllRowsSelected(false);
     }
-  };
+  }, [dispatch, isEntireTableSelected, selectedRows, toggleAllRowsSelected]);
+
   return {
     clearSelection,
   };

--- a/src/DataTable/hooks.jsx
+++ b/src/DataTable/hooks.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { useContext } from 'react';
 import DataTableContext from './DataTableContext';
 import { clearSelectionAction } from './selection/data/actions';
 
@@ -26,14 +26,14 @@ export const useSelectionActions = (
 ) => {
   const [{ selectedRows, isEntireTableSelected }, dispatch] = controlledTableSelections;
 
-  const clearSelection = useCallback(() => {
+  const clearSelection = () => {
     // if using controlled selection component DataTable.ControlledSelectionStatus
     if (selectedRows.length > 0 || isEntireTableSelected) {
       dispatch(clearSelectionAction());
     } else {
       toggleAllRowsSelected(false);
     }
-  }, [dispatch, isEntireTableSelected, selectedRows, toggleAllRowsSelected]);
+  };
 
   return {
     clearSelection,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -2,7 +2,7 @@ import React, {
   useEffect, useMemo, useReducer,
 } from 'react';
 import PropTypes from 'prop-types';
-import { useTable } from 'react-table';
+import { useTable, useMountedLayoutEffect } from 'react-table';
 
 import classNames from 'classnames';
 import Table from './Table';
@@ -127,7 +127,7 @@ function DataTable({
     }
   }, [fetchData, tableStatePageSize, tableStatePageIndex, tableStateSortBy, tableStateFilters]);
 
-  useEffect(() => {
+  useMountedLayoutEffect(() => {
     if (onSelectedRowsChanged) {
       onSelectedRowsChanged(tableStateSelectedRowIds);
     }

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -51,6 +51,7 @@ function DataTable({
   disableElevation,
   isLoading,
   children,
+  onSelectedRowsChanged,
   ...props
 }) {
   const defaultColumn = useMemo(
@@ -107,17 +108,30 @@ function DataTable({
   // Use the state and functions returned from useTable to build your UI
   const instance = useTable(...tableArgs);
 
-  // Call ``fetchData`` whenever the state of the table changes (e.g., page change, sort or filter applied) but ignore
-  // any state changes to current row selections as we don't want to re-fetch data whenever row(s) are selected.
-  const tableStateWithoutSelections = { ...instance.state };
-  delete tableStateWithoutSelections.selectedRowIds;
+  const {
+    pageSize: tableStatePageSize,
+    pageIndex: tableStatePageIndex,
+    sortBy: tableStateSortBy,
+    filters: tableStateFilters,
+    selectedRowIds: tableStateSelectedRowIds,
+  } = instance.state;
 
   useEffect(() => {
     if (fetchData) {
-      fetchData(tableStateWithoutSelections);
+      fetchData({
+        pageSize: tableStatePageSize,
+        pageIndex: tableStatePageIndex,
+        sortBy: tableStateSortBy,
+        filters: tableStateFilters,
+      });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchData, JSON.stringify(tableStateWithoutSelections)]);
+  }, [fetchData, tableStatePageSize, tableStatePageIndex, tableStateSortBy, tableStateFilters]);
+
+  useEffect(() => {
+    if (onSelectedRowsChanged) {
+      onSelectedRowsChanged(tableStateSelectedRowIds);
+    }
+  }, [tableStateSelectedRowIds, onSelectedRowsChanged]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
 
@@ -134,6 +148,7 @@ function DataTable({
     disableElevation,
     isLoading,
     isSelectable,
+    manualSelectColumn,
     ...selectionProps,
     ...selectionActions,
     ...props,
@@ -193,6 +208,7 @@ DataTable.defaultProps = {
   renderRowSubComponent: undefined,
   isExpandable: false,
   isLoading: false,
+  onSelectedRowsChanged: undefined,
 };
 
 DataTable.propTypes = {
@@ -264,6 +280,7 @@ DataTable.propTypes = {
     pageIndex: requiredWhen(PropTypes.number, 'isPaginated'),
     filters: requiredWhen(PropTypes.arrayOf(PropTypes.shape()), 'manualFilters'),
     sortBy: requiredWhen(PropTypes.arrayOf(PropTypes.shape()), 'manualSortBy'),
+    selectedRowIds: PropTypes.shape(),
   }),
   /** Table options passed to react-table's useTable hook. Will override some options passed in to DataTable, such
      as: data, columns, defaultColumn, manualFilters, manualPagination, manualSortBy, and initialState */
@@ -351,13 +368,16 @@ DataTable.propTypes = {
      * actions section. Only 'left' and 'bottom' are supported */
     togglePlacement: PropTypes.string,
   }),
-  /** remove the default box shadow on the component */
+  /** Remove the default box shadow on the component */
   disableElevation: PropTypes.bool,
   /** A function that will render contents of expanded row, accepts `row` as a prop. */
   renderRowSubComponent: PropTypes.func,
   /** Indicates whether table supports expandable rows. */
   isExpandable: PropTypes.bool,
+  /** Indicates whether the table should show loading states. */
   isLoading: PropTypes.bool,
+  /** Callback function called when row selections change. */
+  onSelectedRowsChanged: PropTypes.func,
 };
 
 DataTable.BulkActions = BulkActions;

--- a/src/DataTable/tests/CardView.test.jsx
+++ b/src/DataTable/tests/CardView.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { selectColumn } from '../utils/getVisibleColumns';
-import CardView from '../CardView';
+import CardView, { DEFAULT_SKELETON_CARD_COUNT } from '../CardView';
 import DataTableContext from '../DataTableContext';
 
 const instance = {
@@ -34,6 +34,11 @@ const instance = {
   }],
 };
 
+const loadingInstance = {
+  ...instance,
+  isLoading: true,
+};
+
 const selectableInstance = {
   ...instance,
   isSelectable: true,
@@ -52,10 +57,10 @@ function Card({ name }) {
 }
 
 // eslint-disable-next-line react/prop-types
-function CardViewWrapper({ value = instance }) {
+function CardViewWrapper({ value = instance, ...props }) {
   return (
     <DataTableContext.Provider value={value}>
-      <CardView CardComponent={Card} />
+      <CardView CardComponent={Card} {...props} />
     </DataTableContext.Provider>
   );
 }
@@ -85,5 +90,10 @@ describe('<CardView />', () => {
     expect(selectionComponents.length).toEqual(2);
     expect(selectionComponents[0]).not.toBeChecked();
     expect(selectionComponents[1]).toBeChecked();
+  });
+
+  it('renders card loading state', () => {
+    render(<CardViewWrapper value={loadingInstance} />);
+    expect(screen.queryAllByTestId('default-skeleton-card-component')).toHaveLength(DEFAULT_SKELETON_CARD_COUNT);
   });
 });

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -1,8 +1,11 @@
 import React, { useContext } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import * as reactTable from 'react-table';
 import { IntlProvider } from 'react-intl';
+import '@testing-library/jest-dom';
 
 import DataTable from '..';
 import TableControlBar from '../TableControlBar';
@@ -30,37 +33,44 @@ const additionalColumns = [
 const props = {
   data: [
     {
+      uuid: '1',
       name: 'Lil Bub',
       color: 'brown tabby',
       famous_for: 'weird tongue',
     },
     {
+      uuid: '2',
       name: 'Grumpy Cat',
       color: 'siamese',
       famous_for: 'serving moods',
     },
     {
+      uuid: '3',
       name: 'Smoothie',
       color: 'orange tabby',
       famous_for: 'modeling',
     },
     {
+      uuid: '4',
       name: 'Maru',
       color: 'brown tabby',
       famous_for: 'being a lovable oaf',
     },
     {
+      uuid: '5',
       name: 'Keyboard Cat',
       color: 'orange tabby',
       famous_for: 'piano virtuoso',
     },
     {
+      uuid: '6',
       name: 'Long Cat',
       color: 'russian white',
       famous_for:
         'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
     },
     {
+      uuid: '7',
       name: 'Zeno',
       color: 'brown tabby',
       famous_for: 'getting halfway there',
@@ -82,6 +92,9 @@ const props = {
     },
   ],
   itemCount: 7,
+  initialTableOptions: {
+    getRowId: row => row.uuid,
+  },
 };
 
 const emptyTestText = 'We love bears';
@@ -193,7 +206,7 @@ describe('<DataTable />', () => {
   // TODO: test that useTable is called with the correct arguments when isPaginated, isFilterable, isSelectable are used
   // TODO: test that fetchData is called correctly
 
-  describe('controlled table selections', () => {
+  describe('[legacy] controlled table selections', () => {
     it('passes initial controlledTableSelections to context', () => {
       const wrapper = mount(
         <DataTableWrapper {...props}>
@@ -243,6 +256,50 @@ describe('<DataTable />', () => {
         }),
       );
       expect(contextValue.selectedFlatRows).toEqual([selectedRow]);
+    });
+  });
+
+  describe('controlled table selections', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls onSelectedRowsChanged when selected rows are updated', () => {
+      const mockOnSelectedRowsChange = jest.fn();
+      const propsWithSelection = {
+        ...props,
+        isSelectable: true,
+        onSelectedRowsChanged: mockOnSelectedRowsChange,
+      };
+      render(<DataTableWrapper {...propsWithSelection} />);
+
+      // select first row
+      userEvent.click(screen.getAllByTestId('datatable-select-column-checkbox-cell')[0]);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledTimes(1);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          1: true,
+        }),
+      );
+
+      // select third row
+      userEvent.click(screen.getAllByTestId('datatable-select-column-checkbox-cell')[2]);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledTimes(2);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          1: true,
+          3: true,
+        }),
+      );
+
+      // unselect third row
+      userEvent.click(screen.getAllByTestId('datatable-select-column-checkbox-cell')[2]);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledTimes(3);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          1: true,
+        }),
+      );
     });
   });
 });

--- a/src/DataTable/tests/TableFooter.test.jsx
+++ b/src/DataTable/tests/TableFooter.test.jsx
@@ -13,6 +13,7 @@ const footerInstance = {
   state: { pageIndex: 1 },
   pageCount: 3,
   itemCount: 30,
+  RowStatusComponent: undefined,
 };
 
 // eslint-disable-next-line react/prop-types
@@ -39,5 +40,13 @@ describe('<TableFooter />', () => {
     const leftText = "I'm on the left";
     const wrapper = mount(<TableFooterWrapper><div>{leftText}</div></TableFooterWrapper>);
     expect(wrapper.text()).toContain(leftText);
+  });
+  it('uses custom RowStatus component, if provided', () => {
+    const dataTableContextValue = {
+      ...footerInstance,
+      RowStatusComponent: () => <p>Hello world</p>,
+    };
+    const wrapper = mount(<TableFooterWrapper value={dataTableContextValue} />);
+    expect(wrapper.text()).toContain('Hello world');
   });
 });

--- a/src/DataTable/utils/getVisibleColumns.jsx
+++ b/src/DataTable/utils/getVisibleColumns.jsx
@@ -23,7 +23,10 @@ export const selectColumn = {
 
     return (
       <div className="pgn__data-table__controlled-select">
-        <CheckboxControl {...updatedProps} />
+        <CheckboxControl
+          {...updatedProps}
+          data-testid="datatable-select-column-checkbox-header"
+        />
       </div>
     );
   },
@@ -36,7 +39,10 @@ export const selectColumn = {
 
     return (
       <div className="pgn__data-table__controlled-select">
-        <CheckboxControl {...updatedProps} />
+        <CheckboxControl
+          {...updatedProps}
+          data-testid="datatable-select-column-checkbox-cell"
+        />
       </div>
     );
   },

--- a/src/Figure/README.md
+++ b/src/Figure/README.md
@@ -23,7 +23,7 @@ notes: |
 <Figure>
   <Figure.Image
     alt="nature flower"
-    src="https://source.unsplash.com/200x200/?nature,flower"
+    src="https://picsum.photos/200/200/"
   />
   <Figure.Caption>
     Nulla vitae elit libero, a pharetra augue mollis interdum.

--- a/src/Image/README.md
+++ b/src/Image/README.md
@@ -24,19 +24,19 @@ notes: |
 <>
   <Image
     className="mr-2"
-    src="https://source.unsplash.com/100x100/?nature,flower"
+    src="https://picsum.photos/100/100/"
     rounded
     alt="Image description"
   />
   <Image
     className="mr-2"
-    src="https://source.unsplash.com/100x100/?nature,flower"
+    src="https://picsum.photos/100/100/"
     roundedCircle
     alt="Image description"
   />
   <Image
     className="mr-2"
-    src="https://source.unsplash.com/100x100/?nature,flower"
+    src="https://picsum.photos/100/100/"
     thumbnail
     alt="Image description"
   />
@@ -46,7 +46,7 @@ notes: |
 ## Fluid Sizing
 
 ```jsx live
-<Image src="https://source.unsplash.com/1600x800/?nature,flower" fluid alt="Image description" />
+<Image src="https://picsum.photos/1600/800/" fluid alt="Image description" />
 ```
 
 

--- a/src/Modal/marketing-modal.mdx
+++ b/src/Modal/marketing-modal.mdx
@@ -35,7 +35,7 @@ The ``MarketingModal`` is a preconfigured `ModalDialog` that accepts an image an
         heroNode={(
           <ModalDialog.Hero>
             <ModalDialog.Hero.Background
-              backgroundSrc="https://source.unsplash.com/1600x800/?nature,flower"
+              backgroundSrc="https://picsum.photos/1600/800/"
             />
             <ModalDialog.Hero.Content style={{ maxWidth: '15rem' }}>
               <ModalDialog.Title as="h1">

--- a/src/Modal/modal-dialog.mdx
+++ b/src/Modal/modal-dialog.mdx
@@ -114,7 +114,7 @@ label for the dialog element.
       >
         <ModalDialog.Hero>
           <ModalDialog.Hero.Background
-            backgroundSrc="https://source.unsplash.com/1600x800/?nature,flower"
+            backgroundSrc="https://picsum.photos/1600/800/"
           />
           <ModalDialog.Hero.Content style={{ maxWidth: '15rem' }}>
             <ModalDialog.Title as="h1">

--- a/src/Skeleton/README.md
+++ b/src/Skeleton/README.md
@@ -73,7 +73,7 @@ you can also set the number of columns in the displayed ``Skeleton``.
         : <Image
               alt="some image"
               roundedCircle
-              src="https://source.unsplash.com/200x200/?nature,flower"
+              src="https://picsum.photos/200/200/"
           />}
       </div>
     </>

--- a/src/Skeleton/Skeleton.scss
+++ b/src/Skeleton/Skeleton.scss
@@ -1,0 +1,3 @@
+.react-loading-skeleton {
+    z-index: unset;
+}

--- a/src/Skeleton/Skeleton.scss
+++ b/src/Skeleton/Skeleton.scss
@@ -1,3 +1,3 @@
 .react-loading-skeleton {
-    z-index: unset;
+  z-index: unset;
 }

--- a/src/Truncate/README.md
+++ b/src/Truncate/README.md
@@ -52,7 +52,7 @@ A Truncate component can help you crop multiline text. There will be three dots 
   return (
     <Card style={{ width: isExtraSmall ? "100%" : "18rem" }} isClickable>
       <Card.ImageCap
-        src="https://source.unsplash.com/360x200/?nature,flower"
+        src="https://picsum.photos/360/200/"
         srcAlt="Card image"
       />
       <Card.Header

--- a/src/hooks/useToggle.mdx
+++ b/src/hooks/useToggle.mdx
@@ -52,7 +52,7 @@ Toggle a boolean value on or off with handlers
 
   return (
     <Card style={{ width: '18rem' }}>
-      <Card.ImageCap src="https://source.unsplash.com/400x200/?nature,flower" srcAlt="Image description" />
+      <Card.ImageCap src="https://picsum.photos/400/200/" srcAlt="Image description" />
       <Card.Header title="Card Title"/>
       <Card.Section>
         <p>

--- a/src/index.scss
+++ b/src/index.scss
@@ -31,6 +31,7 @@
 @import "./SearchField/SearchField";
 @import "./Scrollable/Scrollable";
 @import "./Sheet/Sheet";
+@import "./Skeleton/Skeleton";
 @import "./Spinner/Spinner";
 @import "./Stepper/Stepper";
 @import "./StatefulButton/StatefulButton";

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -3,6 +3,8 @@ import 'regenerator-runtime/runtime';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
+const crypto = require('crypto');
+
 class ResizeObserver {
   observe() {
     // do nothing
@@ -18,5 +20,9 @@ class ResizeObserver {
 }
 
 window.ResizeObserver = ResizeObserver;
+
+window.crypto = {
+  getRandomValues: arr => crypto.randomBytes(arr.length),
+};
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/www/src/components/exampleComponents/MiyazakiCard.tsx
+++ b/www/src/components/exampleComponents/MiyazakiCard.tsx
@@ -17,7 +17,7 @@ const MiyazakiCard = ({ className, original }: IMiyazakiCard) => {
 
   return (
     <Card className={className}>
-      <Card.ImageCap src="https://source.unsplash.com/360x200/?nature,flower" srcAlt="Card image" />
+      <Card.ImageCap src="https://picsum.photos/360/200/" srcAlt="Card image" />
       <Card.Header title={title} />
       <Card.Section>
         <dl>


### PR DESCRIPTION
## Description

* Refactored to be more explicit about how often `DataTable` calls `fetchData` as well as what data it passes in its arguments.
* Make `children` optional for `Card.Section` and `Card.Footer`.
* Implements a loading state for `CardView`; consumer may override the skeleton card component to use with the `SkeletonCardComponent` prop to `CardView`.
* Exposes a new `onSelectedRowsChanged` prop to `DataTable` as a way to inform parent/consuming components when `DataTable` selections has changed in some way (e.g., a row was selected/unselected).
  * This approach is similar to [this official code example](https://codesandbox.io/embed/tannerlinsleyreact-table-row-selection-controlled-euyku?fontsize=14&hidenavigation=1&theme=dark) for "controlled" selections.
* Ensures `TableFooter` adheres to whether `RowStatus` is overridden by the `RowStatusComponent` prop on `DataTable`.

### Deploy Preview

https://deploy-preview-1804--paragon-openedx.netlify.app/components/card/
https://deploy-preview-1804--paragon-openedx.netlify.app/components/datatable/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
