### PR TITLE
[BD-46] fix: consider 0 a truthy value in input components

### DIFF
--- a/src/Form/fieldUtils.js
+++ b/src/Form/fieldUtils.js
@@ -20,8 +20,8 @@ const callAllHandlers = (...handlers) => {
 };
 
 const useHasValue = ({ defaultValue, value }) => {
-  const [hasUncontrolledValue, setHasUncontrolledValue] = useState(!!defaultValue);
-  const hasValue = !!value || hasUncontrolledValue;
+  const [hasUncontrolledValue, setHasUncontrolledValue] = useState(!!defaultValue || defaultValue === 0);
+  const hasValue = !!value || value === 0 || hasUncontrolledValue;
   const handleInputEvent = (e) => setHasUncontrolledValue(e.target.value);
   return [hasValue, handleInputEvent];
 };


### PR DESCRIPTION
## Description

Fix `useHasValue` (hook that checks whether input component has a value) to consider 0 as a truthy value.

### Deploy Preview

https://deploy-preview-1848--paragon-openedx.netlify.app/components/form/form-control/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
