### PR TITLE
fix: Takes into account pagination pageCount <=1 page

### DIFF
--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -333,7 +333,7 @@ describe('<Pagination />', () => {
       const variantTypes = ['default', 'secondary', 'reduced', 'minimal'];
       // default
       variantTypes.forEach((variantType) => {
-        for (let i = 0; i < 2; i++) {
+        for (let i = 0; i < 3; i++) {
           props = {
             ...baseProps,
             variant: variantType,
@@ -342,7 +342,7 @@ describe('<Pagination />', () => {
           wrapper = mount(<Pagination {...props} />);
           const disabled = wrapper.find('button[disabled=true]');
           expect(props.pageCount).toEqual(i);
-          expect(disabled.length).toEqual(2);
+          expect(disabled.length).toEqual(i === 2 ? 1 : 2);
         }
       });
     });

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -329,94 +329,22 @@ describe('<Pagination />', () => {
       expect(props.pageCount).toEqual(1);
       expect(disabled.length).toEqual(2);
     });
-    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
+    it('renders chevrons and buttons disabled when pageCount is 1 || 0 for all variants', () => {
+      const variantTypes = ['default', 'secondary', 'reduced', 'minimal'];
       // default
-      props = {
-        ...baseProps,
-        variant: 'default',
-        pageCount: 0,
-      };
-      wrapper = mount(<Pagination {...props} />);
-      const disabled1 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(0);
-      expect(disabled1.length).toEqual(2);
-
-      props = {
-        ...baseProps,
-        variant: 'default',
-        pageCount: 1,
-      };
-      wrapper = mount(<Pagination {...props} />);
-
-      const disabled2 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(1);
-      expect(disabled2.length).toEqual(2);
-    });
-    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
-      props = {
-        ...baseProps,
-        variant: 'secondary',
-        pageCount: 0,
-      };
-      wrapper = mount(<Pagination {...props} />);
-      const disabled1 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(0);
-      expect(disabled1.length).toEqual(2);
-
-      props = {
-        ...baseProps,
-        variant: 'secondary',
-        pageCount: 1,
-      };
-      wrapper = mount(<Pagination {...props} />);
-
-      const disabled2 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(1);
-      expect(disabled2.length).toEqual(2);
-    });
-    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
-      props = {
-        ...baseProps,
-        variant: 'reduced',
-        pageCount: 0,
-      };
-      wrapper = mount(<Pagination {...props} />);
-      const disabled1 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(0);
-      expect(disabled1.length).toEqual(2);
-
-      props = {
-        ...baseProps,
-        variant: 'reduced',
-        pageCount: 1,
-      };
-      wrapper = mount(<Pagination {...props} />);
-
-      const disabled2 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(1);
-      expect(disabled2.length).toEqual(2);
-    });
-    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
-      props = {
-        ...baseProps,
-        variant: 'minimal',
-        pageCount: 0,
-      };
-      wrapper = mount(<Pagination {...props} />);
-      const disabled1 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(0);
-      expect(disabled1.length).toEqual(2);
-
-      props = {
-        ...baseProps,
-        variant: 'minimal',
-        pageCount: 1,
-      };
-      wrapper = mount(<Pagination {...props} />);
-
-      const disabled2 = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(1);
-      expect(disabled2.length).toEqual(2);
+      variantTypes.forEach((variantType) => {
+        for (let i = 0; i < 2; i++) {
+          props = {
+            ...baseProps,
+            variant: variantType,
+            pageCount: i,
+          };
+          wrapper = mount(<Pagination {...props} />);
+          const disabled = wrapper.find('button[disabled=true]');
+          expect(props.pageCount).toEqual(i);
+          expect(disabled.length).toEqual(2);
+        }
+      });
     });
   });
 });

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -309,26 +309,6 @@ describe('<Pagination />', () => {
       expect(items.length).toEqual(2);
     });
 
-    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
-      // default
-      props = {
-        ...baseProps,
-        pageCount: 0,
-      };
-      wrapper = mount(<Pagination {...props} />);
-      const disabled = wrapper.find('button[disabled=true]');
-      expect(props.pageCount).toEqual(0);
-      expect(disabled.length).toEqual(2);
-
-      props = {
-        ...baseProps,
-        pageCount: 1,
-      };
-      wrapper = mount(<Pagination {...props} />);
-
-      expect(props.pageCount).toEqual(1);
-      expect(disabled.length).toEqual(2);
-    });
     it('renders chevrons and buttons disabled when pageCount is 1 || 0 for all variants', () => {
       const variantTypes = ['default', 'secondary', 'reduced', 'minimal'];
       // default

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -308,5 +308,115 @@ describe('<Pagination />', () => {
 
       expect(items.length).toEqual(2);
     });
+
+    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
+      // default
+      props = {
+        ...baseProps,
+        pageCount: 0,
+      };
+      wrapper = mount(<Pagination {...props} />);
+      const disabled = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(0);
+      expect(disabled.length).toEqual(2);
+
+      props = {
+        ...baseProps,
+        pageCount: 1,
+      };
+      wrapper = mount(<Pagination {...props} />);
+
+      expect(props.pageCount).toEqual(1);
+      expect(disabled.length).toEqual(2);
+    });
+    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
+      // default
+      props = {
+        ...baseProps,
+        variant: 'default',
+        pageCount: 0,
+      };
+      wrapper = mount(<Pagination {...props} />);
+      const disabled1 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(0);
+      expect(disabled1.length).toEqual(2);
+
+      props = {
+        ...baseProps,
+        variant: 'default',
+        pageCount: 1,
+      };
+      wrapper = mount(<Pagination {...props} />);
+
+      const disabled2 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(1);
+      expect(disabled2.length).toEqual(2);
+    });
+    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
+      props = {
+        ...baseProps,
+        variant: 'secondary',
+        pageCount: 0,
+      };
+      wrapper = mount(<Pagination {...props} />);
+      const disabled1 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(0);
+      expect(disabled1.length).toEqual(2);
+
+      props = {
+        ...baseProps,
+        variant: 'secondary',
+        pageCount: 1,
+      };
+      wrapper = mount(<Pagination {...props} />);
+
+      const disabled2 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(1);
+      expect(disabled2.length).toEqual(2);
+    });
+    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
+      props = {
+        ...baseProps,
+        variant: 'reduced',
+        pageCount: 0,
+      };
+      wrapper = mount(<Pagination {...props} />);
+      const disabled1 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(0);
+      expect(disabled1.length).toEqual(2);
+
+      props = {
+        ...baseProps,
+        variant: 'reduced',
+        pageCount: 1,
+      };
+      wrapper = mount(<Pagination {...props} />);
+
+      const disabled2 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(1);
+      expect(disabled2.length).toEqual(2);
+    });
+    it('renders chevrons and buttons disabled when pageCount is 1 || 0 on default variant', () => {
+      props = {
+        ...baseProps,
+        variant: 'minimal',
+        pageCount: 0,
+      };
+      wrapper = mount(<Pagination {...props} />);
+      const disabled1 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(0);
+      expect(disabled1.length).toEqual(2);
+
+      props = {
+        ...baseProps,
+        variant: 'minimal',
+        pageCount: 1,
+      };
+      wrapper = mount(<Pagination {...props} />);
+
+      const disabled2 = wrapper.find('button[disabled=true]');
+      expect(props.pageCount).toEqual(1);
+      expect(disabled2.length).toEqual(2);
+    });
   });
 });

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -106,8 +106,7 @@ class Pagination extends React.Component {
 
     if (page === 1) {
       this.nextButtonRef.focus();
-    } else
-    if (page === pageCount) {
+    } else if (page === pageCount) {
       this.previousButtonRef.focus();
     }
     this.setState({ currentPage: page });
@@ -266,7 +265,8 @@ class Pagination extends React.Component {
       buttonLabels, pageCount, icons, variant, size,
     } = this.props;
     const { currentPage } = this.state;
-    const isLastPage = (currentPage === pageCount) || (pageCount <= 1);
+    const isLastPage = (currentPage === pageCount);
+    const isDisabled = isLastPage || (pageCount <= 1);
     const nextPage = isLastPage ? null : currentPage + 1;
     const iconSize = (variant !== VARIANTS.reduced && size !== 'small') || variant === VARIANTS.minimal;
 
@@ -280,7 +280,7 @@ class Pagination extends React.Component {
         className={classNames(
           'page-item',
           {
-            disabled: isLastPage,
+            disabled: isDisabled,
           },
         )}
       >
@@ -288,10 +288,10 @@ class Pagination extends React.Component {
           <Button
             className="next page-link"
             aria-label={ariaLabel}
-            tabIndex={isLastPage ? '-1' : undefined}
+            tabIndex={isDisabled ? '-1' : undefined}
             onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
             ref={(element) => { this.nextButtonRef = element; }}
-            disabled={isLastPage}
+            disabled={isDisabled}
           >
             <div>
               {variant === VARIANTS.default ? buttonLabels.next : null}
@@ -304,10 +304,10 @@ class Pagination extends React.Component {
             iconAs={Icon}
             className="next page-link"
             aria-label={ariaLabel}
-            tabIndex={isLastPage ? '-1' : undefined}
+            tabIndex={isDisabled ? '-1' : undefined}
             onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
             ref={(element) => { this.nextButtonRef = element; }}
-            disabled={isLastPage || pageCount <= 1}
+            disabled={isDisabled}
             alt={PAGINATION_BUTTON_ICON_BUTTON_NEXT_ALT}
           />
         )}
@@ -344,10 +344,10 @@ class Pagination extends React.Component {
       requireFirstAndLastPages: true,
     });
 
+    if (pageCount <= 1) {
+      return null;
+    }
     return pages.map((pageIndex) => {
-      if (pageCount <= 1) {
-        return null;
-      }
       if (pageIndex === ELLIPSIS) {
         return this.renderEllipsisButton();
       }

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -31,6 +31,7 @@ const VARIANTS = {
 };
 
 function ReducedPagination({ currentPage, pageCount, handlePageSelect }) {
+  if (pageCount <= 1) { return null; }
   return (
     <Dropdown>
       <Dropdown.Toggle variant="tertiary" id="Pagination dropdown">
@@ -105,7 +106,8 @@ class Pagination extends React.Component {
 
     if (page === 1) {
       this.nextButtonRef.focus();
-    } else if (page === pageCount) {
+    } else
+    if (page === pageCount) {
       this.previousButtonRef.focus();
     }
     this.setState({ currentPage: page });
@@ -203,7 +205,7 @@ class Pagination extends React.Component {
 
   renderPreviousButton() {
     const {
-      buttonLabels, icons, variant, size,
+      buttonLabels, icons, variant, size, pageCount,
     } = this.props;
     const { currentPage } = this.state;
     const isFirstPage = currentPage === 1;
@@ -250,7 +252,7 @@ class Pagination extends React.Component {
                 tabIndex={isFirstPage ? '-1' : undefined}
                 onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
                 ref={(element) => { this.previousButtonRef = element; }}
-                disabled={isFirstPage}
+                disabled={isFirstPage || pageCount <= 1}
                 alt={PAGINATION_BUTTON_ICON_BUTTON_PREV_ALT}
               />
             )
@@ -264,7 +266,7 @@ class Pagination extends React.Component {
       buttonLabels, pageCount, icons, variant, size,
     } = this.props;
     const { currentPage } = this.state;
-    const isLastPage = currentPage === pageCount;
+    const isLastPage = (currentPage === pageCount) || (pageCount <= 1);
     const nextPage = isLastPage ? null : currentPage + 1;
     const iconSize = (variant !== VARIANTS.reduced && size !== 'small') || variant === VARIANTS.minimal;
 
@@ -305,7 +307,7 @@ class Pagination extends React.Component {
             tabIndex={isLastPage ? '-1' : undefined}
             onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
             ref={(element) => { this.nextButtonRef = element; }}
-            disabled={isLastPage}
+            disabled={isLastPage || pageCount <= 1}
             alt={PAGINATION_BUTTON_ICON_BUTTON_NEXT_ALT}
           />
         )}
@@ -343,6 +345,9 @@ class Pagination extends React.Component {
     });
 
     return pages.map((pageIndex) => {
+      if (pageCount <= 1) {
+        return null;
+      }
       if (pageIndex === ELLIPSIS) {
         return this.renderEllipsisButton();
       }

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -208,6 +208,7 @@ class Pagination extends React.Component {
     } = this.props;
     const { currentPage } = this.state;
     const isFirstPage = currentPage === 1;
+    const isDisabled = isFirstPage || pageCount === 0;
     const previousPage = isFirstPage ? null : currentPage - 1;
     const iconSize = (variant !== VARIANTS.reduced && size !== 'small') || variant === VARIANTS.minimal;
 
@@ -221,7 +222,7 @@ class Pagination extends React.Component {
         className={classNames(
           'page-item',
           {
-            disabled: isFirstPage,
+            disabled: isDisabled,
           },
         )}
       >
@@ -231,10 +232,10 @@ class Pagination extends React.Component {
               <Button
                 className="previous page-link"
                 aria-label={ariaLabel}
-                tabIndex={isFirstPage ? '-1' : undefined}
+                tabIndex={isDisabled ? '-1' : undefined}
                 onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
                 ref={(element) => { this.previousButtonRef = element; }}
-                disabled={isFirstPage}
+                disabled={isDisabled}
               >
                 <div>
                   {icons.leftIcon}
@@ -248,10 +249,10 @@ class Pagination extends React.Component {
                 iconAs={Icon}
                 className="previous page-link"
                 aria-label={ariaLabel}
-                tabIndex={isFirstPage ? '-1' : undefined}
+                tabIndex={isDisabled ? '-1' : undefined}
                 onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
                 ref={(element) => { this.previousButtonRef = element; }}
-                disabled={isFirstPage || pageCount <= 1}
+                disabled={isDisabled}
                 alt={PAGINATION_BUTTON_ICON_BUTTON_PREV_ALT}
               />
             )


### PR DESCRIPTION
## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.
https://2u-internal.atlassian.net/browse/ENT-6567

Fixes issue with pagination where if pageCount === (0 || 1) , allows for infinite pagination. This fix would disable the pagination buttons if the pageCount <= 1.  

Takes into account all variants, including the default. 

Testing WIP

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
