### PR TITLE
feat: updated CardDeck

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -70,7 +70,7 @@ a .pgn__card {
 .pgn__card-deck {
   position: relative;
   margin-bottom: $card-deck-margin-bottom;
-  
+
   .pgn__card-deck-row {
     overflow: hidden;
     overflow-x: scroll;
@@ -349,14 +349,16 @@ a .pgn__card {
 }
 
 .pgn__card {
-  @include pgn-box-shadow(1, "down");
   outline: none;
+
+  @include pgn-box-shadow(1, "down");
 
   &.clickable {
     &:hover,
     &:focus,
     &.focus {
       cursor: pointer;
+
       @include pgn-box-shadow(2, "down");
     }
 

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -56,8 +56,27 @@ a .pgn__card {
 .pgn__card-grid {
   .row > div[class*="col-"] {
     margin-bottom: $card-grid-margin;
+  }
+}
+
+.pgn__card-grid,
+.pgn__card-deck {
+  .row > div[class*="col-"] {
     display: flex;
     flex: 1 0 auto;
+  }
+}
+
+.pgn__card-deck {
+  margin: -5px -5px;
+  padding: 5px 5px;
+  overflow: hidden;
+  overflow-x: scroll;
+
+  border: 1px solid $primary-500;
+
+  .pgn__card-deck-row {
+    flex-wrap: nowrap;
   }
 }
 
@@ -306,7 +325,6 @@ a .pgn__card {
 }
 
 %pgn__card-focused {
-  box-shadow: none;
   outline: none;
 
   &::before {
@@ -329,9 +347,9 @@ a .pgn__card {
   @include pgn-box-shadow(1, "down");
 
   &.clickable {
-    &:hover {
+    &:hover,
+    &:focus {
       cursor: pointer;
-
       @include pgn-box-shadow(2, "down");
     }
 

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -69,30 +69,19 @@ a .pgn__card {
 
 .pgn__card-deck {
   position: relative;
-  margin: 0 -$card-focus-border-offset;
-  padding: 0 $card-focus-border-offset;
   margin-bottom: $card-deck-margin-bottom;
-  overflow: hidden;
-
-  &:focus-visible {
-    outline: $card-focus-border-width solid $card-border-focus-color;
-    border-radius: $card-focus-border-radius
-  }
-
+  
   .pgn__card-deck-row {
     overflow: hidden;
     overflow-x: scroll;
     flex-wrap: nowrap;
     padding-top: $card-focus-border-offset;
     padding-bottom: $card-focus-border-offset;
-    
-    // > div[class*="col"]:first-child {
-    //   padding-left: $card-focus-border-offset;
-    // }
 
-    // > div[class*="col"]:last-child {
-    //   padding-right: $card-focus-border-offset;
-    // }
+    &:focus-visible {
+      outline: $card-focus-border-width solid $card-border-focus-color;
+      border-radius: $card-focus-border-radius;
+    }
   }
 }
 
@@ -361,6 +350,7 @@ a .pgn__card {
 
 .pgn__card {
   @include pgn-box-shadow(1, "down");
+  outline: none;
 
   &.clickable {
     &:hover,

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -69,11 +69,10 @@ a .pgn__card {
 
 .pgn__card-deck {
   position: relative;
-  margin: -$card-focus-border-offset;
-  padding: $card-focus-border-offset;
+  margin: 0 -$card-focus-border-offset;
+  padding: 0 $card-focus-border-offset;
   margin-bottom: $card-deck-margin-bottom;
   overflow: hidden;
-  overflow-x: scroll;
 
   &:focus-visible {
     outline: $card-focus-border-width solid $card-border-focus-color;
@@ -81,11 +80,19 @@ a .pgn__card {
   }
 
   .pgn__card-deck-row {
+    overflow: hidden;
+    overflow-x: scroll;
     flex-wrap: nowrap;
+    padding-top: $card-focus-border-offset;
+    padding-bottom: $card-focus-border-offset;
     
-    > div[class*="col"]:last-child {
-      padding-right: $card-focus-border-offset;
-    }
+    // > div[class*="col"]:first-child {
+    //   padding-left: $card-focus-border-offset;
+    // }
+
+    // > div[class*="col"]:last-child {
+    //   padding-right: $card-focus-border-offset;
+    // }
   }
 }
 

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -55,7 +55,7 @@ a .pgn__card {
 
 .pgn__card-grid {
   .row > div[class*="col-"] {
-    margin-bottom: $card-grid-margin;
+    margin-bottom: $card-grid-margin-bottom;
   }
 }
 
@@ -68,15 +68,24 @@ a .pgn__card {
 }
 
 .pgn__card-deck {
-  margin: -5px -5px;
-  padding: 5px 5px;
+  position: relative;
+  margin: -$card-focus-border-offset;
+  padding: $card-focus-border-offset;
+  margin-bottom: $card-deck-margin-bottom;
   overflow: hidden;
   overflow-x: scroll;
 
-  border: 1px solid $primary-500;
+  &:focus-visible {
+    outline: $card-focus-border-width solid $card-border-focus-color;
+    border-radius: $card-focus-border-radius
+  }
 
   .pgn__card-deck-row {
     flex-wrap: nowrap;
+    
+    > div[class*="col"]:last-child {
+      padding-right: $card-focus-border-offset;
+    }
   }
 }
 
@@ -348,7 +357,8 @@ a .pgn__card {
 
   &.clickable {
     &:hover,
-    &:focus {
+    &:focus,
+    &.focus {
       cursor: pointer;
       @include pgn-box-shadow(2, "down");
     }

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -5,12 +5,12 @@ import BaseCardDeck from 'react-bootstrap/CardDeck';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
-function CardDeck({
+const CardDeck = React.forwardRef(({
   className,
   children,
   columnSizes,
   hasInteractiveChildren,
-}) {
+}, ref) => {
   const cards = useMemo(
     () => React.Children.map(children, card => (
       <Col {...columnSizes}>
@@ -22,6 +22,7 @@ function CardDeck({
 
   return (
     <div
+      ref={ref}
       className={classNames('pgn__card-deck', className)}
       tabIndex={hasInteractiveChildren ? -1 : 0}
     >
@@ -30,7 +31,7 @@ function CardDeck({
       </Row>
     </div>
   );
-}
+});
 
 CardDeck.propTypes = {
   /** The class name for the CardDeck component */

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -5,12 +5,13 @@ import BaseCardDeck from 'react-bootstrap/CardDeck';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
-const CardDeck = React.forwardRef(({
+function CardDeck({
   className,
   children,
   columnSizes,
   hasInteractiveChildren,
-}, ref) => {
+  overflowRef,
+}) {
   const cards = useMemo(
     () => React.Children.map(children, card => (
       <Col {...columnSizes}>
@@ -21,17 +22,17 @@ const CardDeck = React.forwardRef(({
   );
 
   return (
-    <div
-      ref={ref}
-      className={classNames('pgn__card-deck', className)}
-      tabIndex={hasInteractiveChildren ? -1 : 0}
-    >
-      <Row className="pgn__card-deck-row">
+    <div className={classNames('pgn__card-deck', className)}>
+      <Row
+        className="pgn__card-deck-row"
+        tabIndex={hasInteractiveChildren ? -1 : 0}
+        ref={overflowRef}
+      >
         {cards}
       </Row>
     </div>
   );
-});
+}
 
 CardDeck.propTypes = {
   /** The class name for the CardDeck component */

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -1,0 +1,68 @@
+import React, { useMemo } from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import BaseCardDeck from 'react-bootstrap/CardDeck';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function CardDeck({
+  className,
+  children,
+  columnSizes,
+  hasInteractiveChildren,
+}) {
+  const cards = useMemo(
+    () => React.Children.map(children, card => (
+      <Col {...columnSizes}>
+        {card}
+      </Col>
+    )),
+    [children, columnSizes],
+  );
+
+  return (
+    <div
+      className={classNames('pgn__card-deck', className)}
+      tabIndex={hasInteractiveChildren ? -1 : 0}
+    >
+      <Row className="pgn__card-deck-row">
+        {cards}
+      </Row>
+    </div>
+  );
+}
+
+CardDeck.propTypes = {
+  /** The class name for the CardDeck component */
+  className: PropTypes.string,
+  /** The Card components to organize */
+  children: PropTypes.node.isRequired,
+  /**
+   * An object containing the desired column size at each breakpoint, following a similar
+   * props API as ``react-bootstrap/Col``
+   */
+  columnSizes: PropTypes.shape({
+    xs: PropTypes.number,
+    sm: PropTypes.number,
+    md: PropTypes.number,
+    lg: PropTypes.number,
+    xl: PropTypes.number,
+  }),
+  /** Whether the child `Card` components are interactive/focusable. If not, a `tabindex="0"` is
+   * added to be a11y-compliant */
+  hasInteractiveChildren: PropTypes.bool,
+};
+
+CardDeck.defaultProps = {
+  className: undefined,
+  columnSizes: {
+    sm: 12,
+    lg: 6,
+    xl: 4,
+  },
+  hasInteractiveChildren: false,
+};
+
+CardDeck.Deprecated = BaseCardDeck;
+
+export default CardDeck;

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -53,6 +53,11 @@ CardDeck.propTypes = {
   /** Whether the child `Card` components are interactive/focusable. If not, a `tabindex="0"` is
    * added to be a11y-compliant */
   hasInteractiveChildren: PropTypes.bool,
+  /** The ref to be passed to the scrollable CardDeck element */
+  overflowRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 CardDeck.defaultProps = {
@@ -63,6 +68,7 @@ CardDeck.defaultProps = {
     xl: 4,
   },
   hasInteractiveChildren: false,
+  overflowRef: null,
 };
 
 CardDeck.Deprecated = BaseCardDeck;

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -56,7 +56,7 @@ CardDeck.propTypes = {
   /** The ref to be passed to the scrollable CardDeck element */
   overflowRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(typeof Element === 'undefined' ? () => {} : Element) }),
   ]),
 };
 

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -802,12 +802,16 @@ behavior.
 
 ## CardDeck
 
-Displays child `Card` components in a horizontal row with equal height and width, along with an  appropriate gutter between cards. The width of the child `Card` components is determined by the (optional) `columnSizes` prop. If any child `Card` components overflow beyond the parent's width, they will be hidden but accessible via scrolling horizontally or keyboard navigation (e.g., if the cards are clickable).
+Displays child `Card` components in a horizontal row with equal height and width, with an appropriate gutter between cards. The width of each child `Card` component is determined by the (optional) `columnSizes` prop. If any child `Card` components overflow beyond the parent's width, they will be hidden but accessible via scrolling horizontally or keyboard navigation.
+
+For accessibility, if the child `Card` components are interactive (e.g., `isClickable`), pass the `hasInteractiveChildren` prop so the `CardDeck` itself isn't focusable.
 
 ```jsx live
 () => {
+  const [hasInteractiveChildren, setHasInteractiveChildren] = useState('false');
+
   const CardComponent = () => (
-    <Card>
+    <Card isClickable={hasInteractiveChildren === 'true'}>
       <Card.ImageCap
         src="https://picsum.photos/360/200/"
         srcAlt="Card image"
@@ -818,20 +822,34 @@ Displays child `Card` components in a horizontal row with equal height and width
       </Card.Section>
     </Card>
   );
+
   return (
-    <CardDeck>
-      <CardComponent />
-      <CardComponent />
-      <CardComponent />
-      <CardComponent />
-      <CardComponent />
-    </CardDeck>
+    <>
+      {/* start example form block */}
+      <ExamplePropsForm
+        inputs={[
+          {
+            value: hasInteractiveChildren,
+            setValue: setHasInteractiveChildren,
+            options: ['true', 'false'],
+            name: 'hasInteractiveChildren',
+          },
+        ]}
+      />
+      {/* end example form block */}
+      <CardDeck hasInteractiveChildren={hasInteractiveChildren === 'true'}>
+        <CardComponent />
+        <CardComponent />
+        <CardComponent />
+        <CardComponent />
+        <CardComponent />
+      </CardDeck>
+    </>
   );
 }
 ```
 
-### CardDeck.Deprecated
-
+## CardDeck.Deprecated
 
 Gives any child `Card` components equal height with an appropriate gutter between cards. Each child `Card` component's width will be adjusted (e.g., become more narrow) to ensure all `Card` components fit within its parent's width.
 

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -812,71 +812,63 @@ behavior.
 </CardGrid>
 ```
 
-## CardDeck (Deprecated)
+## CardDeck
 
-This component gives any child Card components equal height with an appropriate gutter between cards. However,
-it is meant to be used as a single horizontal row of Cards, not as a grid. See CardGrid for more details.
-
-**Note**: this component is deprecated and is going to be removed soon.
+Displays child `Card` components in a horizontal row with equal height and width, along with an  appropriate gutter between cards. The width of the child `Card` components is determined by the (optional) `columnSizes` prop. If any child `Card` components overflow beyond the parent's width, they will be hidden but accessible via scrolling horizontally or keyboard navigation (e.g., if the cards are clickable).
 
 ```jsx live
-<CardDeck>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This card has even longer content than the first to 
-      show that equal height action.
-    </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This content is a little bit longer.
-    </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This card has even longer content than the first to 
-      show that equal height action.
-    </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
-  </Card>
-</CardDeck>
+() => {
+  const CardComponent = () => (
+    <Card>
+      <Card.ImageCap
+        src="https://picsum.photos/360/200/"
+        srcAlt="Card image"
+      />
+      <Card.Header title="Card title" />
+      <Card.Section  title="Section title">
+        <HipsterIpsum numShortParagraphs={1} />
+      </Card.Section>
+    </Card>
+  );
+  return (
+    <CardDeck>
+      <CardComponent />
+      <CardComponent />
+      <CardComponent />
+      <CardComponent />
+      <CardComponent />
+    </CardDeck>
+  );
+}
 ```
 
+### CardDeck.Deprecated
+
+
+Gives any child `Card` components equal height with an appropriate gutter between cards. Each child `Card` component's width will be adjusted (e.g., become more narrow) to ensure all `Card` components fit within its parent's width.
+
+Note: This component A pass-thru from `react-bootstrap`
+
+```jsx live
+() => {
+  const CardComponent = () => (
+    <Card>
+      <Card.ImageCap
+        src="https://picsum.photos/360/200/"
+        srcAlt="Card image"
+      />
+      <Card.Header title="Card title" />
+      <Card.Section title="Section title">
+        <HipsterIpsum numShortParagraphs={1} />
+      </Card.Section>
+    </Card>
+  );
+  return (
+    <CardDeck.Deprecated>
+      <CardComponent />
+      <CardComponent />
+      <CardComponent />
+    </CardDeck.Deprecated>
+  )
+}
+```

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -712,9 +712,7 @@ behavior.
       additional content. This card has even longer content than the first to 
       show that equal height action.
     </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
+    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
   </Card>
   <Card>
     <Card.ImageCap
@@ -730,9 +728,7 @@ behavior.
       This is a wider card with supporting text below as a natural lead-in to 
       additional content. This content is a little bit longer.
     </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
+    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
   </Card>
   <Card>
     <Card.ImageCap
@@ -749,9 +745,7 @@ behavior.
       additional content. This card has even longer content than the first to 
       show that equal height action.
     </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
+    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
   </Card>
   <Card>
     <Card.ImageCap
@@ -768,9 +762,7 @@ behavior.
       additional content. This card has even longer content than the first to 
       show that equal height action.
     </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
+    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
   </Card>
   <Card>
     <Card.ImageCap
@@ -786,9 +778,7 @@ behavior.
       This is a wider card with supporting text below as a natural lead-in to 
       additional content. This content is a little bit longer.
     </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
+    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
   </Card>
   <Card>
     <Card.ImageCap
@@ -805,9 +795,7 @@ behavior.
       additional content. This card has even longer content than the first to 
       show that equal height action.
     </Card.Section>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
+    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
   </Card>
 </CardGrid>
 ```
@@ -819,7 +807,7 @@ Displays child `Card` components in a horizontal row with equal height and width
 ```jsx live
 () => {
   const CardComponent = () => (
-    <Card>
+    <Card isClickable>
       <Card.ImageCap
         src="https://picsum.photos/360/200/"
         srcAlt="Card image"
@@ -847,7 +835,7 @@ Displays child `Card` components in a horizontal row with equal height and width
 
 Gives any child `Card` components equal height with an appropriate gutter between cards. Each child `Card` component's width will be adjusted (e.g., become more narrow) to ensure all `Card` components fit within its parent's width.
 
-Note: This component A pass-thru from `react-bootstrap`
+Note: This component is a pass-thru from `react-bootstrap`.
 
 ```jsx live
 () => {

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -807,7 +807,7 @@ Displays child `Card` components in a horizontal row with equal height and width
 ```jsx live
 () => {
   const CardComponent = () => (
-    <Card isClickable>
+    <Card>
       <Card.ImageCap
         src="https://picsum.photos/360/200/"
         srcAlt="Card image"

--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -1,4 +1,4 @@
-// Cards
+// Card
 
 $card-spacer-y:                      .75rem !default;
 $card-spacer-x:                      1.25rem !default;
@@ -21,6 +21,8 @@ $card-img-overlay-padding:           1.25rem !default;
 $card-group-margin:                  calc($grid-gutter-width / 2) !default;
 $card-deck-margin:                   $card-group-margin !default;
 $card-grid-margin:                   $card-group-margin !default;
+$card-deck-margin-bottom:            map_get($spacers, 3) !default;
+$card-grid-margin-bottom:            map_get($spacers, 3) !default;
 
 $card-columns-count:                 3 !default;
 $card-columns-gap:                   1.25rem !default;

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -39,14 +39,14 @@ const Card = React.forwardRef(({
           [`pgn__card-${resolvedVariant}`]: resolvedVariant,
         })}
         ref={ref}
-        tabIndex={isClickable ? '0' : '-1'}
+        tabIndex={isClickable ? 0 : -1}
       />
     </CardContextProvider>
   );
 });
 
 export { default as CardColumns } from 'react-bootstrap/CardColumns';
-export { default as CardDeck } from 'react-bootstrap/CardDeck';
+export { default as CardDeck } from './CardDeck';
 export { default as CardImg } from 'react-bootstrap/CardImg';
 export { default as CardGroup } from 'react-bootstrap/CardGroup';
 export { default as CardGrid } from './CardGrid';

--- a/src/Card/tests/CardDeck.test.jsx
+++ b/src/Card/tests/CardDeck.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { v4 as uuidv4 } from 'uuid';
 import CardDeck from '../CardDeck';
 import Card from '../index';
 
@@ -21,7 +22,7 @@ function ExampleCard(props) {
 }
 
 function CardContent({ cardCount = 5, ...props }) {
-  return Array.from({ length: cardCount }).map(() => <ExampleCard {...props} />);
+  return Array.from({ length: cardCount }).map(() => <ExampleCard key={uuidv4()} {...props} />);
 }
 
 describe('<CardDeck />', () => {

--- a/src/Card/tests/CardDeck.test.jsx
+++ b/src/Card/tests/CardDeck.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import CardDeck from '../CardDeck';
+import Card from '../index';
+
+function ExampleCard(props) {
+  return (
+    <Card {...props}>
+      <Card.ImageCap src="http://fake.image" />
+      <Card.Body>
+        <Card.Header>Card title</Card.Header>
+        <Card.Section>
+          This is a wider card with supporting text below as a natural lead-in to
+          additional content. This card has even longer content than the first to
+          show that equal height action.
+        </Card.Section>
+      </Card.Body>
+      <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
+    </Card>
+  );
+}
+
+function CardContent({ cardCount = 5, ...props }) {
+  return Array.from({ length: cardCount }).map(() => <ExampleCard {...props} />);
+}
+
+describe('<CardDeck />', () => {
+  it('renders default columnSizes', () => {
+    const tree = renderer.create((
+      <CardDeck>
+        <CardContent />
+      </CardDeck>
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with controlled columnSizes', () => {
+    const tree = renderer.create((
+      <CardDeck
+        columnSizes={{
+          xs: 12,
+          md: 6,
+          lg: 4,
+          xl: 3,
+        }}
+      >
+        <CardContent />
+      </CardDeck>
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('has tabIndex="-1" when `hasInteractiveChildren` is true', () => {
+    const tree = renderer.create((
+      <CardDeck hasInteractiveChildren>
+        <CardContent isClickable />
+      </CardDeck>
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/Card/tests/CardGrid.test.jsx
+++ b/src/Card/tests/CardGrid.test.jsx
@@ -40,6 +40,7 @@ describe('<CardGrid />', () => {
             xs: 12,
             md: 6,
             lg: 4,
+            xl: 3,
           }}
         >
           {cardContent}

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -1,0 +1,694 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 1`] = `
+<div
+  className="pgn__card-deck"
+  tabIndex={-1}
+>
+  <div
+    className="pgn__card-deck-row row"
+  >
+    <div
+      className="col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card clickable pgn__card-light card"
+        tabIndex={0}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card clickable pgn__card-light card"
+        tabIndex={0}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card clickable pgn__card-light card"
+        tabIndex={0}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card clickable pgn__card-light card"
+        tabIndex={0}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card clickable pgn__card-light card"
+        tabIndex={0}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CardDeck /> renders default columnSizes 1`] = `
+<div
+  className="pgn__card-deck"
+  tabIndex={0}
+>
+  <div
+    className="pgn__card-deck-row row"
+  >
+    <div
+      className="col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
+<div
+  className="pgn__card-deck"
+  tabIndex={0}
+>
+  <div
+    className="pgn__card-deck-row row"
+  >
+    <div
+      className="col-xl-3 col-lg-4 col-md-6 col-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -3,10 +3,10 @@
 exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 1`] = `
 <div
   className="pgn__card-deck"
-  tabIndex={-1}
 >
   <div
     className="pgn__card-deck-row row"
+    tabIndex={-1}
   >
     <div
       className="col-xl-4 col-lg-6 col-sm-12"
@@ -234,10 +234,10 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
 exports[`<CardDeck /> renders default columnSizes 1`] = `
 <div
   className="pgn__card-deck"
-  tabIndex={0}
 >
   <div
     className="pgn__card-deck-row row"
+    tabIndex={0}
   >
     <div
       className="col-xl-4 col-lg-6 col-sm-12"
@@ -465,10 +465,10 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
 exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
 <div
   className="pgn__card-deck"
-  tabIndex={0}
 >
   <div
     className="pgn__card-deck-row row"
+    tabIndex={0}
   >
     <div
       className="col-xl-3 col-lg-4 col-md-6 col-12"

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -8,11 +8,11 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
     className="row"
   >
     <div
-      className="col-lg-4 col-md-6 col-12"
+      className="col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
-        tabIndex="-1"
+        tabIndex={-1}
       >
         <div
           className="pgn__card-wrapper-image-cap vertical"
@@ -66,7 +66,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
     >
       <div
         className="pgn__card pgn__card-light card"
-        tabIndex="-1"
+        tabIndex={-1}
       >
         <div
           className="pgn__card-wrapper-image-cap vertical"

--- a/www/src/components/exampleComponents/HipsterIpsum.tsx
+++ b/www/src/components/exampleComponents/HipsterIpsum.tsx
@@ -91,13 +91,7 @@ const HipsterIpsum = ({
     paragraphs,
     numParagraphs,
   });
-
-  return (
-    <>
-      {content}
-      <p className="x-small">Sourced with love from <a href="https://hipsum.co/">https://hipsum.co/</a></p>
-    </>
-  );
+  return content;
 };
 
 HipsterIpsum.propTypes = {

--- a/www/src/components/exampleComponents/HipsterIpsum.tsx
+++ b/www/src/components/exampleComponents/HipsterIpsum.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -41,15 +41,56 @@ const paragraphs: Array<string> = [
   'Vice post-ironic etsy health goth kogi aesthetic, wolf tilde tofu man bun gluten-free venmo. Yuccie kogi celiac distillery, four loko adaptogen yr mixtape bushwick vinyl pabst messenger bag. Trust fund glossier hell of selfies pop-up marfa. Pitchfork woke listicle humblebrag adaptogen enamel pin trust fund butcher helvetica cred succulents try-hard raw denim seitan. Keffiyeh tumeric slow-carb, chillwave drinking vinegar af austin pabst paleo squid prism enamel pin.',
 ];
 
-export type HipsterIpsumTypes = {
+const shortParagraphs: Array<string> = [
+  'Af crucifix listicle brooklyn letterpress. Synth polaroid art party, you probably havent heard of them pop-up subway tile pok pok migas cred paleo ugh. Tumeric green juice wolf seitan hammock ethical.',
+  'Vice post-ironic etsy health goth kogi aesthetic, wolf tilde tofu man bun gluten-free venmo.',
+  'Stumptown pop-up chia master cleanse health goth, bushwick mlkshk umami vexillologist single-origin coffee drinking',
+  'Pinterest tote bag synth, tattooed echo park cronut flannel kombucha kickstarter viral.',
+];
+
+export type HipsterIpsumType = {
   numParagraphs: number,
+  numShortParagraphs: number,
 };
 
-const HipsterIpsum = ({ numParagraphs }: HipsterIpsumTypes) => {
-  const shuffledParagraphs = React.useMemo(() => shuffle(paragraphs), []);
-  const content = shuffledParagraphs
+const getHipsterIpsumContent = (paragraphs: Array<string>, numParagraphs: number) => {
+  return paragraphs
     .slice(0, numParagraphs)
     .map(text => <p key={text}>{text}</p>);
+};
+
+export type useHipsterIpsumContentType = {
+  shortParagraphs: Array<string>,
+  numShortParagraphs: number,
+  paragraphs: Array<string>,
+  numParagraphs: number,
+}
+
+const useHipsterIpsumContent = ({
+  shortParagraphs,
+  numShortParagraphs,
+  paragraphs,
+  numParagraphs,
+}: useHipsterIpsumContentType) => {
+  if (numShortParagraphs !== undefined) {
+    const shuffledShortParagraphs = shuffle(shortParagraphs);
+    return getHipsterIpsumContent(shuffledShortParagraphs, numShortParagraphs);
+  }
+
+  const shuffledParagraphs = shuffle(paragraphs);
+  return getHipsterIpsumContent(shuffledParagraphs, numParagraphs);
+};
+
+const HipsterIpsum = ({
+  numParagraphs,
+  numShortParagraphs,
+}: HipsterIpsumType) => {
+  const content = useHipsterIpsumContent({
+    shortParagraphs,
+    numShortParagraphs,
+    paragraphs,
+    numParagraphs,
+  });
 
   return (
     <>
@@ -61,9 +102,11 @@ const HipsterIpsum = ({ numParagraphs }: HipsterIpsumTypes) => {
 
 HipsterIpsum.propTypes = {
   numParagraphs: PropTypes.number,
+  numShortParagraphs: PropTypes.number,
 };
 HipsterIpsum.defaultProps = {
   numParagraphs: 2,
+  numShortParagraphs: undefined,
 };
 
 export default HipsterIpsum;


### PR DESCRIPTION
## Description

Updates `CardDeck` to be more applicable to valid use cases for such a component. `CardGrid` is intended to be used to display a grid of `Card` components; however, we had a need for showing a single horizontal row of `Card` components, with similar column/gutter behavior as `CardGrid` with horizontal scrolling for any `Card` components that overflow the container.

Migrates the original `CardDeck` (pass-thru from react-bootstrap`) to `CardDeck.Deprecated` to keep it available for the one consumer of the original `CardDeck`.

### Deploy Preview

https://deploy-preview-1866--paragon-openedx.netlify.app/components/card/#carddeck

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
