### PR TITLE
[BD-46] DRAFT: fixed pagination buttons

### DIFF
--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -159,6 +159,12 @@
       color: $pagination-page-link-color;
     }
 
+    button.page-link.btn-inverse-tertiary:hover {
+      color: $white;
+      background-color: #2D494E;
+      border-color: rgba(0, 0, 0, 0);
+    }
+
     button.page-link {
       @extend %dark-styles;
 

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -36,8 +36,14 @@
 .page-link {
   border: none;
   background-color: transparent;
+  color: $pagination-page-link-color;
 
-  &.btn-primary:not(:disabled):not(.disabled):focus {
+  &:hover {
+    color: $pagination-page-link-color;
+  }
+
+  &.btn-primary:not(:disabled):not(.disabled):focus,
+  &.btn-tertiary:not(:disabled):not(.disabled):focus {
     background-color: $pagination-bg;
     color: $pagination-focus-color-text;
   }
@@ -46,7 +52,8 @@
     box-shadow: none;
   }
 
-  &.btn-primary:focus::before {
+  &.btn-primary:focus::before,
+  &.btn-tertiary:focus::before {
     border: $pagination-focus-border-width solid $pagination-focus-color;
     border-radius: $btn-border-radius;
   }
@@ -149,7 +156,7 @@
 
     &.active button.page-link {
       background-color: $pagination-bg;
-      color: $pagination-color;
+      color: $pagination-page-link-color;
     }
 
     button.page-link {

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -57,6 +57,7 @@
 
 .page-link {
   border: none;
+  background-color: transparent;
 
   &.btn-primary:not(:disabled):not(.disabled):focus {
     background-color: $pagination-bg;

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -1,14 +1,6 @@
 @import "variables";
 @import "~bootstrap/scss/pagination";
 
-.pagination {
-  align-items: center;
-
-  .dropdown {
-    z-index: 4;
-  }
-}
-
 %pagination-icon-button-right {
   border-top-right-radius: 50%;
   border-bottom-right-radius: 50%;
@@ -19,12 +11,12 @@
   border-bottom-left-radius: 50%;
 }
 
-.pagination-icon-button-right {
-  @extend %pagination-icon-button-right;
-}
+.pagination {
+  align-items: center;
 
-.pagination-icon-button-left {
-  @extend %pagination-icon-button-left;
+  .dropdown {
+    z-index: 4;
+  }
 }
 
 .pagination-default {
@@ -37,20 +29,6 @@
     &.next .pgn__icon {
       margin-inline-start: $pagination-margin-x;
       margin-inline-end: 0;
-    }
-  }
-
-  .page-item {
-    &:first-child .page-link {
-      [dir="rtl"] & {
-        border-radius: 0 $pagination-border-radius-lg $pagination-border-radius-lg 0;
-      }
-    }
-
-    &:last-child .page-link {
-      [dir="rtl"] & {
-        border-radius: $pagination-border-radius-lg 0 0 $pagination-border-radius-lg;
-      }
     }
   }
 }
@@ -70,8 +48,7 @@
 
   &.btn-primary:focus::before {
     border: $pagination-focus-border-width solid $pagination-focus-color;
-
-    @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
+    border-radius: $btn-border-radius;
   }
 
   div {

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -1,5 +1,4 @@
 @import "variables";
-@import "~bootstrap/scss/pagination";
 
 %pagination-icon-button-right {
   border-top-right-radius: 50%;
@@ -12,15 +11,58 @@
 }
 
 .pagination {
-  align-items: center;
+  display: flex;
 
   .dropdown {
     z-index: 4;
   }
-}
 
-.pagination-default {
-  .page-link {
+  .page-item {
+    &:first-child .page-link {
+      margin-left: 0;
+
+      @include border-left-radius($border-radius);
+    }
+
+    &:last-child .page-link {
+      @include border-right-radius($border-radius);
+    }
+
+    &:first-child .btn-icon.page-link {
+      @extend %pagination-icon-button-left;
+    }
+
+    &:last-child .btn-icon.page-link {
+      @extend %pagination-icon-button-right;
+    }
+
+    &.active .page-link {
+      z-index: 3;
+      color: $pagination-active-color;
+      background-color: $pagination-active-bg;
+      border-color: $pagination-active-border-color;
+    }
+
+    &.disabled .page-link {
+      color: $pagination-disabled-color;
+      pointer-events: none;
+      cursor: auto;
+      background-color: $pagination-disabled-bg;
+      border-color: $pagination-disabled-border-color;
+    }
+
+    > .btn {
+      transition: none;
+      line-height: $pagination-line-height;
+    }
+
+    &.active .page-link.btn-primary:not(:disabled):not(.disabled):focus {
+      background-color: $pagination-focus-color;
+      color: $pagination-bg;
+    }
+  }
+
+  &-default .page-link {
     &.previous .pgn__icon {
       margin-inline-start: 0;
       margin-inline-end: $pagination-margin-x;
@@ -31,25 +73,199 @@
       margin-inline-end: 0;
     }
   }
+
+  @include list-unstyled();
+  @include border-radius();
+
+  &-small {
+    .page-link {
+      font-size: $pagination-font-size-sm;
+      line-height: $pagination-line-height;
+      padding: .375rem .78rem;
+
+      &.previous,
+      &.next {
+        padding: 0 $pagination-padding-y;
+        line-height: $pagination-secondary-height-sm;
+
+        div {
+          display: flex;
+          align-items: center;
+        }
+      }
+    }
+
+    &:not(.pagination-default) .page-link {
+      &.previous,
+      &.next {
+        padding: 0;
+        width: $pagination-icon-width;
+      }
+    }
+  }
+
+  &-secondary {
+    button.next,
+    button.previous {
+      height: $pagination-secondary-height;
+      padding: 0 $pagination-padding-y;
+    }
+
+    &.pagination-small {
+      button.next,
+      button.previous {
+        height: $pagination-secondary-height-sm;
+        line-height: $pagination-line-height;
+      }
+    }
+  }
+
+  &-inverse {
+    %dark-styles {
+      background-color: transparent;
+      color: $pagination-color-inverse;
+    }
+
+    .page-item {
+      &.disabled .page-link {
+        @extend %dark-styles;
+      }
+
+      &.active button.page-link {
+        background-color: $pagination-bg;
+        color: $pagination-page-link-color;
+      }
+
+      button.page-link.btn-inverse-tertiary:hover {
+        background-color: #2D494E;
+      }
+
+      button.page-link {
+        @extend %dark-styles;
+
+        &:focus {
+          box-shadow: inset 0 0 0 2px $pagination-color-inverse;
+        }
+      }
+    }
+
+    .dropdown {
+      .btn-tertiary {
+        color: $pagination-color-inverse;
+
+        &::after {
+          border-top: $pagination-toggle-border solid $pagination-color-inverse;
+        }
+
+        &:active,
+        &:hover {
+          background-color: transparent;
+        }
+
+        &:not(:disabled):not(.disabled):active {
+          color: $pagination-color-inverse;
+        }
+      }
+    }
+
+    .show > .dropdown-toggle {
+      background-color: transparent;
+    }
+  }
+
+  &-reduced {
+    &-dropdown-menu {
+      overflow-y: auto;
+      max-height: $pagination-reduced-dropdown-max-height;
+      min-width: $pagination-reduced-dropdown-min-width;
+
+      a {
+        text-align: center;
+      }
+    }
+
+    .dropdown-toggle::after {
+      width: 0;
+      height: 0;
+      border-left: $pagination-toggle-border solid transparent;
+      border-right: $pagination-toggle-border solid transparent;
+      border-top: $pagination-toggle-border solid $gray-700;
+      transform: rotate(0);
+      inset-inline-start: .5rem;
+      top: 0;
+      margin-inline-end: 1rem;
+    }
+
+    button.next,
+    button.previous {
+      height: $pagination-secondary-height;
+      padding: 0 $pagination-padding-y;
+    }
+
+    &.pagination-small {
+      .btn.dropdown-toggle {
+        font-size: $pagination-font-size-sm;
+
+        &::after {
+          border-left-width: $pagination-toggle-border-sm;
+          border-right-width: $pagination-toggle-border-sm;
+          border-top-width: $pagination-toggle-border-sm;
+        }
+      }
+
+      button.previous,
+      button.next {
+        line-height: $pagination-icon-height;
+        height: $pagination-icon-height;
+      }
+    }
+  }
+
+  &-minimal {
+    .page-item:first-child {
+      margin-inline-end: .3rem;
+    }
+
+    button.next,
+    button.previous {
+      padding: $pagination-padding-y;
+      height: $pagination-secondary-height;
+    }
+
+    &.pagination-small {
+      button.next,
+      button.previous {
+        padding: 0 $pagination-padding-y;
+        height: $pagination-secondary-height-sm;
+      }
+    }
+  }
 }
 
 .page-link {
   border: none;
-  background-color: transparent;
+  margin-left: -$pagination-border-width;
   color: $pagination-page-link-color;
 
-  &:hover {
-    color: $pagination-page-link-color;
+  &.btn-primary {
+    background-color: transparent;
+
+    &:hover {
+      text-decoration: none;
+      background-color: $gray-100;
+      border-color: $gray-100;
+      color: $pagination-page-link-color;
+    }
+  }
+
+  &:focus {
+    z-index: 3;
   }
 
   &.btn-primary:not(:disabled):not(.disabled):focus,
   &.btn-tertiary:not(:disabled):not(.disabled):focus {
     background-color: $pagination-bg;
     color: $pagination-focus-color-text;
-  }
-
-  &:focus {
-    box-shadow: none;
   }
 
   &.btn-primary:focus::before,
@@ -66,229 +282,5 @@
     svg {
       transform: scale(-1);
     }
-  }
-
-  &:focus::before,
-  &.focus::before {
-    border-radius: 0;
-  }
-}
-
-.page-item {
-  > .btn {
-    transition: none;
-    line-height: $pagination-line-height;
-  }
-
-  &.active .page-link.btn-primary:not(:disabled):not(.disabled):focus {
-    background-color: $pagination-focus-color;
-    color: $pagination-bg;
-  }
-}
-
-.pagination-small {
-  .page-link {
-    font-size: $pagination-font-size-sm;
-    line-height: $pagination-line-height;
-    padding: .375rem .78rem;
-
-    &.previous,
-    &.next {
-      padding: 0 $pagination-padding-y;
-      line-height: $pagination-secondary-height-sm;
-
-      div {
-        display: flex;
-        align-items: center;
-      }
-    }
-  }
-
-  &:not(.pagination-default) {
-    .page-link {
-      &.previous,
-      &.next {
-        padding: 0;
-        width: $pagination-icon-width;
-      }
-    }
-  }
-}
-
-.pagination-secondary {
-  button.next,
-  button.previous {
-    height: $pagination-secondary-height;
-    padding: 0 $pagination-padding-y;
-  }
-
-  &.pagination-small {
-    button.next,
-    button.previous {
-      height: $pagination-secondary-height-sm;
-      line-height: $pagination-line-height;
-    }
-  }
-
-  .page-item:first-child .page-link {
-    @extend %pagination-icon-button-left;
-  }
-
-  .page-item:last-child .page-link {
-    @extend %pagination-icon-button-right;
-  }
-}
-
-.pagination-inverse {
-  %dark-styles {
-    background-color: transparent;
-    color: $white;
-  }
-
-  .pgn__dark-styles {
-    @extend %dark-styles;
-  }
-
-  .page-item {
-    &.disabled .page-link {
-      @extend %dark-styles;
-    }
-
-    &.active button.page-link {
-      background-color: $pagination-bg;
-      color: $pagination-page-link-color;
-    }
-
-    button.page-link.btn-inverse-tertiary:hover {
-      color: $white;
-      background-color: #2D494E;
-      border-color: rgba(0, 0, 0, 0);
-    }
-
-    button.page-link {
-      @extend %dark-styles;
-
-      &:focus {
-        box-shadow: none;
-      }
-    }
-
-    &:not(.active):focus {
-      box-shadow: $level-1-box-shadow;
-    }
-  }
-
-  .page-link {
-    &:focus::before,
-    &.focus::before {
-      display: none;
-    }
-  }
-
-  .dropdown {
-    .btn-tertiary {
-      color: $pagination-color-inverse;
-
-      &::after {
-        border-top: $pagination-toggle-border solid $pagination-color-inverse;
-      }
-
-      &:active,
-      &:hover {
-        background-color: transparent;
-      }
-
-      &:not(:disabled):not(.disabled):active {
-        color: $pagination-color-inverse;
-      }
-    }
-  }
-
-  .show > .dropdown-toggle {
-    background-color: transparent;
-  }
-}
-
-.pgn__reduced-pagination-dropdown {
-  overflow-y: auto;
-  max-height: $pagination-reduced-dropdown-max-height;
-  min-width: $pagination-reduced-dropdown-min-width;
-
-  a {
-    text-align: center;
-  }
-}
-
-.pagination-reduced {
-  .dropdown-toggle::after {
-    width: 0;
-    height: 0;
-    border-left: $pagination-toggle-border solid transparent;
-    border-right: $pagination-toggle-border solid transparent;
-    border-top: $pagination-toggle-border solid $gray-700;
-    transform: rotate(0);
-    inset-inline-start: .5rem;
-    top: 0;
-    margin-inline-end: 1rem;
-  }
-
-  button.next,
-  button.previous {
-    height: $pagination-secondary-height;
-    padding: 0 $pagination-padding-y;
-  }
-
-  &.pagination-small {
-    .btn.dropdown-toggle {
-      font-size: $pagination-font-size-sm;
-
-      &::after {
-        border-left-width: $pagination-toggle-border-sm;
-        border-right-width: $pagination-toggle-border-sm;
-        border-top-width: $pagination-toggle-border-sm;
-      }
-    }
-
-    button.previous,
-    button.next {
-      line-height: $pagination-icon-height;
-      height: $pagination-icon-height;
-    }
-  }
-
-  .page-item:first-child .page-link {
-    @extend %pagination-icon-button-left;
-  }
-
-  .page-item:last-child .page-link {
-    @extend %pagination-icon-button-right;
-  }
-}
-
-.pagination-minimal {
-  .page-item:first-child {
-    margin-inline-end: .3rem;
-  }
-
-  button.next,
-  button.previous {
-    padding: $pagination-padding-y;
-    height: $pagination-secondary-height;
-  }
-
-  &.pagination-small {
-    button.next,
-    button.previous {
-      padding: 0 $pagination-padding-y;
-      height: $pagination-secondary-height-sm;
-    }
-  }
-
-  .page-item:first-child .page-link {
-    @extend %pagination-icon-button-left;
-  }
-
-  .page-item:last-child .page-link {
-    @extend %pagination-icon-button-right;
   }
 }

--- a/src/Pagination/_variables.scss
+++ b/src/Pagination/_variables.scss
@@ -1,21 +1,21 @@
 // Pagination
 
 $pagination-padding-y:              .625rem !default;
-$pagination-padding-x:              1rem !default;
-$pagination-padding-y-sm:           .8rem !default;
-$pagination-padding-x-sm:           .6rem !default;
-$pagination-padding-y-lg:           .75rem !default;
-$pagination-padding-x-lg:           1.5rem !default;
+// $pagination-padding-x:              1rem !default;
+// $pagination-padding-y-sm:           .8rem !default;
+// $pagination-padding-x-sm:           .6rem !default;
+// $pagination-padding-y-lg:           .75rem !default;
+// $pagination-padding-x-lg:           1.5rem !default;
 $pagination-margin-x:               .5rem !default;
-$pagination-margin-y:               .5rem !default;
+// $pagination-margin-y:               .5rem !default;
 $pagination-line-height:            1.5rem !default;
 $pagination-font-size-sm:           .875rem !default;
 
-$pagination-icon-size:              1.375rem !default;
-$pagination-icon-size-sm:           1rem !default;
+// $pagination-icon-size:              1.375rem !default;
+// $pagination-icon-size-sm:           1rem !default;
 $pagination-icon-width:             2.25rem !default;
 $pagination-icon-height:            2.25rem !default;
-$pagination-padding-icon:           .5rem !default;
+// $pagination-padding-icon:           .5rem !default;
 $pagination-toggle-border:          .3125rem !default;
 $pagination-toggle-border-sm:       .25rem !default;
 $pagination-secondary-height:       2.75rem !default;
@@ -26,17 +26,17 @@ $pagination-color-inverse:          $white !default;
 $pagination-page-link-color:        $gray-700 !default;
 $pagination-bg:                     $white !default;
 $pagination-border-width:           $border-width !default;
-$pagination-border-color:           theme-color("gray", "border") !default;
+// $pagination-border-color:           theme-color("gray", "border") !default;
 
-$pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
-$pagination-focus-outline:          0 !default;
+// $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
+// $pagination-focus-outline:          0 !default;
 $pagination-focus-border-width:     .125rem !default;
 $pagination-focus-color:            $primary-500 !default;
 $pagination-focus-color-text:       $black !default;
 
-$pagination-hover-color:            $link-hover-color !default;
-$pagination-hover-bg:               theme-color("gray", "background") !default;
-$pagination-hover-border-color:     theme-color("gray", "border") !default;
+// $pagination-hover-color:            $link-hover-color !default;
+// $pagination-hover-bg:               theme-color("gray", "background") !default;
+// $pagination-hover-border-color:     theme-color("gray", "border") !default;
 
 $pagination-active-color:           $component-active-color !default;
 $pagination-active-bg:              $component-active-bg !default;
@@ -46,8 +46,8 @@ $pagination-disabled-color:         theme-color("gray", "light-text") !default;
 $pagination-disabled-bg:            $white !default;
 $pagination-disabled-border-color:  theme-color("gray", "disabled-border") !default;
 
-$pagination-border-radius-sm:       $border-radius-sm !default;
-$pagination-border-radius-lg:       $border-radius-lg !default;
+// $pagination-border-radius-sm:       $border-radius-sm !default;
+// $pagination-border-radius-lg:       $border-radius-lg !default;
 
 $pagination-reduced-dropdown-max-height: 60vh !default;
 $pagination-reduced-dropdown-min-width: 6rem !default;

--- a/src/Pagination/_variables.scss
+++ b/src/Pagination/_variables.scss
@@ -23,6 +23,7 @@ $pagination-secondary-height-sm:    2.25rem !default;
 
 $pagination-color:                  $link-color !default;
 $pagination-color-inverse:          $white !default;
+$pagination-page-link-color:        $gray-700 !default;
 $pagination-bg:                     $white !default;
 $pagination-border-width:           $border-width !default;
 $pagination-border-color:           theme-color("gray", "border") !default;

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -36,7 +36,7 @@ function ReducedPagination({ currentPage, pageCount, handlePageSelect }) {
       <Dropdown.Toggle variant="tertiary" id="Pagination dropdown">
         {currentPage} of {pageCount}
       </Dropdown.Toggle>
-      <Dropdown.Menu className="pgn__reduced-pagination-dropdown">
+      <Dropdown.Menu className="pagination-reduced-dropdown-menu">
         {[...Array(pageCount).keys()].map(pageNum => (
           <Dropdown.Item onClick={() => handlePageSelect(pageNum + 1)} key={pageNum}>
             {pageNum + 1}
@@ -145,30 +145,6 @@ class Pagination extends React.Component {
       ariaLabel += `, ${buttonLabels.currentPage}`;
     }
 
-    if (invertColors) {
-      return (
-        <li
-          className={classNames([
-            'page-item',
-            {
-              active,
-            },
-          ])}
-          key={page}
-        >
-          <Button
-            className="page-link"
-            aria-label={ariaLabel}
-            variant={active ? 'inverse-primary' : 'inverse-tertiary'}
-            ref={(element) => { this.pageRefs[page] = element; }}
-            onClick={() => { this.handlePageSelect(page); }}
-          >
-            {page.toString()}
-          </Button>
-        </li>
-      );
-    }
-
     return (
       <li
         className={classNames([
@@ -182,7 +158,8 @@ class Pagination extends React.Component {
         <Button
           className="page-link"
           aria-label={ariaLabel}
-          variant={active ? 'primary' : 'tertiary'}
+          /* eslint-disable-next-line no-nested-ternary */
+          variant={invertColors ? (active ? 'inverse-primary' : 'inverse-tertiary') : (active ? 'primary' : 'tertiary')}
           ref={(element) => { this.pageRefs[page] = element; }}
           onClick={() => { this.handlePageSelect(page); }}
         >

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -137,12 +137,36 @@ class Pagination extends React.Component {
   }
 
   renderPageButton(page) {
-    const { buttonLabels } = this.props;
+    const { buttonLabels, invertColors } = this.props;
     const active = page === this.state.currentPage || null;
 
     let ariaLabel = `${buttonLabels.page} ${page}`;
     if (active) {
       ariaLabel += `, ${buttonLabels.currentPage}`;
+    }
+
+    if (invertColors) {
+      return (
+        <li
+          className={classNames([
+            'page-item',
+            {
+              active,
+            },
+          ])}
+          key={page}
+        >
+          <Button
+            className="page-link"
+            aria-label={ariaLabel}
+            variant={active ? 'inverse-primary' : 'inverse-tertiary'}
+            ref={(element) => { this.pageRefs[page] = element; }}
+            onClick={() => { this.handlePageSelect(page); }}
+          >
+            {page.toString()}
+          </Button>
+        </li>
+      );
     }
 
     return (

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -158,6 +158,7 @@ class Pagination extends React.Component {
         <Button
           className="page-link"
           aria-label={ariaLabel}
+          variant={active ? 'primary' : 'tertiary'}
           ref={(element) => { this.pageRefs[page] = element; }}
           onClick={() => { this.handlePageSelect(page); }}
         >


### PR DESCRIPTION
## Description

- Ensure the Pagination buttons no longer use .btn-primary.
- Ensure the non-active pages of Pagination have a transparent background (they are currently white). This will help make Pagination usable on a wider array of background colors than just white.

![image](https://user-images.githubusercontent.com/93188219/207959274-a2314eec-1069-419c-9028-bb5356e8c10b.png)

### Deploy Preview

[Pagination component](https://deploy-preview-1849--paragon-openedx.netlify.app/components/pagination/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
