### PR TITLE
fix: use callback refs instead of `useRef` and fallback to offsetLeft: 0 when first child element ref no longer exists

### DIFF
--- a/src/Card/CardCarousel/CardCarouselItems.jsx
+++ b/src/Card/CardCarousel/CardCarouselItems.jsx
@@ -8,12 +8,12 @@ function CardCarouselItems({ children }) {
     columnSizes,
     hasInteractiveChildren,
     canScrollHorizontal,
-    overflowRef,
+    setOverflowRef,
   } = useContext(CardCarouselContext);
 
   return (
     <CardDeck
-      ref={overflowRef}
+      ref={setOverflowRef}
       columnSizes={columnSizes}
       hasInteractiveChildren={hasInteractiveChildren}
       canScrollHorizontal={canScrollHorizontal}

--- a/src/Card/CardCarousel/CardCarouselProvider.jsx
+++ b/src/Card/CardCarousel/CardCarouselProvider.jsx
@@ -13,6 +13,7 @@ function CardCarouselProvider({
 }) {
   const {
     overflowRef,
+    setOverflowRef,
     isScrolledToStart,
     isScrolledToEnd,
     scrollToPrevious,
@@ -21,6 +22,7 @@ function CardCarouselProvider({
 
   const cardCarouselContextValue = useMemo(() => ({
     overflowRef,
+    setOverflowRef,
     columnSizes,
     hasInteractiveChildren,
     canScrollHorizontal,
@@ -31,6 +33,7 @@ function CardCarouselProvider({
     CardCarouselControls,
   }), [
     overflowRef,
+    setOverflowRef,
     columnSizes,
     hasInteractiveChildren,
     canScrollHorizontal,

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -891,6 +891,7 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
 () => {
   const [canScrollHorizontal, setCanScrollHorizontal] = useState('true');
   const [disableOpacityMasks, setDisableOpacityMasks] = useState('false');
+  const [hasOverflowCards, setHasOverflowCards] = useState('false');
 
   const CardComponent = () => (
     <Card isClickable>
@@ -904,6 +905,20 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
       </Card.Section>
     </Card>
   );
+
+  const cardItems = useMemo(() => {
+    if (hasOverflowCards === 'true') {
+      return Array.from({ length: 8 }).map(() => <CardComponent key={uuidv4()} />);
+    }
+    return Array.from({ length: 2 }).map(() => <CardComponent key={uuidv4()} />);
+  }, [hasOverflowCards]);
+
+  const getCardItems = () => {
+    if (hasOverflowCards === 'true') {
+      return Array.from({ length: 8 }).map(() => <CardComponent key={uuidv4()} />);
+    }
+    return Array.from({ length: 2 }).map(() => <CardComponent key={uuidv4()} />);
+  };
 
   return (
     <>
@@ -922,11 +937,18 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
             options: ['true', 'false'],
             name: 'disableOpacityMasks',
           },
+          {
+            value: hasOverflowCards,
+            setValue: setHasOverflowCards,
+            options: ['true', 'false'],
+            name: 'hasOverflowCards',
+          }
         ]}
       />
       {/* end example form block */}
 
       <CardCarousel
+        ariaLabel="example card carousel"
         title={<h3>Recommended for you</h3>}
         subtitle="The following content was picked just for you."
         canScrollHorizontal={canScrollHorizontal === 'true'}
@@ -934,8 +956,7 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
         onScrollPrevious={() => { console.log('onScrollPrevious'); } }
         onScrollNext={() => { console.log('onScrollNext'); } }
       >
-        <CardComponent />
-        <CardComponent />
+        {getCardItems()}
       </CardCarousel>
     </>
   );

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -913,13 +913,6 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
     return Array.from({ length: 2 }).map(() => <CardComponent key={uuidv4()} />);
   }, [hasOverflowCards]);
 
-  const getCardItems = () => {
-    if (hasOverflowCards === 'true') {
-      return Array.from({ length: 8 }).map(() => <CardComponent key={uuidv4()} />);
-    }
-    return Array.from({ length: 2 }).map(() => <CardComponent key={uuidv4()} />);
-  };
-
   return (
     <>
       {/* start example form block */}
@@ -956,7 +949,7 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
         onScrollPrevious={() => { console.log('onScrollPrevious'); } }
         onScrollNext={() => { console.log('onScrollNext'); } }
       >
-        {getCardItems()}
+        {cardItems}
       </CardCarousel>
     </>
   );

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -936,9 +936,6 @@ Includes support for an optional `title` and `subtitle`. You may rely on the def
       >
         <CardComponent />
         <CardComponent />
-        <CardComponent />
-        <CardComponent />
-        <CardComponent />
       </CardCarousel>
     </>
   );

--- a/src/Chip/README.md
+++ b/src/Chip/README.md
@@ -54,7 +54,7 @@ notes: |
 <OverflowScroll ariaLabel="example chip carousel" hasInteractiveChildren>
   <OverflowScrollContext.Consumer>
     {({
-      overflowRef,
+      setOverflowRef,
       isScrolledToStart,
       isScrolledToEnd,
       scrollToPrevious,
@@ -78,7 +78,7 @@ notes: |
             Next
           </Button>
         </div>
-        <div ref={overflowRef} className="d-flex">
+        <div ref={setOverflowRef} className="d-flex">
           <OverflowScroll.Items>
             <Chip iconAfter={Close}>New</Chip>
             <Chip iconAfter={Close}>New</Chip>

--- a/src/OverflowScroll/OverflowScroll.jsx
+++ b/src/OverflowScroll/OverflowScroll.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useOverflowScroll } from './data';
 import OverflowScrollContext from './OverflowScrollContext';
@@ -14,8 +14,9 @@ function OverflowScroll({
   onScrollPrevious,
   onScrollNext,
 }) {
+  const [overflowRef, setOverflowRef] = useState();
+
   const {
-    overflowRef,
     isScrolledToStart,
     isScrolledToEnd,
     scrollToPrevious,
@@ -27,16 +28,19 @@ function OverflowScroll({
     disableOpacityMasks,
     onScrollPrevious,
     onScrollNext,
+    overflowRef,
   });
 
   const contextValue = useMemo(() => ({
     overflowRef,
+    setOverflowRef,
     isScrolledToStart,
     isScrolledToEnd,
     scrollToPrevious,
     scrollToNext,
   }), [
     overflowRef,
+    setOverflowRef,
     isScrolledToStart,
     isScrolledToEnd,
     scrollToPrevious,

--- a/src/OverflowScroll/OverflowScroll.mdx
+++ b/src/OverflowScroll/OverflowScroll.mdx
@@ -31,10 +31,10 @@ The following example demonstrates how to use `OverflowScroll` and `OverflowScro
   );
 
   const OverflowScrollContent = () => {
-    const { overflowRef } = useContext(OverflowScrollContext);
+    const { overflowRef, setOverflowRef } = useContext(OverflowScrollContext);
     return (
       <div
-        ref={overflowRef}
+        ref={setOverflowRef}
         className="d-flex"
       >
         <OverflowScroll.Items>{items}</OverflowScroll.Items>

--- a/src/OverflowScroll/data/getOverflowElementScrollLeft.js
+++ b/src/OverflowScroll/data/getOverflowElementScrollLeft.js
@@ -5,10 +5,10 @@
  * @returns The scroll left position of the overflow container element.
  */
 const getOverflowElementScrollLeft = (overflowRef) => {
-  if (!overflowRef.current) {
+  if (!overflowRef) {
     return 0;
   }
-  return Math.abs(Math.round(overflowRef.current.scrollLeft));
+  return Math.abs(Math.round(overflowRef.scrollLeft));
 };
 
 export default getOverflowElementScrollLeft;

--- a/src/OverflowScroll/data/tests/useOverflowScroll.test.jsx
+++ b/src/OverflowScroll/data/tests/useOverflowScroll.test.jsx
@@ -5,11 +5,6 @@ import useOverflowScroll from '../useOverflowScroll';
 import useOverflowScrollActions from '../useOverflowScrollActions';
 import getChildrenElements from '../getChildrenElements';
 
-const divElement = document.createElement('div');
-const mockRef = {
-  current: divElement,
-};
-
 jest.mock('../useOverflowScrollEventListeners');
 jest.mock('../useOverflowScrollElementAttributes');
 
@@ -47,7 +42,6 @@ describe('useOverflowScroll', () => {
     const actualReturnedValue = result.current;
     expect(actualReturnedValue).toEqual(
       expect.objectContaining({
-        overflowRef: mockRef,
         isScrolledToStart: true,
         isScrolledToEnd: true,
         scrollToPrevious: expect.any(Function),

--- a/src/OverflowScroll/data/tests/useOverflowScrollActions.test.jsx
+++ b/src/OverflowScroll/data/tests/useOverflowScrollActions.test.jsx
@@ -3,9 +3,7 @@ import { act } from 'react-test-renderer';
 import useOverflowScrollActions from '../useOverflowScrollActions';
 
 const divElement = document.createElement('div');
-const mockRef = {
-  current: divElement,
-};
+const mockRef = divElement;
 
 const mockScrollTo = jest.fn();
 Element.prototype.scrollTo = mockScrollTo;

--- a/src/OverflowScroll/data/tests/useOverflowScrollElementAttributes.test.jsx
+++ b/src/OverflowScroll/data/tests/useOverflowScrollElementAttributes.test.jsx
@@ -7,9 +7,7 @@ import useOverflowScrollElementAttributes, {
 } from '../useOverflowScrollElementAttributes';
 
 const divElement = document.createElement('div');
-const mockRef = {
-  current: divElement,
-};
+const mockRef = divElement;
 
 const baseArgs = {
   overflowRef: mockRef,
@@ -27,8 +25,8 @@ describe('useOverflowScrollElementAttributes', () => {
 
   it('returns correct base object properties', () => {
     renderHook(() => useOverflowScrollElementAttributes(baseArgs));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
-    const hasOverflowClass = baseArgs.overflowRef.current.classList.contains(OVERFLOW_SCROLL_OVERFLOW_CONTAINER_CLASS);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
+    const hasOverflowClass = baseArgs.overflowRef.classList.contains(OVERFLOW_SCROLL_OVERFLOW_CONTAINER_CLASS);
 
     // class name
     expect(hasOverflowClass).toBeTruthy();
@@ -44,7 +42,7 @@ describe('useOverflowScrollElementAttributes', () => {
     expect(webkitMaskImageStyle).toBeTruthy();
 
     // a11y
-    expect(baseArgs.overflowRef.current.tabIndex).toEqual(0);
+    expect(baseArgs.overflowRef.tabIndex).toEqual(0);
   });
 
   it('tabIndex={-1} if `hasInteractiveChildren` is true', () => {
@@ -53,7 +51,7 @@ describe('useOverflowScrollElementAttributes', () => {
       hasInteractiveChildren: true,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    expect(baseArgs.overflowRef.current.tabIndex).toEqual(-1);
+    expect(baseArgs.overflowRef.tabIndex).toEqual(-1);
   });
 
   it('applies `overflow-x: hidden` on the overflow container element when `disableScroll=true`', () => {
@@ -62,7 +60,7 @@ describe('useOverflowScrollElementAttributes', () => {
       disableScroll: true,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
     const overflowXStyle = overflowRefStyles.getPropertyValue('overflow-x');
     expect(overflowXStyle).toEqual('hidden');
   });
@@ -73,7 +71,7 @@ describe('useOverflowScrollElementAttributes', () => {
       disableOpacityMasks: true,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
     const maskImageStyle = overflowRefStyles.getPropertyValue('mask-image');
     expect(maskImageStyle).toBeFalsy();
     const webkitMaskImageStyle = overflowRefStyles.getPropertyValue('webkit-mask-image');
@@ -87,7 +85,7 @@ describe('useOverflowScrollElementAttributes', () => {
       isScrolledToEnd: false,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
     const maskImageStyle = overflowRefStyles.getPropertyValue('mask-image');
     expect(maskImageStyle).toEqual(OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_END);
     const webkitMaskImageStyle = overflowRefStyles.getPropertyValue('webkit-mask-image');
@@ -101,7 +99,7 @@ describe('useOverflowScrollElementAttributes', () => {
       isScrolledToEnd: true,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
     const maskImageStyle = overflowRefStyles.getPropertyValue('mask-image');
     expect(maskImageStyle).toEqual(OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_START);
     const webkitMaskImageStyle = overflowRefStyles.getPropertyValue('webkit-mask-image');
@@ -115,7 +113,7 @@ describe('useOverflowScrollElementAttributes', () => {
       isScrolledToEnd: false,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
     const maskImageStyle = overflowRefStyles.getPropertyValue('mask-image');
     expect(maskImageStyle).toEqual(OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_START_END);
     const webkitMaskImageStyle = overflowRefStyles.getPropertyValue('webkit-mask-image');
@@ -129,7 +127,7 @@ describe('useOverflowScrollElementAttributes', () => {
       isScrolledToEnd: true,
     };
     renderHook(() => useOverflowScrollElementAttributes(args));
-    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef.current);
+    const overflowRefStyles = global.getComputedStyle(baseArgs.overflowRef);
     const maskImageStyle = overflowRefStyles.getPropertyValue('mask-image');
     expect(maskImageStyle).toBeFalsy();
     const webkitMaskImageStyle = overflowRefStyles.getPropertyValue('webkit-mask-image');

--- a/src/OverflowScroll/data/tests/useOverflowScrollEventListeners.test.jsx
+++ b/src/OverflowScroll/data/tests/useOverflowScrollEventListeners.test.jsx
@@ -3,9 +3,7 @@ import { act } from '@testing-library/react';
 import useOverflowScrollEventListeners from '../useOverflowScrollEventListeners';
 
 const divElement = document.createElement('div');
-const mockRef = {
-  current: divElement,
-};
+const mockRef = divElement;
 
 const createDivWithLink = () => {
   const element = document.createElement('div');
@@ -59,13 +57,13 @@ describe('useOverflowScrollElementAttributes', () => {
     const eventArrowRight = { key: 'ArrowRight' };
 
     // mock initial scrolling
-    baseArgs.overflowRef.current.scrollLeft = 25;
+    baseArgs.overflowRef.scrollLeft = 25;
 
     // ArrowRight
     act(() => {
       updateActiveChildElementOnKeyDown(eventArrowRight);
       // mock some right scrolling
-      baseArgs.overflowRef.current.scrollLeft = 50;
+      baseArgs.overflowRef.scrollLeft = 50;
       updateActiveChildElementOnKeyUp(eventArrowRight);
     });
     expect(result.current.previousOverflowScrollLeft).toEqual(25);
@@ -74,7 +72,7 @@ describe('useOverflowScrollElementAttributes', () => {
     act(() => {
       updateActiveChildElementOnKeyDown(eventArrowLeft);
       // mock some right scrolling
-      baseArgs.overflowRef.current.scrollLeft = 25;
+      baseArgs.overflowRef.scrollLeft = 25;
       updateActiveChildElementOnKeyUp(eventArrowLeft);
     });
     expect(result.current.previousOverflowScrollLeft).toEqual(50);

--- a/src/OverflowScroll/data/useOverflowScroll.js
+++ b/src/OverflowScroll/data/useOverflowScroll.js
@@ -65,7 +65,7 @@ const useOverflowScroll = ({
       (sumWidth, childElement) => sumWidth + childElement.offsetWidth,
       0,
     );
-    const firstChildElementOffsetLeft = childrenElements[0]?.offsetLeft;
+    const firstChildElementOffsetLeft = childrenElements[0]?.offsetLeft || 0;
 
     // 1. is scrolled start?
     if (currentScrollLeft <= firstChildElementOffsetLeft) {

--- a/src/OverflowScroll/data/useOverflowScroll.js
+++ b/src/OverflowScroll/data/useOverflowScroll.js
@@ -46,8 +46,6 @@ const useOverflowScroll = ({
   disableOpacityMasks = false,
   scrollAnimationBehavior = 'smooth',
 }) => {
-  // const [childrenElements, setChildrenElements] = useState([]);
-
   const [isScrolledToStart, setIsScrolledToStart] = useState(true);
   const [isScrolledToEnd, setIsScrolledToEnd] = useState(true);
 

--- a/src/OverflowScroll/data/useOverflowScroll.js
+++ b/src/OverflowScroll/data/useOverflowScroll.js
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import useOverflowScrollActions from './useOverflowScrollActions';
@@ -15,6 +14,8 @@ import getOverflowElementScrollLeft from './getOverflowElementScrollLeft';
  * carousel-like UI components.
  *
  * @param {object} args
+ * @param {HTMLElement} args.overflowRef A reference to the underlying overflow
+ *  container element, created with a callback ref.
  * @param {string} args.childQuerySelector A CSS query selector to find all
  *  child elements within the overflow container.
  * @param {function} args.onScrollPrevious An optional callback function for when `scrollToPrevious` is called.
@@ -36,6 +37,7 @@ import getOverflowElementScrollLeft from './getOverflowElementScrollLeft';
  * - activeChildElementIndex
  */
 const useOverflowScroll = ({
+  overflowRef,
   childQuerySelector,
   onScrollPrevious,
   onScrollNext,
@@ -44,28 +46,32 @@ const useOverflowScroll = ({
   disableOpacityMasks = false,
   scrollAnimationBehavior = 'smooth',
 }) => {
-  const overflowRef = useRef();
-  const [childrenElements, setChildrenElements] = useState([]);
+  // const [childrenElements, setChildrenElements] = useState([]);
 
   const [isScrolledToStart, setIsScrolledToStart] = useState(true);
   const [isScrolledToEnd, setIsScrolledToEnd] = useState(true);
 
-  const [currentScrollLeft, setCurrentScrollLeft] = useState(overflowRef.current?.scrollLeft || 0);
+  const [currentScrollLeft, setCurrentScrollLeft] = useState(0);
+
+  const childrenElements = getChildrenElements({
+    element: overflowRef,
+    childQuerySelector,
+  });
 
   useEffect(() => {
-    const children = getChildrenElements({
-      element: overflowRef.current,
+    if (!overflowRef) {
+      return;
+    }
+
+    const currentChildElements = getChildrenElements({
+      element: overflowRef,
       childQuerySelector,
     });
-    setChildrenElements(children);
-  }, [childQuerySelector]);
-
-  useEffect(() => {
-    const childElementOffsetWidth = childrenElements.reduce(
+    const childElementOffsetWidth = currentChildElements.reduce(
       (sumWidth, childElement) => sumWidth + childElement.offsetWidth,
       0,
     );
-    const firstChildElementOffsetLeft = childrenElements[0]?.offsetLeft || 0;
+    const firstChildElementOffsetLeft = Math.max(childrenElements[0]?.offsetLeft, 0);
 
     // 1. is scrolled start?
     if (currentScrollLeft <= firstChildElementOffsetLeft) {
@@ -77,9 +83,9 @@ const useOverflowScroll = ({
     // 1. is not enough content to need scrolling to the right?
     // 2. is scrolled to end?
     const overflowScrollLeft = getOverflowElementScrollLeft(overflowRef);
-    const canScrollRight = childElementOffsetWidth > overflowRef.current.getBoundingClientRect().width;
+    const canScrollRight = childElementOffsetWidth > overflowRef.getBoundingClientRect().width || false;
     const isScrolledRightMax = (
-      overflowScrollLeft >= overflowRef.current.scrollWidth - overflowRef.current.clientWidth
+      overflowScrollLeft >= overflowRef.scrollWidth - overflowRef.clientWidth
     );
 
     if (!canScrollRight || isScrolledRightMax) {
@@ -87,7 +93,7 @@ const useOverflowScroll = ({
     } else {
       setIsScrolledToEnd(false);
     }
-  }, [currentScrollLeft, childrenElements]);
+  }, [overflowRef, childQuerySelector, isScrolledToStart, isScrolledToEnd, currentScrollLeft, childrenElements]);
 
   const [activeChildElementIndex, setActiveChildElementIndex] = useState(0);
 
@@ -152,7 +158,6 @@ const useOverflowScroll = ({
   });
 
   return {
-    overflowRef,
     scrollToPrevious,
     scrollToNext,
     isScrolledToStart,

--- a/src/OverflowScroll/data/useOverflowScrollActions.js
+++ b/src/OverflowScroll/data/useOverflowScrollActions.js
@@ -20,28 +20,29 @@ const useOverflowScrollActions = ({
    * A helper function to scroll to the previous element in the overflow container.
    */
   const scrollToPrevious = useCallback(() => {
-    if (overflowRef) {
-      const getPreviousChildElement = (previousChildElementIndex) => {
-        // return the first element if the overflow container reached the beginning
-        if (previousChildElementIndex <= 0) {
-          return childrenElements[0];
-        }
-        // otherwise return the previous element
-        return childrenElements[previousChildElementIndex];
-      };
-
-      const previousChildElementIndex = activeChildElementIndex - 1;
-      const previousChildElement = getPreviousChildElement(previousChildElementIndex);
-      const calculatedOffsetLeft = calculateOffsetLeft(previousChildElement);
-      overflowRef.scrollTo({
-        left: calculatedOffsetLeft,
-        behavior: scrollAnimationBehavior,
-      });
-      const currentActiveChildElementIndex = previousChildElementIndex <= 0 ? 0 : previousChildElementIndex;
-      onScrollPrevious({
-        currentActiveChildElementIndex,
-      });
+    if (!overflowRef) {
+      return;
     }
+    const getPreviousChildElement = (previousChildElementIndex) => {
+      // return the first element if the overflow container reached the beginning
+      if (previousChildElementIndex <= 0) {
+        return childrenElements[0];
+      }
+      // otherwise return the previous element
+      return childrenElements[previousChildElementIndex];
+    };
+
+    const previousChildElementIndex = activeChildElementIndex - 1;
+    const previousChildElement = getPreviousChildElement(previousChildElementIndex);
+    const calculatedOffsetLeft = calculateOffsetLeft(previousChildElement);
+    overflowRef.scrollTo({
+      left: calculatedOffsetLeft,
+      behavior: scrollAnimationBehavior,
+    });
+    const currentActiveChildElementIndex = previousChildElementIndex <= 0 ? 0 : previousChildElementIndex;
+    onScrollPrevious({
+      currentActiveChildElementIndex,
+    });
   }, [
     overflowRef,
     childrenElements,

--- a/src/OverflowScroll/data/useOverflowScrollActions.js
+++ b/src/OverflowScroll/data/useOverflowScrollActions.js
@@ -20,7 +20,7 @@ const useOverflowScrollActions = ({
    * A helper function to scroll to the previous element in the overflow container.
    */
   const scrollToPrevious = useCallback(() => {
-    if (overflowRef.current) {
+    if (overflowRef) {
       const getPreviousChildElement = (previousChildElementIndex) => {
         // return the first element if the overflow container reached the beginning
         if (previousChildElementIndex <= 0) {
@@ -33,7 +33,7 @@ const useOverflowScrollActions = ({
       const previousChildElementIndex = activeChildElementIndex - 1;
       const previousChildElement = getPreviousChildElement(previousChildElementIndex);
       const calculatedOffsetLeft = calculateOffsetLeft(previousChildElement);
-      overflowRef.current.scrollTo({
+      overflowRef.scrollTo({
         left: calculatedOffsetLeft,
         behavior: scrollAnimationBehavior,
       });
@@ -54,30 +54,31 @@ const useOverflowScrollActions = ({
    * A helper function to scroll to the next element in the overflow container.
    */
   const scrollToNext = useCallback(() => {
-    if (overflowRef.current) {
-      const childElementCount = childrenElements.length;
-      const lastChildElementIndex = childElementCount - 1;
-      const nextChildElementIndex = activeChildElementIndex + 1;
-      const isNextChildIndexAtEnd = nextChildElementIndex >= lastChildElementIndex;
-
-      const getNextChildElement = () => {
-        // return the last element if the overflow container reached the end
-        if (isNextChildIndexAtEnd) {
-          return childrenElements[lastChildElementIndex];
-        }
-        // otherwise return the next element
-        return childrenElements[nextChildElementIndex];
-      };
-
-      const nextChildElement = getNextChildElement();
-      const calculatedOffsetLeft = calculateOffsetLeft(nextChildElement);
-      overflowRef.current.scrollTo({
-        left: calculatedOffsetLeft,
-        behavior: scrollAnimationBehavior,
-      });
-      const currentActiveChildElementIndex = isNextChildIndexAtEnd ? lastChildElementIndex : nextChildElementIndex;
-      onScrollNext({ currentActiveChildElementIndex });
+    if (!overflowRef) {
+      return;
     }
+    const childElementCount = childrenElements.length;
+    const lastChildElementIndex = childElementCount - 1;
+    const nextChildElementIndex = activeChildElementIndex + 1;
+    const isNextChildIndexAtEnd = nextChildElementIndex >= lastChildElementIndex;
+
+    const getNextChildElement = () => {
+      // return the last element if the overflow container reached the end
+      if (isNextChildIndexAtEnd) {
+        return childrenElements[lastChildElementIndex];
+      }
+      // otherwise return the next element
+      return childrenElements[nextChildElementIndex];
+    };
+
+    const nextChildElement = getNextChildElement();
+    const calculatedOffsetLeft = calculateOffsetLeft(nextChildElement);
+    overflowRef.scrollTo({
+      left: calculatedOffsetLeft,
+      behavior: scrollAnimationBehavior,
+    });
+    const currentActiveChildElementIndex = isNextChildIndexAtEnd ? lastChildElementIndex : nextChildElementIndex;
+    onScrollNext({ currentActiveChildElementIndex });
   }, [
     overflowRef,
     activeChildElementIndex,

--- a/src/OverflowScroll/data/useOverflowScrollElementAttributes.js
+++ b/src/OverflowScroll/data/useOverflowScrollElementAttributes.js
@@ -39,64 +39,66 @@ const useOverflowScrollElementAttributes = ({
    * a11y attributes and CSS styles to support the overflow scrolling behavior.
    */
   useEffect(() => {
-    if (overflowRef.current) {
-      // a11y
-      if (hasInteractiveChildren && overflowRef.current.tabIndex !== '-1') {
-        overflowRef.current.tabIndex = '-1';
-      }
-      if (!hasInteractiveChildren && overflowRef.current.tabIndex !== '0') {
-        overflowRef.current.tabIndex = '0';
-      }
+    if (!overflowRef) {
+      return;
+    }
 
-      // styles
-      const overflowRefStyles = global.getComputedStyle(overflowRef.current);
-      const positionStyle = overflowRefStyles.getPropertyValue('position');
-      const overflowXStyle = overflowRefStyles.getPropertyValue('overflow-x');
-      const hasOverflowClass = overflowRef.current.classList.contains(OVERFLOW_SCROLL_OVERFLOW_CONTAINER_CLASS);
+    // a11y
+    if (hasInteractiveChildren && overflowRef.tabIndex !== '-1') {
+      overflowRef.tabIndex = '-1';
+    }
+    if (!hasInteractiveChildren && overflowRef.tabIndex !== '0') {
+      overflowRef.tabIndex = '0';
+    }
 
-      // class name
-      if (!hasOverflowClass) {
-        overflowRef.current.classList.add(OVERFLOW_SCROLL_OVERFLOW_CONTAINER_CLASS);
-      }
+    // styles
+    const overflowRefStyles = global.getComputedStyle(overflowRef);
+    const positionStyle = overflowRefStyles.getPropertyValue('position');
+    const overflowXStyle = overflowRefStyles.getPropertyValue('overflow-x');
+    const hasOverflowClass = overflowRef.classList.contains(OVERFLOW_SCROLL_OVERFLOW_CONTAINER_CLASS);
 
-      if (positionStyle !== 'relative') {
-        overflowRef.current.style.position = 'relative';
-      }
-      if (disableScroll && overflowXStyle !== 'hidden') {
-        overflowRef.current.style.overflowX = 'hidden';
-      }
-      if (!disableScroll && overflowXStyle !== 'scroll') {
-        overflowRef.current.style.overflowX = 'scroll';
-      }
+    // class name
+    if (!hasOverflowClass) {
+      overflowRef.classList.add(OVERFLOW_SCROLL_OVERFLOW_CONTAINER_CLASS);
+    }
 
-      if (disableOpacityMasks) {
-        overflowRef.current.style.removeProperty('mask-image');
-        overflowRef.current.style.removeProperty('webkit-mask-image');
-      } else {
-        const getMaskImageStyleValue = () => {
-          // TODO: make the `mask-image` property (optionally) extensible/customizable (e.g., passed as a prop)
-          if (isScrolledToStart && !isScrolledToEnd) {
-            return OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_END;
-          }
-          if (!isScrolledToStart && isScrolledToEnd) {
-            return OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_START;
-          }
+    if (positionStyle !== 'relative') {
+      overflowRef.style.position = 'relative';
+    }
+    if (disableScroll && overflowXStyle !== 'hidden') {
+      overflowRef.style.overflowX = 'hidden';
+    }
+    if (!disableScroll && overflowXStyle !== 'scroll') {
+      overflowRef.style.overflowX = 'scroll';
+    }
 
-          if (!isScrolledToStart && !isScrolledToEnd) {
-            return OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_START_END;
-          }
-
-          // no opacity mask required
-          return undefined;
-        };
-        const maskImageStyleValue = getMaskImageStyleValue();
-        if (maskImageStyleValue) {
-          overflowRef.current.style.maskImage = maskImageStyleValue;
-          overflowRef.current.style.webkitMaskImage = maskImageStyleValue;
-        } else {
-          overflowRef.current.style.removeProperty('mask-image');
-          overflowRef.current.style.removeProperty('webkit-mask-image');
+    if (disableOpacityMasks) {
+      overflowRef.style.removeProperty('mask-image');
+      overflowRef.style.removeProperty('webkit-mask-image');
+    } else {
+      const getMaskImageStyleValue = () => {
+        // TODO: make the `mask-image` property (optionally) extensible/customizable (e.g., passed as a prop)
+        if (isScrolledToStart && !isScrolledToEnd) {
+          return OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_END;
         }
+        if (!isScrolledToStart && isScrolledToEnd) {
+          return OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_START;
+        }
+
+        if (!isScrolledToStart && !isScrolledToEnd) {
+          return OVERFLOW_SCROLL_OVERFLOW_OPACITY_MASK_GRADIENT_START_END;
+        }
+
+        // no opacity mask required
+        return undefined;
+      };
+      const maskImageStyleValue = getMaskImageStyleValue();
+      if (maskImageStyleValue) {
+        overflowRef.style.maskImage = maskImageStyleValue;
+        overflowRef.style.webkitMaskImage = maskImageStyleValue;
+      } else {
+        overflowRef.style.removeProperty('mask-image');
+        overflowRef.style.removeProperty('webkit-mask-image');
       }
     }
   }, [

--- a/src/OverflowScroll/data/useOverflowScrollEventListeners.js
+++ b/src/OverflowScroll/data/useOverflowScrollEventListeners.js
@@ -67,10 +67,7 @@ const useOverflowScrollEventListeners = ({
    * which element within the overflow container currently has the user's focus.
    */
   const updateActiveChildElementOnFocusIn = useCallback(() => {
-    if (!overflowRef?.current) {
-      return;
-    }
-    if (overflowRef.current === document.activeElement) {
+    if (!overflowRef || overflowRef === document.activeElement) {
       return;
     }
     for (let i = 0; i < childrenElements.length; i++) {
@@ -142,7 +139,7 @@ const useOverflowScrollEventListeners = ({
    */
   const updateActiveChildElementOnKeyUp = useCallback((e) => {
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-      const isScrollingLeft = overflowRef.current.scrollLeft < previousOverflowScrollLeft;
+      const isScrollingLeft = overflowRef.scrollLeft < previousOverflowScrollLeft;
       updateActiveChildElementIndex({ isScrollingLeft });
     }
   }, [overflowRef, previousOverflowScrollLeft, updateActiveChildElementIndex]);
@@ -163,27 +160,35 @@ const useOverflowScrollEventListeners = ({
    * to an appropriate element.
    */
   useEffect(() => {
-    const overflowRefCopy = overflowRef.current;
+    if (!overflowRef) {
+      return undefined;
+    }
 
-    overflowRefCopy?.addEventListener('focusin', updateActiveChildElementOnFocusIn);
-    overflowRefCopy?.addEventListener('keydown', updateActiveChildElementOnKeyDown);
-    overflowRefCopy?.addEventListener('keyup', updateActiveChildElementOnKeyUp);
+    const overflowRefCopy = overflowRef;
+
+    overflowRefCopy.addEventListener('focusin', updateActiveChildElementOnFocusIn);
+    overflowRefCopy.addEventListener('keydown', updateActiveChildElementOnKeyDown);
+    overflowRefCopy.addEventListener('keyup', updateActiveChildElementOnKeyUp);
 
     // we must handle the `scroll` event even when `disableScroll` is true because the `mousedown` and `mouseup`
     // events trigger a scroll.
-    overflowRefCopy?.addEventListener('scroll', handleScrollEvent);
+    overflowRefCopy.addEventListener('scroll', handleScrollEvent);
 
     if (!disableScroll) {
-      overflowRefCopy?.addEventListener('wheel', updateActiveChildElementOnWheel);
-      overflowRefCopy?.addEventListener('mousedown', handleMouseDownEvent);
-      overflowRefCopy?.addEventListener('mouseup', handleMouseUpEvent);
+      overflowRefCopy.addEventListener('wheel', updateActiveChildElementOnWheel);
+      overflowRefCopy.addEventListener('mousedown', handleMouseDownEvent);
+      overflowRefCopy.addEventListener('mouseup', handleMouseUpEvent);
     }
 
     return () => {
-      overflowRefCopy?.removeEventListener('focusin', updateActiveChildElementOnFocusIn);
-      overflowRefCopy?.removeEventListener('keydown', updateActiveChildElementOnKeyDown);
-      overflowRefCopy?.removeEventListener('keyup', updateActiveChildElementOnKeyUp);
-      overflowRefCopy?.removeEventListener('scroll', handleScrollEvent);
+      if (!overflowRef) {
+        return;
+      }
+
+      overflowRefCopy.removeEventListener('focusin', updateActiveChildElementOnFocusIn);
+      overflowRefCopy.removeEventListener('keydown', updateActiveChildElementOnKeyDown);
+      overflowRefCopy.removeEventListener('keyup', updateActiveChildElementOnKeyUp);
+      overflowRefCopy.removeEventListener('scroll', handleScrollEvent);
 
       if (!disableScroll) {
         overflowRefCopy?.removeEventListener('wheel', updateActiveChildElementOnWheel);

--- a/src/OverflowScroll/useOverflowScroll.mdx
+++ b/src/OverflowScroll/useOverflowScroll.mdx
@@ -17,17 +17,17 @@ The following example demonstrates how to use `useOverflowScroll` to build a car
 
 ```jsx live
 () => {
+  const [overflowRef, setOverflowRef] = useState();
+
   const {
-    overflowRef,
     isScrolledToStart,
     isScrolledToEnd,
     scrollToPrevious,
     scrollToNext,
   } = useOverflowScroll({
     childQuerySelector: '.example-item',
+    overflowRef,
   });
-
-  console.log('overflowRef', overflowRef);
 
   const ExampleItem = ({ className }) => (
     <div
@@ -66,8 +66,7 @@ The following example demonstrates how to use `useOverflowScroll` to build a car
         </Button>
       </div>
       <div
-        ref={overflowRef}
-        role="region"
+        ref={setOverflowRef}
         aria-label="example overflow scroll container"
         className="d-flex"
       >


### PR DESCRIPTION
## Description

* Switches to use callback refs with `useOverflowScroll` instead of `useRef` per the guidance of the following documentation:
  * https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
  * https://stackoverflow.com/questions/64668211/how-to-listen-to-ref-object-changes
* Resolves a couple outstanding bugs

### Deploy Preview

TBD

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
