### PR TITLE
fix: ensure CardHeader title and subtitle turn white with dark variant

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -21,6 +21,12 @@
 
     .pgn__card-header {
       @extend %dark-variant-content;
+
+      .pgn__card-header-title,
+      .pgn__card-header-title-sm,
+      .pgn__card-header-title-md {
+        @extend %dark-variant-content;
+      }
     }
 
     .pgn__card-section {

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -75,16 +75,7 @@ Use `variant` prop to use `Card` specific style variant.
           src="https://picsum.photos/360/200/"
           srcAlt="Card image"
         />
-        <Card.Header
-          title={(
-            <Hyperlink
-              destination="https://google.com"
-              target="_blank"
-            >
-              Card Title
-             </Hyperlink>
-          )}
-        />
+        <Card.Header title="Card Title" />
         <Card.Section>
           This is a card section. It can contain anything but usually text, a list, or list of links. Multiple sections have a card divider between them.
         </Card.Section>


### PR DESCRIPTION
## Description

Noticed that when passing a `title`/`subtitle` as a string vs. the `Hyperlink` element, the color doesn't flip to white as expected when `Card`'s `variant="dark"`:

### Before

<img width="315" alt="image" src="https://user-images.githubusercontent.com/2828721/208960780-ac017c15-e10c-45bf-aa94-5ad150867eda.png">

### After

<img width="302" alt="image" src="https://user-images.githubusercontent.com/2828721/208960847-5cfe5330-0c1a-4579-9d5b-3127ea95ca8b.png">

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
