### PR TITLE
[BD-46] docs: fixed markup issues in Layout and Spacing pages

### DIFF
--- a/www/src/components/LayoutGenerator.tsx
+++ b/www/src/components/LayoutGenerator.tsx
@@ -13,59 +13,61 @@ export interface IColumn {
   onChangeOffset: Function,
 }
 
-const Column = ({
+function Column({
   index, width, onChangeWidth, offset, onChangeOffset,
-}: IColumn) => (
-  <div
-    className={classNames('col mb-4', {
-      [`col-${width}`]: width > 0,
-      [`offset-${offset}`]: offset > 0,
-    })}
-  >
+}: IColumn) {
+  return (
     <div
-      className="text-align-center p-1"
-      style={{ background: '#eee', minHeight: '2rem' }}
+      className={classNames('col mb-4', {
+        [`col-${width}`]: width > 0,
+        [`offset-${offset}`]: offset > 0,
+      })}
     >
-      <div className="form-inline m-2">
-        <label className="font-weight-normal" htmlFor={`column-${index}-width`}>
-          Width
-        </label>
-        <Input
-          type="number"
-          id={`column-${index}-width`}
-          className="form-control-sm"
-          value={width}
-          placeholder="Width (1 - 12)"
-          style={{ width: '3rem' }}
-          min={0}
-          step={1}
-          max={12}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeWidth(index, e.target.value)}
-        />
-      </div>
-      <div className="form-inline m-2">
-        <label
-          className="font-weight-normal"
-          htmlFor={`column-${index}-offset`}
-        >
-          Offset
-        </label>
-        <Input
-          type="number"
-          id={`column-${index}-offset`}
-          className="form-control-sm"
-          value={offset}
-          placeholder="Offset (1 - 11)"
-          style={{ width: '3rem' }}
-          min={0}
-          step={1}
-          max={11}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeOffset(index, e.target.value)}
-        />
+      <div
+        className="text-align-center p-1"
+        style={{ background: '#eee', minHeight: '2rem' }}
+      >
+        <div className="form-inline m-2">
+          <label className="font-weight-normal mr-2" htmlFor={`column-${index}-width`}>
+            Width
+          </label>
+          <Input
+            type="number"
+            id={`column-${index}-width`}
+            className="form-control-sm"
+            value={width}
+            placeholder="Width (1 - 12)"
+            style={{ width: '4rem' }}
+            min={0}
+            step={1}
+            max={12}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeWidth(index, e.target.value)}
+          />
+        </div>
+        <div className="form-inline m-2">
+          <label
+            className="font-weight-normal mr-2"
+            htmlFor={`column-${index}-offset`}
+          >
+            Offset
+          </label>
+          <Input
+            type="number"
+            id={`column-${index}-offset`}
+            className="form-control-sm mr-2"
+            value={offset}
+            placeholder="Offset (1 - 11)"
+            style={{ width: '4rem' }}
+            min={0}
+            step={1}
+            max={11}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeOffset(index, e.target.value)}
+          />
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+}
 
 Column.propTypes = {
   index: PropTypes.number.isRequired,
@@ -140,7 +142,7 @@ ${columnsString.join('')}
         values for each column and see the output below.
       </p>
       <div className="form-inline mb-4">
-        <label htmlFor="num-cols-range mr-2">
+        <label className="mr-2" htmlFor="num-cols-range">
           Number of Columns {numColumns}
         </label>
         <Input

--- a/www/src/components/LayoutGenerator.tsx
+++ b/www/src/components/LayoutGenerator.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 // @ts-ignore
-import { Input } from '~paragon-react'; // eslint-disable-line
+import { Form } from '~paragon-react'; // eslint-disable-line
 import CodeBlock from './CodeBlock';
 
 export interface IColumn {
@@ -27,43 +27,30 @@ function Column({
         className="text-align-center p-1"
         style={{ background: '#eee', minHeight: '2rem' }}
       >
-        <div className="form-inline m-2">
-          <label className="font-weight-normal mr-2" htmlFor={`column-${index}-width`}>
-            Width
-          </label>
-          <Input
+        <Form.Group className="form-inline m-2">
+          <Form.Label>Width</Form.Label>
+          <Form.Control
+            className="mx-2"
             type="number"
-            id={`column-${index}-width`}
-            className="form-control-sm"
             value={width}
-            placeholder="Width (1 - 12)"
-            style={{ width: '4rem' }}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeWidth(index, e.target.value)}
             min={0}
             step={1}
             max={12}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeWidth(index, e.target.value)}
           />
-        </div>
-        <div className="form-inline m-2">
-          <label
-            className="font-weight-normal mr-2"
-            htmlFor={`column-${index}-offset`}
-          >
-            Offset
-          </label>
-          <Input
+        </Form.Group>
+        <Form.Group className="form-inline m-2">
+          <Form.Label>Offset</Form.Label>
+          <Form.Control
+            className="mx-2"
             type="number"
-            id={`column-${index}-offset`}
-            className="form-control-sm mr-2"
             value={offset}
-            placeholder="Offset (1 - 11)"
-            style={{ width: '4rem' }}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeOffset(index, e.target.value)}
             min={0}
             step={1}
             max={11}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeOffset(index, e.target.value)}
           />
-        </div>
+        </Form.Group>
       </div>
     </div>
   );
@@ -141,19 +128,22 @@ ${columnsString.join('')}
         Drag the slider to add or remove columns. Edit the width and offset
         values for each column and see the output below.
       </p>
-      <div className="form-inline mb-4">
-        <label className="mr-2" htmlFor="num-cols-range">
-          Number of Columns {numColumns}
-        </label>
-        <Input
-          id="num-cols-range"
-          type="range"
-          value={numColumns}
-          min={1}
-          step={1}
-          max={12}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setColumns(parseInt(e.target.value, 10))}
-        />
+      <div className="form-inline">
+        <Form.Group className="form-inline">
+          <Form.Label>
+            Number of Columns {numColumns}
+          </Form.Label>
+          <Form.Control
+            className="mx-2"
+            type="range"
+            value={numColumns}
+            size="sm"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setColumns(parseInt(e.target.value, 10))}
+            min={1}
+            step={1}
+            max={12}
+          />
+        </Form.Group>
       </div>
       <div className="row">{columns}</div>
 

--- a/www/src/pages/foundations/spacing.scss
+++ b/www/src/pages/foundations/spacing.scss
@@ -1,5 +1,0 @@
-.pgn-doc__spacing-directions .form-check-input {
-  [dir="rtl"] & {
-    margin-right: -1.25rem;
-  }
-}

--- a/www/src/pages/foundations/spacing.scss
+++ b/www/src/pages/foundations/spacing.scss
@@ -1,0 +1,5 @@
+.pgn-doc__spacing-directions .form-check-input {
+  [dir="rtl"] & {
+    margin-right: -1.25rem;
+  }
+}

--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -2,12 +2,10 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 // @ts-ignore
-import { Input, Container, DataTable } from '~paragon-react'; // eslint-disable-line
+import { Form, Container, DataTable } from '~paragon-react'; // eslint-disable-line
 import SEO from '../../components/SEO';
 import Layout from '../../components/PageLayout';
 import MeasuredItem from '../../components/MeasuredItem';
-
-import './spacing.scss';
 
 const directions = [
   { key: '', name: 'all' },
@@ -124,37 +122,31 @@ export default function SpacingPage() {
         <div className="border p-4">
           <div className="d-flex flex-column align-items-center">
             <h4>Direction</h4>
-            <div className="mb-2 pgn-doc__spacing-directions">
+            <div className="d-flex flex-wrap mt-2">
               {directions.map(({ key, name }) => (
-                <label
-                  className="form-check d-inline-block mr-4"
-                  htmlFor={`set-direction-${key}`}
+                <Form.Radio
+                  key={key}
+                  className="mx-2 mb-3"
+                  name="direction"
+                  value={key}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDirection(e.target.value)}
                 >
-                  <Input
-                    id={`set-direction-${key}`}
-                    key={key}
-                    className="mt-2"
-                    type="radio"
-                    name="direction"
-                    value={key}
-                    checked={key === direction}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDirection(e.target.value)}
-                  />
                   {name}
-                </label>
+                </Form.Radio>
               ))}
             </div>
-            <label className="d-block" htmlFor="set-size">
-              <span className="d-block text-center">Spacing Level: {size}</span>
+            <Form.Group>
+              <Form.Label className="d-block">
+                <span className="d-block text-center">Spacing Level: {size}</span>
+              </Form.Label>
               <div
                 className="d-flex align-items-center"
                 style={{ maxWidth: '20rem' }}
               >
                 -6
-                <Input
-                  type="range"
-                  id="set-size"
+                <Form.Control
                   className="mx-2"
+                  type="range"
                   min={-6}
                   step={0.5}
                   max={6}
@@ -163,7 +155,7 @@ export default function SpacingPage() {
                 />
                 6
               </div>
-            </label>
+            </Form.Group>
           </div>
           <div className="d-flex justify-content-center">
             <SpaceBlock />

--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -7,6 +7,8 @@ import SEO from '../../components/SEO';
 import Layout from '../../components/PageLayout';
 import MeasuredItem from '../../components/MeasuredItem';
 
+import './spacing.scss';
+
 const directions = [
   { key: '', name: 'all' },
   { key: 't', name: 'top' },
@@ -30,21 +32,23 @@ export type PixelCellTypes = {
   spacer: number,
 };
 
-const PixelCell = ({ spacer }: PixelCellTypes) => (
-  <MeasuredItem
-    properties={['margin']}
-    renderAfter={(measurements: { margin: number }) => (
-      <code>
-        {measurements.margin}
-      </code>
-    )}
-  >
-    <div
-      style={{ display: 'none' }}
-      className={`m-${spacer}`}
-    />
-  </MeasuredItem>
-);
+function PixelCell({ spacer }: PixelCellTypes) {
+  return (
+    <MeasuredItem
+      properties={['margin']}
+      renderAfter={(measurements: { margin: number }) => (
+        <code>
+          {measurements.margin}
+        </code>
+      )}
+    >
+      <div
+        style={{ display: 'none' }}
+        className={`m-${spacer}`}
+      />
+    </MeasuredItem>
+  );
+}
 
 PixelCell.propTypes = {
   spacer: PropTypes.number.isRequired,
@@ -54,22 +58,24 @@ export type SpaceBlockTypes = {
   utilityClass: string,
 };
 
-const SpaceBlock = ({ utilityClass }: SpaceBlockTypes) => (
-  <code
-    className={classNames(utilityClass)}
-    style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      height: '5rem',
-      textAlign: 'center',
-      width: '10rem',
-      background: 'rgba(0,0,0,.1)',
-    }}
-  >
-    {utilityClass ? `.${utilityClass}` : null}
-  </code>
-);
+function SpaceBlock({ utilityClass }: SpaceBlockTypes) {
+  return (
+    <code
+      className={classNames(utilityClass)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '5rem',
+        textAlign: 'center',
+        width: '10rem',
+        background: 'rgba(0,0,0,.1)',
+      }}
+    >
+      {utilityClass ? `.${utilityClass}` : null}
+    </code>
+  );
+}
 
 SpaceBlock.propTypes = {
   utilityClass: PropTypes.string,
@@ -118,7 +124,7 @@ export default function SpacingPage() {
         <div className="border p-4">
           <div className="d-flex flex-column align-items-center">
             <h4>Direction</h4>
-            <div className="mb-2">
+            <div className="mb-2 pgn-doc__spacing-directions">
               {directions.map(({ key, name }) => (
                 <label
                   className="form-check d-inline-block mr-4"
@@ -127,7 +133,7 @@ export default function SpacingPage() {
                   <Input
                     id={`set-direction-${key}`}
                     key={key}
-                    className="mt-0"
+                    className="mt-2"
                     type="radio"
                     name="direction"
                     value={key}


### PR DESCRIPTION
## Description

1. Input fields on [Grid section of Layout page](https://paragon-openedx.netlify.app/foundations/layout#grid) have incorrect spacing around them.
![image](https://user-images.githubusercontent.com/93188219/204670377-8d757010-0ffc-428e-85f3-3b93d24c4c9d.png)

3. Similarly, radio buttons are not properly aligned with their labels in the margins section of [Spacing page](https://paragon-openedx.netlify.app/foundations/spacing)
![image1](https://user-images.githubusercontent.com/93188219/204670371-33b14a38-e2c9-459d-b3de-8e41b6c7f8a7.png)

[GitHub issue](https://github.com/openedx/paragon/issues/1802)

### Deploy Preview

[Spacing page](https://deploy-preview-1806--paragon-openedx.netlify.app/foundations/spacing)
[Layout page](https://deploy-preview-1806--paragon-openedx.netlify.app/foundations/layout)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
