### PR TITLE
[BD-46] docs: update Form.Switch and Form.Checkbox to the latest versions

### DIFF
--- a/src/Form/README.md
+++ b/src/Form/README.md
@@ -75,17 +75,8 @@ notes: |
   </Form.Row>
 
   <Form.Group controlId="formSwitch">
-    <Form.Check
-      type="switch"
-      id="custom-switch"
-      label="Check this switch"
-    />
-    <Form.Check
-      disabled
-      type="switch"
-      label="disabled switch"
-      id="disabled-custom-switch"
-    />
+    <Form.Switch>Check this switch</Form.Switch><br/>
+    <Form.Switch disabled>disabled switch</Form.Switch>
   </Form.Group>
 
   <Form.Group controlId="whichColor">
@@ -103,7 +94,7 @@ notes: |
   </Form.Group>
 
   <Form.Group id="formGridCheckbox">
-    <Form.Check type="checkbox" id="formGridCheckboxCheck" label="Check me out" />
+    <Form.Checkbox>Check me out</Form.Checkbox>
   </Form.Group>
   <div className="d-flex">
     <Button variant="primary" type="submit">
@@ -166,21 +157,12 @@ notes: |
   </Form.Row>
 
   <Form.Group controlId="formSwitch-2">
-    <Form.Check
-      type="switch"
-      id="custom-switch-2"
-      label="Check this switch"
-    />
-    <Form.Check
-      disabled
-      type="switch"
-      label="disabled switch"
-      id="disabled-custom-switch-2"
-    />
+    <Form.Switch>Check this switch</Form.Switch><br/>
+    <Form.Switch disabled>disabled switch</Form.Switch>
   </Form.Group>
 
   <Form.Group id="formGridCheckbox-2">
-    <Form.Check type="checkbox" id="formGridCheckboxCheck-2" label="Check me out" />
+      <Form.Checkbox>Check me out</Form.Checkbox>
   </Form.Group>
   <div className="d-flex">
     <Button variant="primary" type="submit">


### PR DESCRIPTION
## Description
Currently, old Switch and Checkbox components are displayed as examples on [Forms page](https://paragon-openedx.netlify.app/components/form/)
![image](https://user-images.githubusercontent.com/93188219/212570438-f3d7f9cb-20c5-4286-bde6-4950dc1041f9.png)

### Deploy Preview

[Form component](https://deploy-preview-1920--paragon-openedx.netlify.app/components/form/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
