### PR TITLE
[BD-46] fix: install dependencies in tokens module after installing Paragon

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,5 +7,3 @@ dependent-usage-analyzer/
 build-scss.js
 component-generator/
 example/
-style-dictionary-build/
-build-tokens.js

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ jest*
 dist
 src/i18n/transifex_input.json
 src/i18n/temp
-style-dictionary-build
 
 # gatsby files
 www/.cache/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "sideEffects": false,
   "scripts": {
+    "postinstall": "cd ./tokens && npm ci",
     "generate-component-install": "cd component-generator && npm install",
     "consumer-app-install": "cd example && npm install",
     "doc-site-install": "cd www && npm install",

--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -6,12 +6,11 @@ const StyleDictionary = require('./style-dictionary');
 program
   .version('0.0.1')
   .description('CLI to build design tokens for various platforms (currently only CSS is supported) from Paragon Design Tokens.')
-  .option('--prefix <char>', 'A prefix that will be added to the names of all built tokens.', 'pgn')
   .option('--build-dir <char>', 'A path to directory where to put files with built tokens, must end with a /.', './build/')
-  .option('--tokens-source <char>', 'A path where to look for additional tokens that will get merged with Paragon ones, accepts glob patterns, e.g. "mytokens/**/*.json". Only json files are allowed.')
-  .parse()
+  .option('--source <char>', 'A path where to look for additional tokens that will get merged with Paragon ones, accepts glob patterns, e.g. "mytokens/**/*.json". Only json files are allowed.')
+  .parse();
 
-const { prefix, buildDir, tokensSource } = program.opts();
+const { buildDir, source: tokensSource } = program.opts();
 const source = tokensSource ? [tokensSource] : [];
 
 const config = {
@@ -19,7 +18,7 @@ const config = {
   source,
   platforms: {
     css: {
-      prefix,
+      prefix: 'pgn',
       transformGroup: 'css',
       buildPath: buildDir,
       files: [


### PR DESCRIPTION
## Description
 
Install dependencies in tokens module after installing Paragon

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
