### PR TITLE
[BD-46] fix: remove ResizeObserver from useIndexOfLastVisibleChild hook

### DIFF
--- a/src/Bubble/index.tsx
+++ b/src/Bubble/index.tsx
@@ -38,7 +38,7 @@ const Bubble = React.forwardRef<HTMLDivElement, BubbleProps>(({
 
 Bubble.propTypes = {
   /** Specifies contents of the component. */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /** The `Bubble` style variant to use. */
   variant: PropTypes.oneOf(STYLE_VARIANTS),
   /** Activates disabled variant. */
@@ -50,6 +50,7 @@ Bubble.propTypes = {
 };
 
 Bubble.defaultProps = {
+  children: null,
   variant: 'primary',
   disabled: false,
   className: undefined,

--- a/src/hooks/useIndexOfLastVisibleChild.jsx
+++ b/src/hooks/useIndexOfLastVisibleChild.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 import useWindowSize from './useWindowSize';
 
@@ -22,22 +22,8 @@ import useWindowSize from './useWindowSize';
  *    is optional.
  */
 const useIndexOfLastVisibleChild = (containerElementRef, overflowElementRef) => {
-  const [containerWidth, setContainerWidth] = useState(0);
   const [indexOfLastVisibleChild, setIndexOfLastVisibleChild] = useState(-1);
   const windowSize = useWindowSize();
-
-  useEffect(() => {
-    if (containerElementRef) {
-      const observer = new ResizeObserver(entries => {
-        for (let i = 0; i < entries.length; i++) {
-          setContainerWidth(entries[i].contentRect.width);
-        }
-      });
-      observer.observe(containerElementRef);
-      return () => observer.disconnect();
-    }
-    return undefined;
-  }, [containerElementRef]);
 
   useLayoutEffect(() => {
     if (!containerElementRef) {
@@ -51,7 +37,7 @@ const useIndexOfLastVisibleChild = (containerElementRef, overflowElementRef) => 
       // sum the widths to find the last visible element's index
       .reduce((acc, childNode, index) => {
         acc.sumWidth += childNode.getBoundingClientRect().width;
-        if (acc.sumWidth <= containerWidth) {
+        if (acc.sumWidth <= containerElementRef.getBoundingClientRect().width) {
           acc.nextIndexOfLastVisibleChild = index;
         }
         return acc;
@@ -65,7 +51,7 @@ const useIndexOfLastVisibleChild = (containerElementRef, overflowElementRef) => 
       });
 
     setIndexOfLastVisibleChild(nextIndexOfLastVisibleChild);
-  }, [windowSize, containerWidth, containerElementRef, overflowElementRef]);
+  }, [windowSize, containerElementRef, overflowElementRef]);
 
   return indexOfLastVisibleChild;
 };

--- a/src/hooks/useIndexOfLastVisibleChild.mdx
+++ b/src/hooks/useIndexOfLastVisibleChild.mdx
@@ -35,30 +35,40 @@ of the children until they exceed the width of the container.
   const children = useMemo(() => {
     const indexOfOverflowStart = indexOfLastVisibleChild + 1;
     const childrenList = elements.map((element, i) => (
-      <div className="px-4 pt-2" style={i >= indexOfOverflowStart ? invisibleStyles : {}}>{element}</div>
+      <div
+        key={element}
+        className="px-4 pt-2"
+        style={i >= indexOfOverflowStart ? invisibleStyles : {}}
+      >
+        {element}
+      </div>
     ));
-    const overflowChildren = childrenList.slice(indexOfOverflowStart)
+
+    const overflowChildren = elements.slice(indexOfOverflowStart)
       .map(overflowChild => (
-          <Dropdown.Item
-            key={`${overflowChild}overflow`}
-          >
-            {overflowChild.props.children}
-          </Dropdown.Item>
-        ));
-    
-    childrenList.splice(indexOfOverflowStart, 0, (
-      <Dropdown ref={overflowElementRef} style={!overflowChildren.length ? invisibleStyles : {}}>
+        <Dropdown.Item key={`${overflowChild}-overflow`}>
+          {overflowChild}
+        </Dropdown.Item>
+      )
+    );
+
+    const MoreDropdown = (
+    	<Dropdown ref={overflowElementRef} style={!overflowChildren.length ? invisibleStyles : {}} key="overflow-example">
         <Dropdown.Toggle
           variant="link"
+          id="more-toggle"
         >
           More...
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">{overflowChildren}</Dropdown.Menu>
       </Dropdown>
-    ));
-    
+    )
+
+    childrenList.push(MoreDropdown);
+
     return childrenList;
   }, [indexOfLastVisibleChild]);
+
   return (
     <div className="d-flex" ref={containerElementRef}>
       {children}


### PR DESCRIPTION
## Description

Initially this PR aimed to fix `ResizeObserver` error that got reported in #1811, but turned out to be a good clean up opportunity for `useIndexOfLastVisibleChild` hook which resulted in removing `ResizeObserver` altogether, fixing the reported issue.

### Deploy Preview

https://deploy-preview-1842--paragon-openedx.netlify.app/components/hooks/useindexoflastvisiblechild/

**Note**: `ResizeObserver loop limit exceeded` error is not logged to browser's console by default (it still gets caught by New Relic though). To actually check that this error is not reproduced anymore do the following:

1. Go to the deploy-preview link above
2. Open your browser's console
3. Run `addEventListener('error', (e) => console.error(e))`
4. Try to resize your window in multiple ways

Notice that nothing gets logged to your console. If you do the steps above on [current version of useIndexOfLastVisibleChild hook](https://paragon-openedx.netlify.app/components/hooks/useindexoflastvisiblechild/) you will see multiple errors.

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
