### PR TITLE
[BD-46] feat: add ability to render Breadcrumbs with custom elements

### DIFF
--- a/src/Breadcrumb/Breadcrumb.scss
+++ b/src/Breadcrumb/Breadcrumb.scss
@@ -1,5 +1,4 @@
 @import "variables";
-@import "~bootstrap/scss/breadcrumb";
 
 .pgn__breadcrumb {
   .list-inline-item {
@@ -62,20 +61,25 @@
     }
   }
 
-  ol.is-mobile {
-    flex-direction: row-reverse;
-    justify-content: flex-end;
+  ol {
+    display: flex;
+    align-items: center;
 
-    .list-inline-item:not(:last-child) {
-      margin-right: 0;
-      margin-left: $breadcrumb-margin-left;
-    }
+    &.is-mobile {
+      flex-direction: row-reverse;
+      justify-content: flex-end;
 
-    .pgn__icon {
-      transform: scale(-1);
+      .list-inline-item:not(:last-child) {
+        margin-right: 0;
+        margin-left: $breadcrumb-margin-left;
+      }
 
-      [dir="rtl"] & {
-        transform: scale(1);
+      .pgn__icon {
+        transform: scale(-1);
+
+        [dir="rtl"] & {
+          transform: scale(1);
+        }
       }
     }
   }

--- a/src/Breadcrumb/Breadcrumb.test.jsx
+++ b/src/Breadcrumb/Breadcrumb.test.jsx
@@ -7,15 +7,15 @@ const baseProps = {
   links: [
     {
       label: 'Link 1',
-      url: '/link-1',
+      href: '/link-1',
     },
     {
       label: 'Link 2',
-      url: '/link-2',
+      href: '/link-2',
     },
     {
       label: 'Link 3',
-      url: '/link-3',
+      href: '/link-3',
     },
   ],
 };
@@ -74,5 +74,34 @@ describe('<Breadcrumb />', () => {
     const listElements = list.find('li');
     expect(listElements.length).toEqual(2);
     expect(list.hasClass('is-mobile')).toEqual(true);
+  });
+
+  it('renders links as custom elements', () => {
+    wrapper = mount(<Breadcrumb {...baseProps} linkAs="div" />);
+
+    const list = wrapper.find('ol');
+    const anchors = list.find('a');
+    expect(anchors.length).toEqual(0);
+
+    const customLinks = list.find('div');
+    expect(customLinks.length).toEqual(3);
+  });
+
+  it('passes down link props to link elements', () => {
+    const linkProps = {
+      label: 'Link 1',
+      url: '/link-1',
+      className: 'my-link',
+      target: '_blank',
+    };
+
+    wrapper = mount(<Breadcrumb links={[linkProps]} />);
+
+    const list = wrapper.find('ol');
+    const renderedLink = list.find('a').first();
+
+    expect(renderedLink.hasClass('my-link')).toEqual(true);
+    expect(renderedLink.prop('target')).toEqual('_blank');
+    expect(renderedLink.prop('href')).toEqual('/link-1');
   });
 });

--- a/src/Breadcrumb/BreadcrumbLink.jsx
+++ b/src/Breadcrumb/BreadcrumbLink.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export default function BreadcrumbLink({ as, clickHandler, linkProps }) {
+  const {
+    label,
+    url,
+    className,
+    ...props
+  } = linkProps;
+  const addtlProps = {};
+
+  if (as === 'a' && url) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[Deprecated]: using "url" parameter to specify link\'s destination in Breadcrumb component is '
+      + 'deprecated. Please use "href" instead when rendering links as anchor tag.',
+    );
+    addtlProps.href = url;
+  }
+
+  if (clickHandler) {
+    addtlProps.onClick = clickHandler;
+  }
+
+  return React.createElement(
+    as,
+    {
+      ...props,
+      ...addtlProps,
+      className: classNames('link-muted', className),
+    },
+    label,
+  );
+}
+
+BreadcrumbLink.propTypes = {
+  as: PropTypes.elementType.isRequired,
+  clickHandler: PropTypes.func,
+  linkProps: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    className: PropTypes.string,
+  }).isRequired,
+};
+
+BreadcrumbLink.defaultProps = {
+  clickHandler: undefined,
+};

--- a/src/Breadcrumb/README.md
+++ b/src/Breadcrumb/README.md
@@ -18,14 +18,14 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 
 ```jsx live
 () => {
-  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <Breadcrumb ariaLabel="Breadcrumb basic"
       links={[
-        { label: 'Link 1', url: '#link-1' },
-        { label: 'Link 2', url: '#link-2' },
-        { label: 'Link 3', url: '#link-3' },
+        { label: 'Link 1', href: '#link-1' },
+        { label: 'Link 2', href: '#link-2' },
+        { label: 'Link 3', href: '#link-3' },
       ]}
       isMobile={isExtraSmall}
     />
@@ -38,27 +38,27 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 ```jsx live
 <Breadcrumb ariaLabel="Breadcrumb mobile view"
   links={[
-    { label: 'Link 1', url: '/link-1' },
-    { label: 'Link 2', url: '/link-2' },
-    { label: 'Link 3', url: '/link-3' },
+    { label: 'Link 1', href: '/link-1' },
+    { label: 'Link 2', href: '/link-2' },
+    { label: 'Link 3', href: '/link-3' },
   ]}
   isMobile
 />
 ```
 
-### Basic Usage (Inverse Pallete)
+### Basic Usage (Inverse Palette)
 
 ```jsx live
 () => {
-  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <div className="bg-dark-700 p-4">
       <Breadcrumb ariaLabel="Breadcrumb inverse pallete"
         links={[
-          {label: 'Link 1', url: '/link-1'},
-          {label: 'Link 2', url: '/link-2'},
-          {label: 'Link 3', url: '/link-3'},
+          {label: 'Link 1', href: '/link-1'},
+          {label: 'Link 2', href: '/link-2'},
+          {label: 'Link 3', href: '/link-3'},
         ]}
         variant="dark"
         isMobile={isExtraSmall}
@@ -68,18 +68,42 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 }
 ```
 
+## With custom link element
+
+By default `Breadcrumb` uses `a` tag to render breadcrumbs, which may not always suit your needs. 
+This behaviour can be customized with `linkAs` prop, the example below uses Gatsby's `Link` component, but it would also work with [react-router's `Link`](https://reactrouter.com/en/main/components/link) component as well because they share required parts of the component API.
+
+Note that `links` list contains objects with different keys compared to the example above, specifically `href` key is replaced with `to`, that's because Gatsby's `Link` expects its destination to be set through `to` prop (same as react-router's `Link`), internally `Breadcrumb` passes down these objects (except `label` attribute) as props to the `linkAs` element. 
+
+```jsx live
+() => {
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <Breadcrumb ariaLabel="Breadcrumb basic"
+      links={[
+        { label: 'Home', to: '/' },
+        { label: 'CSS Utilities', to: '/foundations/css-utilities' },
+      ]}
+      isMobile={isExtraSmall}
+      linkAs={GatsbyLink}
+    />
+  )
+}
+```
+
 ## With active label
 
 ```jsx live
 () => {
-  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <Breadcrumb ariaLabel="Breadcrumb is active"
       links={[
-        { label: 'Link 1', url: '#link-1' },
-        { label: 'Link 2', url: '#link-2' },
-        { label: 'Link 3', url: '#link-3' },
+        { label: 'Link 1', href: '#link-1' },
+        { label: 'Link 2', href: '#link-2' },
+        { label: 'Link 3', href: '#link-3' },
       ]}
       activeLabel="Link 4"
       isMobile={isExtraSmall}
@@ -92,14 +116,14 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 
 ```jsx live
 () => {
-  const isExtraSmall = useMediaQuery({maxWidth: breakpoints.extraSmall.maxWidth});
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <Breadcrumb ariaLabel="Breadcrumb custom spacer"
       links={[
-        { label: 'Link 1', url: '#link-1' },
-        { label: 'Link 2', url: '#link-2' },
-        { label: 'Link 3', url: '#link-3' },
+        { label: 'Link 1', href: '#link-1' },
+        { label: 'Link 2', href: '#link-2' },
+        { label: 'Link 3', href: '#link-3' },
       ]}
       spacer={<span className="custom-spacer">/</span>}
       isMobile={isExtraSmall}

--- a/src/Breadcrumb/index.jsx
+++ b/src/Breadcrumb/index.jsx
@@ -2,22 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import BreadcrumbLink from './BreadcrumbLink';
 import { ChevronRight } from '../../icons';
 import Icon from '../Icon';
 
 function Breadcrumb({
-  links, activeLabel, spacer, clickHandler, variant, isMobile, ariaLabel,
+  links, activeLabel, spacer, clickHandler,
+  variant, isMobile, ariaLabel, linkAs,
 }) {
   const linkCount = links.length;
   const displayLinks = isMobile ? [links[linkCount - 1]] : links;
 
   return (
     <nav aria-label={ariaLabel} className={classNames('pgn__breadcrumb', `pgn__breadcrumb-${variant}`)}>
-      <ol className={classNames('list-inline', 'd-flex', 'align-items-center', { 'is-mobile': isMobile })}>
-        {displayLinks.map(({ url, label }, i) => (
-          <React.Fragment key={url}>
+      <ol className={classNames('list-inline', { 'is-mobile': isMobile })}>
+        {displayLinks.map((link, i) => (
+          <React.Fragment key={link.label}>
             <li className={classNames('list-inline-item')}>
-              <a className="link-muted" href={url} {...(clickHandler && { onClick: clickHandler })}>{label}</a>
+              <BreadcrumbLink as={linkAs} clickHandler={clickHandler} linkProps={link} />
             </li>
             {(activeLabel || ((i + 1) < linkCount))
               && (
@@ -34,14 +36,13 @@ function Breadcrumb({
 }
 
 Breadcrumb.propTypes = {
-  /** an array of objects with the properties `label` and `url` as strings. */
+  /** An array of objects describing links to be rendered. The contents of an object depend on the value of `linkAs`
+   * prop as these objects will get passed down as props to the underlying component defined by `linkAs` prop.
+   */
   links: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
-    url: PropTypes.string,
   })).isRequired,
-  /** allows to add a label that is not a link to the end of the breadcrumb.
-   * Defaults to `undefined`.
- */
+  /** allows to add a label that is not a link to the end of the breadcrumb. */
   activeLabel: PropTypes.string,
   /** label of the element */
   ariaLabel: PropTypes.string,
@@ -55,6 +56,10 @@ Breadcrumb.propTypes = {
   variant: PropTypes.oneOf(['light', 'dark']),
   /** The `Breadcrumbs` mobile variant view. */
   isMobile: PropTypes.bool,
+  /** Specifies the base element to use when rendering links, you should generally use either plain 'a' or
+   * [react-router's Link](https://reactrouter.com/en/main/components/link).
+   */
+  linkAs: PropTypes.elementType,
 };
 
 Breadcrumb.defaultProps = {
@@ -64,6 +69,7 @@ Breadcrumb.defaultProps = {
   clickHandler: undefined,
   variant: 'light',
   isMobile: false,
+  linkAs: 'a',
 };
 
 export default Breadcrumb;

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
 import axios from 'axios';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import theme from 'prism-react-renderer/themes/duotoneDark';
@@ -84,6 +85,7 @@ function CodeBlock({
             formatMessage: intl.formatMessage,
             MenuIcon: ParagonIcons.Menu,
             axios,
+            GatsbyLink: Link,
           }}
           theme={theme}
         >


### PR DESCRIPTION
## Description

Add ability render `Breadcrumbs` with custom element, e.g. using react-router's `Link` instead of simple `a` tag.

related issue: https://github.com/openedx/paragon/issues/1836

### Deploy Preview

https://deploy-preview-1867--paragon-openedx.netlify.app/components/breadcrumb/#with-custom-link-element

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
