### PR TITLE
fix: ensure `SelectableBox` has white background

### DIFF
--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -35,7 +35,7 @@ As ``Checkbox``
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
   
   return (
-    <div className="bg-primary-500 p-5">
+    <div className="bg-light-200 p-3">
       <SelectableBox.Set
         value={checkedCheeses}
         type={type}

--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -35,32 +35,34 @@ As ``Checkbox``
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
   
   return (
-    <SelectableBox.Set
-      value={checkedCheeses}
-      type={type}
-      onChange={handleChange}
-      name="cheeses"
-      columns={isExtraSmall ? 1 : 2}
-    >
-      <SelectableBox value="swiss" type={type} aria-label="checkbox">
-        <div>
-          <h3>It is my first SelectableBox</h3>
-          <p>Swiss</p>
-        </div>
-      </SelectableBox>
-      <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="checkbox">
-        Cheddar
-      </SelectableBox>
-      <SelectableBox
-        value="pepperjack"
-        inputHidden={false}
+    <div className="bg-primary-500 p-5">
+      <SelectableBox.Set
+        value={checkedCheeses}
         type={type}
-        isInvalid={isInvalid()}
-        aria-label="checkbox"
+        onChange={handleChange}
+        name="cheeses"
+        columns={isExtraSmall ? 1 : 2}
       >
-        <h3>Pepperjack</h3>
-      </SelectableBox>
-    </SelectableBox.Set>
+        <SelectableBox value="swiss" type={type} aria-label="checkbox">
+          <div>
+            <h3>It is my first SelectableBox</h3>
+            <p>Swiss</p>
+          </div>
+        </SelectableBox>
+        <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="checkbox">
+          Cheddar
+        </SelectableBox>
+        <SelectableBox
+          value="pepperjack"
+          inputHidden={false}
+          type={type}
+          isInvalid={isInvalid()}
+          aria-label="checkbox"
+        >
+          <h3>Pepperjack</h3>
+        </SelectableBox>
+      </SelectableBox.Set>
+    </div>
   );
 }
 ```

--- a/src/SelectableBox/SelectableBox.scss
+++ b/src/SelectableBox/SelectableBox.scss
@@ -23,6 +23,7 @@
   box-shadow: $level-1-box-shadow;
   border-radius: $selectable-box-border-radius;
   text-align: start;
+  background: $white;
 
   &:focus-visible {
     outline: 1px solid $primary-700;

--- a/www/src/components/Settings.tsx
+++ b/www/src/components/Settings.tsx
@@ -28,6 +28,7 @@ const Settings = () => {
       position="right"
       show={showSettings}
       variant="light"
+      onClose={closeSettings}
     >
       <div className="d-flex align-items-center justify-content-between mb-3">
         <h3 className="mb-0">Settings</h3>


### PR DESCRIPTION
## Description

* Ensure `SelectableBox` has a white background. Otherwise, the background color underlying the element will be visible.
* Ensures the "Settings" sheet closes on escape or blur.

### Before (`SelectableBox` is transparent)

<img width="915" alt="image" src="https://user-images.githubusercontent.com/2828721/209001401-0631366b-e942-420a-b84f-534cadb5b357.png">

### After (`SelectableBox` is white)

<img width="903" alt="image" src="https://user-images.githubusercontent.com/2828721/209001459-36055d9a-22bc-43cc-84ea-e49795c1aada.png">

### Deploy Preview

https://deploy-preview-1863--paragon-openedx.netlify.app/components/selectablebox

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
