### PR TITLE
[BD-46] feat: fixed buttons inconsistencies with design

### DIFF
--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -139,20 +139,20 @@
     &::before {
       content: "";
       position: absolute;
-      top: -1 * $distance-include-btn-border;
-      right: -1 * $distance-include-btn-border;
-      bottom: -1 * $distance-include-btn-border;
-      left: -1 * $distance-include-btn-border;
+      top: -1 * $btn-focus-distance-to-border;
+      right: -1 * $btn-focus-distance-to-border;
+      bottom: -1 * $btn-focus-distance-to-border;
+      left: -1 * $btn-focus-distance-to-border;
       border: solid $btn-focus-width $ring-color;
-      border-radius: $btn-border-radius-value;
+      border-radius: $btn-focus-border-radius;
     }
 
     &.btn-lg::before {
-      border-radius: $btn-border-radius-value;
+      border-radius: $btn-focus-border-radius;
     }
 
     &.btn-sm::before {
-      border-radius: $btn-border-radius-value;
+      border-radius: $btn-focus-border-radius;
     }
 
     &:active,

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -117,9 +117,8 @@
 
   &.disabled,
   &:disabled {
-    color: lighten($color, 10%);
+    color: $color;
     background-color: transparent;
-    border-color: lighten($color, 10%);
   }
 
   &:not(:disabled):not(.disabled):active,

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -26,7 +26,7 @@
   // Disabled comes first so active can properly restyle
   &.disabled,
   &:disabled {
-    color: color-yiq($background);
+    color: $color;
     background-color: $background;
     border-color: $border;
 
@@ -68,6 +68,7 @@
   &:disabled {
     color: $color;
     background-color: transparent;
+    border-color: $color;
   }
 
   &:not(:disabled):not(.disabled):active,
@@ -116,8 +117,9 @@
 
   &.disabled,
   &:disabled {
-    color: $color;
+    color: lighten($color, 10%);
     background-color: transparent;
+    border-color: lighten($color, 10%);
   }
 
   &:not(:disabled):not(.disabled):active,

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -136,9 +136,6 @@
     outline: 0;
     box-shadow: none;
 
-    $distance: $btn-focus-width + $btn-focus-gap;
-    $distance-include-btn-border: $distance + $btn-border-width;
-
     &::before {
       content: "";
       position: absolute;
@@ -147,15 +144,15 @@
       bottom: -1 * $distance-include-btn-border;
       left: -1 * $distance-include-btn-border;
       border: solid $btn-focus-width $ring-color;
-      border-radius: calc(#{$btn-border-radius} + #{$distance});
+      border-radius: $btn-border-radius-value;
     }
 
     &.btn-lg::before {
-      border-radius: calc(#{$btn-border-radius-lg} + #{$distance});
+      border-radius: $btn-border-radius-value;
     }
 
     &.btn-sm::before {
-      border-radius: calc(#{$btn-border-radius-sm} + #{$distance});
+      border-radius: $btn-border-radius-value;
     }
 
     &:active,

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -109,16 +109,18 @@
   border-color: transparent;
   background-color: $background;
 
-  @include hover {
-    color: darken($color, 7.5%);
-    background-color: darken($background, 7.5%);
-    border-color: transparent;
+  &:not(:disabled):not(.disabled) {
+    @include hover {
+      color: darken($color, 7.5%);
+      background-color: darken($background, 7.5%);
+      border-color: transparent;
+    }
   }
 
   &.disabled,
   &:disabled {
     color: $color;
-    background-color: transparent;
+    background-color: $background;
   }
 
   &:not(:disabled):not(.disabled):active,

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -46,7 +46,8 @@ This component utilizes `Button` from React-Bootstrap and extends it with an abi
   </div>
   <div className="mb-2">
     <Button variant="link" className="mb-2 mb-sm-0">Link</Button>{' '}
-    <Button variant="light" className="mb-2 mb-sm-0">Light</Button> <Button variant="dark">Dark</Button>{' '}
+    <Button variant="light" className="mb-2 mb-sm-0">Light</Button>{' '} 
+    <Button variant="dark" className="mb-2 mb-sm-0">Dark</Button>{' '}
     <Button variant="outline-light" className="mb-2 mb-sm-0">Light</Button>{' '}
     <Button variant="outline-dark" className="mb-2 mb-sm-0">Dark</Button>
   </div>

--- a/src/Button/_variables.scss
+++ b/src/Button/_variables.scss
@@ -43,3 +43,8 @@ $btn-border-radius-lg:        $border-radius-lg !default;
 $btn-border-radius-sm:        $border-radius-sm !default;
 
 $btn-transition: null;
+
+$distance: $btn-focus-width + $btn-focus-gap !default;
+$distance-include-btn-border: $distance + $btn-border-width !default;
+
+$btn-border-radius-value: calc(#{$btn-border-radius} + #{$distance}) !default;

--- a/src/Button/_variables.scss
+++ b/src/Button/_variables.scss
@@ -44,7 +44,7 @@ $btn-border-radius-sm:        $border-radius-sm !default;
 
 $btn-transition: null;
 
-$distance: $btn-focus-width + $btn-focus-gap !default;
-$distance-include-btn-border: $distance + $btn-border-width !default;
+$btn-focus-border-gap: $btn-focus-width + $btn-focus-gap !default;
+$btn-focus-distance-to-border: $btn-focus-border-gap + $btn-border-width !default;
 
-$btn-border-radius-value: calc(#{$btn-border-radius} + #{$distance}) !default;
+$btn-focus-border-radius: calc(#{$btn-border-radius} + #{$btn-focus-border-gap}) !default;


### PR DESCRIPTION
## Description

- for openedx theme fix obvious issues (e.g. tertiary button disappearing in disabled state)
1) ![Screenshot 2023-01-12 at 23 32 53](https://user-images.githubusercontent.com/93188219/212186044-e2138ab4-820b-4fe7-8594-d654e749a9eb.png)
2) ![Screenshot 2023-01-12 at 23 33 27](https://user-images.githubusercontent.com/93188219/212186054-bcc9a47b-cf1e-48c8-b234-959ccdad2a85.png)

### Deploy Preview

[Button component](https://deploy-preview-1910--paragon-openedx.netlify.app/components/button/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
