### PR TITLE
fix: ensure card footer switches to white when card variant is dark

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -26,6 +26,11 @@
     .pgn__card-section {
       @extend %dark-variant-content;
     }
+
+    .pgn__card-footer,
+    .pgn__card-footer-text {
+      @extend %dark-variant-content;
+    }
   }
 
   &.pgn__card-muted {

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -88,7 +88,7 @@ Use `variant` prop to use `Card` specific style variant.
         <Card.Section>
           This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
         </Card.Section>
-        <Card.Footer>
+        <Card.Footer textElement="Course">
           <Button
             variant={cardVariant === 'dark' ? 'inverse-primary' : 'primary'}
           >


### PR DESCRIPTION
## Description

Ensures `Card.Footer`'s `textElement` prop turns white automatically when `variant="dark"` on the top-level `Card` component.

<img width="317" alt="image" src="https://user-images.githubusercontent.com/2828721/208929437-9a875f39-ad75-4505-b2ed-d8adfc31647b.png">

### Deploy Preview

TBD

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
