### PR TITLE
[BD-46] Display computed CSS variables on component's page

### DIFF
--- a/www/src/components/ComponentVariablesTable.tsx
+++ b/www/src/components/ComponentVariablesTable.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+// @ts-ignore
+import { DataTable } from '~paragon-react'; // eslint-disable-line
+
+function ComponentVariablesTable({ rawStylesheet }: ComponentVariablesTableProps) {
+  const [tableData, setTableData] = useState<Array<TableRowData>>([]);
+
+  useEffect(() => {
+    const bodyStyles = getComputedStyle(document.body);
+    const variablesList = rawStylesheet.trim().split('\n').filter((row) => row.startsWith('$'));
+
+    const tableRows = variablesList.map(row => {
+      const [property, value] = row.split(':').map((item) => item.trim());
+      const extractedCSSVariables = value.match(/(?<=var?\()(.*)(?=\))/g);
+      const computedValue = extractedCSSVariables ? bodyStyles.getPropertyValue(extractedCSSVariables[0]) : '';
+
+      return {
+        propertyName: <code>{property}</code>,
+        propertyValue: <code>{value}</code>,
+        computedValue: <code>{computedValue}</code>,
+      };
+    });
+
+    setTableData(tableRows);
+  }, [rawStylesheet]);
+
+  return (
+    <DataTable
+      data={tableData}
+      itemCount={tableData.length}
+      columns={[
+        {
+          Header: 'SCSS Property',
+          accessor: 'propertyName',
+        },
+        {
+          Header: 'Value',
+          accessor: 'propertyValue',
+        },
+        {
+          Header: 'Computed Value',
+          accessor: 'computedValue',
+        },
+      ]}
+    >
+      <DataTable.Table />
+    </DataTable>
+  );
+}
+
+interface ComponentVariablesTableProps {
+  rawStylesheet: string,
+}
+
+interface TableRowData {
+  propertyName: JSX.Element,
+  propertyValue: JSX.Element,
+  computedValue: JSX.Element,
+}
+
+export default ComponentVariablesTable;

--- a/www/src/templates/component-page-template.tsx
+++ b/www/src/templates/component-page-template.tsx
@@ -13,6 +13,7 @@ import GenericPropsTable from '../components/PropsTable';
 import Layout from '../components/PageLayout';
 import SEO from '../components/SEO';
 import LinkedHeading from '../components/LinkedHeading';
+import ComponentVariablesTable from '../components/ComponentVariablesTable';
 
 export interface IPageTemplate {
   data: {
@@ -80,8 +81,8 @@ export default function PageTemplate({
     };
   }, [components]);
 
-  const scssVariablesTitle = 'Theme Variables (SCSS)';
-  const scssVariablesUrl = 'theme-variables-scss';
+  const scssVariablesTitle = 'Theme Variables';
+  const scssVariablesUrl = 'theme-variables';
 
   const getTocData = () => {
     const tableOfContents = JSON.parse(JSON.stringify(mdx.tableOfContents));
@@ -127,7 +128,7 @@ export default function PageTemplate({
                 <span className="pgn-doc__anchor">#</span>
               </a>
             </h2>
-            <CodeBlock className="language-scss">{scssVariables}</CodeBlock>
+            <ComponentVariablesTable rawStylesheet={scssVariables} />
           </div>
         )}
         {typeof sortedComponentNames !== 'string'


### PR DESCRIPTION
## Description

Changes theme variables section to be a `DataTable` with computed CSS variables

![image](https://user-images.githubusercontent.com/52399399/206676998-b105b49a-7ce5-4a48-b59f-63c3fef9bc1e.png)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
