### PR TITLE
fix: ensure SmartStatus renders SelectionStatus based on selectedRowIds

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -51,6 +51,11 @@ for more information.
 
 ```jsx live
   <DataTable
+    isPaginated
+    isSelectable
+    initialState={{
+      pageSize: 2,
+    }}
     isFilterable
     isSortable
     defaultColumnValues={{ Filter: TextFilter }}

--- a/src/DataTable/SmartStatus.jsx
+++ b/src/DataTable/SmartStatus.jsx
@@ -9,25 +9,25 @@ const SMART_STATUS_CLASS = 'pgn__smart-status';
 function SmartStatus() {
   const {
     state,
-    selectedFlatRows,
     SelectionStatusComponent,
     FilterStatusComponent,
     RowStatusComponent,
     showFiltersInSidebar,
   } = useContext(DataTableContext);
-  const numSelectedRows = selectedFlatRows?.length;
+  const { selectedRowIds } = state;
+  const numSelectedRows = Object.keys(selectedRowIds || {}).length;
   const SelectionStatus = SelectionStatusComponent || SelectionStatusDefault;
   const FilterStatus = FilterStatusComponent || FilterStatusDefault;
   const RowStatus = RowStatusComponent || RowStatusDefault;
 
-  if (selectedFlatRows && numSelectedRows > 0) {
+  if (numSelectedRows > 0) {
     return (
       <SelectionStatus
         className={SMART_STATUS_CLASS}
       />
     );
   }
-  if (state?.filters && state.filters.length > 0 && !showFiltersInSidebar) {
+  if (state?.filters?.length > 0 && !showFiltersInSidebar) {
     return (
       <FilterStatus
         className={SMART_STATUS_CLASS}

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -58,16 +58,42 @@ function DataTable({
     () => (defaultColumnValues),
     [defaultColumnValues],
   );
-  const tableOptions = useMemo(() => ({
-    columns,
-    data,
-    defaultColumn,
-    manualFilters,
-    manualPagination,
-    manualSortBy,
-    initialState,
-    ...initialTableOptions,
-  }), [columns, data, defaultColumn, manualFilters, manualPagination, initialState, initialTableOptions, manualSortBy]);
+  const tableOptions = useMemo(() => {
+    const updatedTableOptions = {
+      stateReducer: (newState, action) => {
+        switch (action.type) {
+          // Note: we override the `toggleAllRowsSelected` action
+          // from react-table because it only clears the selections on the
+          // currently visible page; it does not clear the `selectedRowIds`
+          // as we would expect for selections on different pages. Instead, we
+          // force `selectedRowIds` to be cleared when `toggleAllRowsSelected(false)`
+          // is called.
+          case 'toggleAllRowsSelected': {
+            if (action.value) {
+              return newState;
+            }
+            return {
+              ...newState,
+              selectedRowIds: {},
+            };
+          }
+          default:
+            return newState;
+        }
+      },
+      ...initialTableOptions,
+    };
+    return {
+      columns,
+      data,
+      defaultColumn,
+      manualFilters,
+      manualPagination,
+      manualSortBy,
+      initialState,
+      ...updatedTableOptions,
+    };
+  }, [columns, data, defaultColumn, manualFilters, manualPagination, initialState, initialTableOptions, manualSortBy]);
 
   const [selections, selectionsDispatch] = useReducer(selectionsReducer, initialSelectionsState);
 

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -174,6 +174,7 @@ function DataTable({
     disableElevation,
     isLoading,
     isSelectable,
+    isPaginated,
     manualSelectColumn,
     ...selectionProps,
     ...selectionActions,

--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -13,13 +13,14 @@ function BaseSelectionStatus({
   className,
   clearSelectionText,
   numSelectedRows,
+  numSelectedRowsOnPage,
   onSelectAll,
   onClear,
   selectAllText,
   allSelectedText,
   selectedText,
 }) {
-  const { itemCount } = useContext(DataTableContext);
+  const { itemCount, isPaginated } = useContext(DataTableContext);
   const isAllRowsSelected = numSelectedRows === itemCount;
   const intlAllSelectedText = allSelectedText || (
     <FormattedMessage
@@ -29,7 +30,14 @@ function BaseSelectionStatus({
       values={{ numSelectedRows }}
     />
   );
-  const intlSelectedText = selectedText || (
+  const intlSelectedText = selectedText || isPaginated ? (
+    <FormattedMessage
+      id="pgn.DataTable.BaseSelectionStatus.selectedTextPaginated"
+      defaultMessage="{numSelectedRows} selected ({numSelectedRowsOnPage} shown below)"
+      description="Text for selected label when table is paginated"
+      values={{ numSelectedRows, numSelectedRowsOnPage }}
+    />
+  ) : (
     <FormattedMessage
       id="pgn.DataTable.BaseSelectionStatus.selectedText"
       defaultMessage="{numSelectedRows} selected"
@@ -37,6 +45,7 @@ function BaseSelectionStatus({
       values={{ numSelectedRows }}
     />
   );
+
   return (
     <div className={className}>
       <span>{isAllRowsSelected ? intlAllSelectedText : intlSelectedText}</span>
@@ -92,6 +101,8 @@ BaseSelectionStatus.propTypes = {
   clearSelectionText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Count of selected rows in the table. */
   numSelectedRows: PropTypes.number.isRequired,
+  /** Count of selected rows on the current page */
+  numSelectedRowsOnPage: PropTypes.number.isRequired,
   /** A handler for 'Select all' button. */
   onSelectAll: PropTypes.func.isRequired,
   /** A handler for 'Clear selection' button. */

--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -102,7 +102,7 @@ BaseSelectionStatus.propTypes = {
   /** Count of selected rows in the table. */
   numSelectedRows: PropTypes.number.isRequired,
   /** Count of selected rows on the current page */
-  numSelectedRowsOnPage: PropTypes.number,
+  numSelectedRowsOnPage: PropTypes.number.isRequired,
   /** A handler for 'Select all' button. */
   onSelectAll: PropTypes.func.isRequired,
   /** A handler for 'Clear selection' button. */
@@ -113,10 +113,6 @@ BaseSelectionStatus.propTypes = {
   allSelectedText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** A text that appears when some items have been selected, defaults to '{numSelectedRows} selected' */
   selectedText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-};
-
-BaseSelectionStatus.defaultProps = {
-  numSelectedRowsOnPage: 0,
 };
 
 export default BaseSelectionStatus;

--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -102,7 +102,7 @@ BaseSelectionStatus.propTypes = {
   /** Count of selected rows in the table. */
   numSelectedRows: PropTypes.number.isRequired,
   /** Count of selected rows on the current page */
-  numSelectedRowsOnPage: PropTypes.number.isRequired,
+  numSelectedRowsOnPage: PropTypes.number,
   /** A handler for 'Select all' button. */
   onSelectAll: PropTypes.func.isRequired,
   /** A handler for 'Clear selection' button. */
@@ -113,6 +113,10 @@ BaseSelectionStatus.propTypes = {
   allSelectedText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** A text that appears when some items have been selected, defaults to '{numSelectedRows} selected' */
   selectedText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+};
+
+BaseSelectionStatus.defaultProps = {
+  numSelectedRowsOnPage: 0,
 };
 
 export default BaseSelectionStatus;

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -39,6 +39,7 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
   const selectionStatusProps = {
     className,
     numSelectedRows,
+    numSelectedRowsOnPage: 0,
     clearSelectionText,
     onSelectAll: () => dispatch(setSelectAllRowsAllPagesAction()),
     onClear: () => dispatch(clearSelectionAction()),

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -17,7 +17,7 @@ import {
 function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
-    rows,
+    page,
     controlledTableSelections: [{ selectedRows, isEntireTableSelected }, dispatch],
   } = useContext(DataTableContext);
 
@@ -25,21 +25,22 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
     () => {
       if (isEntireTableSelected) {
         const selectedRowIds = getRowIds(selectedRows);
-        const unselectedPageRows = getUnselectedPageRows(selectedRowIds, rows);
-        if (unselectedPageRows?.length) {
+        const unselectedPageRows = getUnselectedPageRows(selectedRowIds, page);
+        if (unselectedPageRows.length) {
           dispatch(setSelectedRowsAction(unselectedPageRows, itemCount));
         }
       }
     },
-    [isEntireTableSelected, selectedRows, itemCount, rows, dispatch],
+    [isEntireTableSelected, selectedRows, itemCount, page, dispatch],
   );
 
   const numSelectedRows = isEntireTableSelected ? itemCount : selectedRows.length;
+  const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;
 
   const selectionStatusProps = {
     className,
     numSelectedRows,
-    numSelectedRowsOnPage: 0,
+    numSelectedRowsOnPage,
     clearSelectionText,
     onSelectAll: () => dispatch(setSelectAllRowsAllPagesAction()),
     onClear: () => dispatch(clearSelectionAction()),

--- a/src/DataTable/selection/SelectionStatus.jsx
+++ b/src/DataTable/selection/SelectionStatus.jsx
@@ -5,10 +5,12 @@ import DataTableContext from '../DataTableContext';
 import BaseSelectionStatus from './BaseSelectionStatus';
 
 function SelectionStatus({ className, clearSelectionText }) {
-  const { toggleAllRowsSelected, selectedFlatRows, state } = useContext(DataTableContext);
+  const dataTableContext = useContext(DataTableContext);
+  console.log('SelectionStatus', dataTableContext);
+  const { toggleAllRowsSelected, page, state } = useContext(DataTableContext);
   const { selectedRowIds } = state;
   const numSelectedRows = Object.keys(selectedRowIds || {}).length;
-  const numSelectedRowsOnPage = selectedFlatRows?.length || 0;
+  const numSelectedRowsOnPage = page.filter(r => r.isSelected).length;
   const selectionStatusProps = {
     className,
     numSelectedRows,

--- a/src/DataTable/selection/SelectionStatus.jsx
+++ b/src/DataTable/selection/SelectionStatus.jsx
@@ -5,11 +5,14 @@ import DataTableContext from '../DataTableContext';
 import BaseSelectionStatus from './BaseSelectionStatus';
 
 function SelectionStatus({ className, clearSelectionText }) {
-  const { toggleAllRowsSelected, selectedFlatRows } = useContext(DataTableContext);
-  const numSelectedRows = selectedFlatRows.length;
+  const { toggleAllRowsSelected, selectedFlatRows, state } = useContext(DataTableContext);
+  const { selectedRowIds } = state;
+  const numSelectedRows = Object.keys(selectedRowIds || {}).length;
+  const numSelectedRowsOnPage = selectedFlatRows?.length || 0;
   const selectionStatusProps = {
     className,
     numSelectedRows,
+    numSelectedRowsOnPage,
     clearSelectionText,
     onSelectAll: () => toggleAllRowsSelected(true),
     onClear: () => toggleAllRowsSelected(false),

--- a/src/DataTable/selection/SelectionStatus.jsx
+++ b/src/DataTable/selection/SelectionStatus.jsx
@@ -5,12 +5,11 @@ import DataTableContext from '../DataTableContext';
 import BaseSelectionStatus from './BaseSelectionStatus';
 
 function SelectionStatus({ className, clearSelectionText }) {
-  const dataTableContext = useContext(DataTableContext);
-  console.log('SelectionStatus', dataTableContext);
   const { toggleAllRowsSelected, page, state } = useContext(DataTableContext);
   const { selectedRowIds } = state;
   const numSelectedRows = Object.keys(selectedRowIds || {}).length;
-  const numSelectedRowsOnPage = page.filter(r => r.isSelected).length;
+  // if `DataTable` is not paginated, `page` is undefined
+  const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;
   const selectionStatusProps = {
     className,
     numSelectedRows,

--- a/src/DataTable/selection/data/helpers.js
+++ b/src/DataTable/selection/data/helpers.js
@@ -1,5 +1,5 @@
-export const getUnselectedPageRows = (selectedRowsIds, currentRows) => {
-  const unselectedPageRows = currentRows.filter(row => !selectedRowsIds.includes(row.id));
+export const getUnselectedPageRows = (selectedRowsIds, currentPageRows) => {
+  const unselectedPageRows = currentPageRows.filter(row => !selectedRowsIds.includes(row.id));
   return unselectedPageRows;
 };
 

--- a/src/DataTable/selection/data/helpers.js
+++ b/src/DataTable/selection/data/helpers.js
@@ -1,4 +1,4 @@
-export const getUnselectedPageRows = (selectedRowsIds, currentPageRows) => {
+export const getUnselectedPageRows = (selectedRowsIds, currentPageRows = []) => {
   const unselectedPageRows = currentPageRows.filter(row => !selectedRowsIds.includes(row.id));
   return unselectedPageRows;
 };

--- a/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
@@ -20,7 +20,7 @@ const instance = {
     },
     jest.fn(),
   ],
-  rows: [{ id: 1 }, { id: 2 }, { id: 5 }],
+  page: [{ id: 1 }, { id: 2 }, { id: 5 }],
 };
 
 // eslint-disable-next-line react/prop-types
@@ -96,7 +96,7 @@ describe('<ControlledSelectionStatus />', () => {
         />,
       );
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
-      const action = setSelectedRowsAction(instance.rows, instance.itemCount);
+      const action = setSelectedRowsAction(instance.page, instance.itemCount);
       expect(dispatchSpy).toHaveBeenCalledWith(action);
     });
   });

--- a/src/DataTable/selection/tests/SelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/SelectionStatus.test.jsx
@@ -11,7 +11,8 @@ import {
 } from '../data/constants';
 
 const instance = {
-  selectedFlatRows: [1, 2, 3, 4],
+  // represents how `react-table` passes the row data for the current page
+  page: [1, 2, 3, 4],
   toggleAllRowsSelected: () => {},
   itemCount: 101,
   state: {
@@ -38,7 +39,7 @@ function SelectionStatusWrapper({ value, props = {} }) {
 describe('<SelectionStatus />', () => {
   it('Shows the number of rows selected', () => {
     const wrapper = mount(<SelectionStatusWrapper value={instance} />);
-    expect(wrapper.text()).toContain(instance.selectedFlatRows.length.toString());
+    expect(wrapper.text()).toContain(instance.page.length.toString());
   });
   it('Shows that all rows are selected', () => {
     const selectedRowIds = {};
@@ -72,7 +73,7 @@ describe('<SelectionStatus />', () => {
   it('does not render the clear selection button if there are no selected rows', () => {
     const value = {
       ...instance,
-      selectedFlatRows: [],
+      page: [],
       state: {
         ...instance.state,
         selectedRowIds: {},

--- a/src/DataTable/selection/tests/SelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/SelectionStatus.test.jsx
@@ -14,6 +14,14 @@ const instance = {
   selectedFlatRows: [1, 2, 3, 4],
   toggleAllRowsSelected: () => {},
   itemCount: 101,
+  state: {
+    selectedRowIds: {
+      1: true,
+      2: true,
+      3: true,
+      4: true,
+    },
+  },
 };
 
 // eslint-disable-next-line react/prop-types
@@ -33,15 +41,21 @@ describe('<SelectionStatus />', () => {
     expect(wrapper.text()).toContain(instance.selectedFlatRows.length.toString());
   });
   it('Shows that all rows are selected', () => {
+    const selectedRowIds = {};
+    [...new Array(101)].forEach((_, index) => {
+      selectedRowIds[index] = true;
+    });
+    const value = {
+      ...instance,
+      state: {
+        ...instance.state,
+        selectedRowIds,
+      },
+    };
     const wrapper = mount(
-      <SelectionStatusWrapper value={{ ...instance, selectedFlatRows: Array(101) }} />,
+      <SelectionStatusWrapper value={value} />,
     );
     expect(wrapper.text()).toContain('All 101');
-  });
-  it('does not show select all button if all rows are selected', () => {
-    const wrapper = mount(
-      <SelectionStatusWrapper value={{ ...instance, selectedFlatRows: Array(101) }} />,
-    );
     const button = wrapper.find(`button.${SELECT_ALL_TEST_ID}`);
     expect(button.length).toEqual(0);
   });
@@ -56,8 +70,16 @@ describe('<SelectionStatus />', () => {
     expect(toggleAllRowsSpy).toHaveBeenCalledWith(true);
   });
   it('does not render the clear selection button if there are no selected rows', () => {
+    const value = {
+      ...instance,
+      selectedFlatRows: [],
+      state: {
+        ...instance.state,
+        selectedRowIds: {},
+      },
+    };
     const wrapper = mount(
-      <SelectionStatusWrapper value={{ ...instance, selectedFlatRows: [] }} />,
+      <SelectionStatusWrapper value={value} />,
     );
     expect(wrapper.find(CLEAR_SELECTION_TEST_ID).length).toEqual(0);
   });

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -301,5 +301,32 @@ describe('<DataTable />', () => {
         }),
       );
     });
+
+    it('deselects all rows across all pages when `toggleAllRowsSelected(false)` is called', () => {
+      const mockOnSelectedRowsChange = jest.fn();
+      const propsWithSelection = {
+        ...props,
+        isPaginated: true,
+        isSelectable: true,
+        onSelectedRowsChanged: mockOnSelectedRowsChange,
+        selectedFlatRows: [{
+          id: '1',
+        }],
+        initialState: {
+          pageIndex: 0,
+          pageSize: 2,
+          selectedRowIds: {
+            1: true,
+            // because `pageSize` is 2, a row id of 3 selects first row on 2nd page
+            3: true,
+          },
+        },
+      };
+      render(<DataTableWrapper {...propsWithSelection} />);
+      userEvent.click(screen.getByText('Clear selection'));
+
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledTimes(1);
+      expect(mockOnSelectedRowsChange).toHaveBeenCalledWith({});
+    });
   });
 });

--- a/src/DataTable/tests/SmartStatus.test.jsx
+++ b/src/DataTable/tests/SmartStatus.test.jsx
@@ -37,8 +37,17 @@ function SmartStatusWrapper({ value, props }) {
 
 describe('<SmartStatus />', () => {
   it('Shows the selection status if rows are selected', () => {
+    const contextValue = {
+      ...instance,
+      state: {
+        selectedRowIds: {
+          0: true,
+          1: true,
+        },
+      },
+    };
     const wrapper = mount(
-      <SmartStatusWrapper value={{ ...instance, state: {}, selectedFlatRows: Array(5) }} />,
+      <SmartStatusWrapper value={contextValue} />,
     );
     expect(wrapper.find(SelectionStatus)).toHaveLength(1);
   });
@@ -73,11 +82,17 @@ describe('<SmartStatus />', () => {
     function AltStatus() {
       return <div>{altStatusText}</div>;
     }
-    const wrapper = mount(<SmartStatusWrapper
-      value={{
-        ...instance, SelectionStatusComponent: AltStatus, state: {}, selectedFlatRows: Array(5),
-      }}
-    />);
+    const contextValue = {
+      ...instance,
+      SelectionStatusComponent: AltStatus,
+      state: {
+        selectedRowIds: {
+          0: true,
+          1: true,
+        },
+      },
+    };
+    const wrapper = mount(<SmartStatusWrapper value={contextValue} />);
     expect(wrapper.text()).toContain(altStatusText);
   });
   it('shows an alternate row status', () => {


### PR DESCRIPTION
## Description

Currently, the `SmartStatus` component shows the `SelectionStatus` component based on `selectedFlatRows`. However, `selectedFlatRows` is only populated if/when the selected row is on the current page. It does _not_ support selections on other pages.

As such, the `SelectionStatus` component is hidden until a row is explicitly selected on page 2, even though there might be a row selection on page 1.

This PR changes the `SmartStatus` to determine selection count based on `selectedRowIds` from the table instance state rather than `selectedFlatRows`. It also updates the default `SelectionStatus` messaging to support selections across pages where data on other pages might not be known to the client yet.

### Deploy Preview

https://deploy-preview-1815--paragon-openedx.netlify.app/components/datatable/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
