### PR TITLE
feat: add feedbackOutline icon

### DIFF
--- a/icons/es5/FeedbackOutline.js
+++ b/icons/es5/FeedbackOutline.js
@@ -1,0 +1,15 @@
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import * as React from "react";
+function SvgFeedbackOutline(props) {
+  return /*#__PURE__*/React.createElement("svg", _extends({
+    width: 24,
+    height: 24,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg"
+  }, props), /*#__PURE__*/React.createElement("path", {
+    d: "M22 2H2.01v2L2 22l4-4h16V4 2zm-2 14H5.17l-.59.59-.58.58V4h16v12zm-9-4h2v2h-2v-2zm0-6h2v4h-2V6z",
+    fill: "currentColor"
+  }));
+}
+export default SvgFeedbackOutline;

--- a/icons/es5/index.js
+++ b/icons/es5/index.js
@@ -752,6 +752,7 @@ export { default as FeaturedPlayList } from './FeaturedPlayList';
 export { default as FeaturedVideo } from './FeaturedVideo';
 export { default as Feed } from './Feed';
 export { default as Feedback } from './Feedback';
+export { default as FeedbackOutline } from './FeedbackOutline';
 export { default as Female } from './Female';
 export { default as Fence } from './Fence';
 export { default as Festival } from './Festival';

--- a/icons/jsx/FeedbackOutline.jsx
+++ b/icons/jsx/FeedbackOutline.jsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+function SvgFeedbackOutline(props) {
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M22 2H2.01v2L2 22l4-4h16V4 2zm-2 14H5.17l-.59.59-.58.58V4h16v12zm-9-4h2v2h-2v-2zm0-6h2v4h-2V6z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+export default SvgFeedbackOutline;

--- a/icons/svg/feedback_outline.svg
+++ b/icons/svg/feedback_outline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 2H2.01C2.01 2 2.01 2.9 2.01 4L2 22L6 18H22C22 18 22 17.1 22 16V4C22 2.9 22 2 22 2ZM20 16H5.17L4.58 16.59L4 17.17V4H20V16ZM11 12H13V14H11V12ZM11 6H13V10H11V6Z" fill="black"/>
+</svg>


### PR DESCRIPTION
## Description

This PR adds the outline variant of the feedback icon. This icon is needed by TNL for their problem editor rewrite.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
