### PR TITLE
[BD-46] fix: update SelectionStatus message based on applied filters

### DIFF
--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -175,6 +175,7 @@ function DataTable({
     isLoading,
     isSelectable,
     isPaginated,
+    isFilterable,
     manualSelectColumn,
     ...selectionProps,
     ...selectionActions,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -175,7 +175,6 @@ function DataTable({
     isLoading,
     isSelectable,
     isPaginated,
-    isFilterable,
     manualSelectColumn,
     ...selectionProps,
     ...selectionActions,

--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -20,7 +20,7 @@ function BaseSelectionStatus({
   allSelectedText,
   selectedText,
 }) {
-  const { itemCount, isPaginated } = useContext(DataTableContext);
+  const { itemCount, isPaginated, isFilterable } = useContext(DataTableContext);
   const isAllRowsSelected = numSelectedRows === itemCount;
   const intlAllSelectedText = allSelectedText || (
     <FormattedMessage
@@ -30,7 +30,8 @@ function BaseSelectionStatus({
       values={{ numSelectedRows }}
     />
   );
-  const intlSelectedText = selectedText || isPaginated ? (
+
+  const defaultSelectedText = isPaginated || isFilterable ? (
     <FormattedMessage
       id="pgn.DataTable.BaseSelectionStatus.selectedTextPaginated"
       defaultMessage="{numSelectedRows} selected ({numSelectedRowsOnPage} shown below)"
@@ -45,6 +46,8 @@ function BaseSelectionStatus({
       values={{ numSelectedRows }}
     />
   );
+
+  const intlSelectedText = selectedText || defaultSelectedText;
 
   return (
     <div className={className}>

--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -20,7 +20,8 @@ function BaseSelectionStatus({
   allSelectedText,
   selectedText,
 }) {
-  const { itemCount, isPaginated, isFilterable } = useContext(DataTableContext);
+  const { itemCount, isPaginated, state } = useContext(DataTableContext);
+  const hasAppliedFilters = state?.filters?.length > 0;
   const isAllRowsSelected = numSelectedRows === itemCount;
   const intlAllSelectedText = allSelectedText || (
     <FormattedMessage
@@ -31,7 +32,7 @@ function BaseSelectionStatus({
     />
   );
 
-  const defaultSelectedText = isPaginated || isFilterable ? (
+  const defaultSelectedText = isPaginated || hasAppliedFilters ? (
     <FormattedMessage
       id="pgn.DataTable.BaseSelectionStatus.selectedTextPaginated"
       defaultMessage="{numSelectedRows} selected ({numSelectedRowsOnPage} shown below)"

--- a/src/DataTable/selection/SelectionStatus.jsx
+++ b/src/DataTable/selection/SelectionStatus.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 import DataTableContext from '../DataTableContext';
 import BaseSelectionStatus from './BaseSelectionStatus';
+import { useRows } from '../hooks';
 
 function SelectionStatus({ className, clearSelectionText }) {
-  const { toggleAllRowsSelected, page, state } = useContext(DataTableContext);
+  const { toggleAllRowsSelected, state } = useContext(DataTableContext);
+  const { displayRows } = useRows();
   const { selectedRowIds } = state;
   const numSelectedRows = Object.keys(selectedRowIds || {}).length;
-  // if `DataTable` is not paginated, `page` is undefined
-  const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;
+  const numSelectedRowsOnPage = displayRows.filter(r => r.isSelected).length;
   const selectionStatusProps = {
     className,
     numSelectedRows,


### PR DESCRIPTION
## Description

This PR extends functionality added in https://github.com/openedx/paragon/pull/1815 and considers `isFilterable` flag as well when rendering selection message, i.e. previously if `DataTable` wasn't paginated filtering could result in misleading selection message
![image](https://user-images.githubusercontent.com/52399399/206671306-5f916220-dc32-4289-87b9-571c76aead39.png)
this PR fixes it to be
![image](https://user-images.githubusercontent.com/52399399/206671511-36288e46-dce5-4c6e-bcab-7ef4c8783674.png)

### Deploy Preview

https://deploy-preview-1832--paragon-openedx.netlify.app/components/datatable/#view-switching

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
