### PR TITLE
fix: aria label fix for SelectableBox

### DIFF
--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -43,13 +43,13 @@ As ``Checkbox``
         name="cheeses"
         columns={isExtraSmall ? 1 : 2}
       >
-        <SelectableBox value="swiss" type={type} aria-label="checkbox">
+        <SelectableBox value="swiss" type={type} aria-label="swiss checkbox">
           <div>
             <h3>It is my first SelectableBox</h3>
             <p>Swiss</p>
           </div>
         </SelectableBox>
-        <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="checkbox">
+        <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="cheddar checkbox">
           Cheddar
         </SelectableBox>
         <SelectableBox
@@ -57,7 +57,7 @@ As ``Checkbox``
           inputHidden={false}
           type={type}
           isInvalid={isInvalid()}
-          aria-label="checkbox"
+          aria-label="pepperjack checkbox"
         >
           <h3>Pepperjack</h3>
         </SelectableBox>
@@ -84,17 +84,17 @@ As ``Radio``
       name="colors"
       columns={isExtraSmall ? 1 : 3}
     >
-      <SelectableBox value="red" type={type} aria-label="checkbox">
+      <SelectableBox value="red" type={type} aria-label="red checkbox">
         <div>
           <h3>It is Red color</h3>
           <p>Select me</p>
         </div>
       </SelectableBox>
-      <SelectableBox value="green" inputHidden={false} type={type} aria-label="checkbox">
+      <SelectableBox value="green" inputHidden={false} type={type} aria-label="green-checkbox">
         <h3>Green</h3>
         <p>Leaves and grass</p>
       </SelectableBox>
-      <SelectableBox value="blue" inputHidden={false} type={type} aria-label="checkbox">
+      <SelectableBox value="blue" inputHidden={false} type={type} aria-label="blue checkbox">
         <h3>Blue</h3>
         <p>The sky</p>
       </SelectableBox>
@@ -133,7 +133,7 @@ As ``Checkbox`` with ``isIndeterminate``
           onClick={handleCheckAllChange}
           inputHidden={false}
           type={type}
-          aria-label="checkbox"
+          aria-label="all options checkbox"
         >
           All the cheese
         </SelectableBox>
@@ -145,16 +145,16 @@ As ``Checkbox`` with ``isIndeterminate``
         name="cheeses"
         columns={isExtraSmall ? 1 : 3}
       >
-        <SelectableBox value="swiss" type={type} aria-label="checkbox">
+        <SelectableBox value="swiss" type={type} aria-label="swiss checkbox">
           <div>
             <h3>It is my first SelectableBox</h3>
             <p>Swiss</p>
           </div>
         </SelectableBox>
-        <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="checkbox">
+        <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="cheddar checkbox">
           Cheddar
         </SelectableBox>
-        <SelectableBox value="pepperjack" inputHidden={false} type={type} aria-label="checkbox">
+        <SelectableBox value="pepperjack" inputHidden={false} type={type} aria-label="pepperjack checkbox">
           <h3>Pepperjack</h3>
         </SelectableBox>
       </SelectableBox.Set>


### PR DESCRIPTION
## Description
Quick fix to the Selectable box aria labels so they are unique and set a good example for future implementations. 

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
