### PR TITLE
fix: ensure CardHeader subtitle is also changed to white

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -24,7 +24,10 @@
 
       .pgn__card-header-title,
       .pgn__card-header-title-sm,
-      .pgn__card-header-title-md {
+      .pgn__card-header-title-md,
+      .pgn__card-header-subtitle,
+      .pgn__card-header-subtitle-sm,
+      .pgn__card-header-subtitle-md {
         @extend %dark-variant-content;
       }
     }


### PR DESCRIPTION
## Description

Ensures the `Card.Header` subtitle text also gets changed to `$white` when `<Card variant="dark" />`.

### Deploy Preview

https://deploy-preview-1865--paragon-openedx.netlify.app/components/card/#card-variants

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
