### PR TITLE
[BD-46] chore: add type-check step to CI and update typescript configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         npm ci
         npm run generate-component-install
         npm run doc-site-install
+    - name: Check Types
+      run: npm run type-check
     - name: Lint
       run: npm run lint
     - name: Test

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "generate-changelog": "node generate-changelog.js",
     "i18n_compile": "formatjs compile-folder --format transifex ./src/i18n/messages ./src/i18n/messages",
     "i18n_extract": "formatjs extract 'src/**/*.{jsx,js,tsx,ts}' --out-file ./src/i18n/transifex_input.json --format transifex",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc --project www --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "build-types": "tsc --emitDeclarationOnly"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["dom", "es6"],
+    "lib": ["dom", "es6", "dom.iterable"],
     "isolatedModules": true,
     "module": "es6",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react",
     "lib": ["dom", "es2019"],
     "isolatedModules": true,
-    "module": "esnext",
+    "module": "es6",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
@@ -17,7 +17,7 @@
     "sourceMap": true,
     "strict": true,
     "strictFunctionTypes": false,
-    "target": "esnext",
+    "target": "es6",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["dom", "es2019"],
+    "lib": ["dom", "es6"],
     "isolatedModules": true,
     "module": "es6",
     "moduleResolution": "node",

--- a/www/src/components/LayoutGenerator.tsx
+++ b/www/src/components/LayoutGenerator.tsx
@@ -98,7 +98,7 @@ function LayoutGenerator() {
   }
 
   const renderMarkupString = () => {
-    const columnsString = columns.map((ColumnComponent, i) => {
+    const columnsString = [...Array(columns.length).keys()].map((i) => {
       const width = columnWidths[i];
       const offset = columnOffsets[i];
 

--- a/www/src/components/SEO.tsx
+++ b/www/src/components/SEO.tsx
@@ -43,7 +43,7 @@ function SEO({
         lang,
       }}
       title={title}
-      titleTemplate={defaultTitle ? `%s | ${defaultTitle}` : null}
+      titleTemplate={defaultTitle ? `%s | ${defaultTitle}` : undefined}
       meta={[
         {
           name: 'description',

--- a/www/src/components/insights/SummaryUsageExamples.tsx
+++ b/www/src/components/insights/SummaryUsageExamples.tsx
@@ -54,7 +54,7 @@ function SummaryUsageExamples({ row }: ISummaryUsageExamples) {
     </div>
   ));
 
-  return componentUsagesExample;
+  return <div>{componentUsagesExample}</div>;
 }
 
 SummaryUsageExamples.propTypes = {

--- a/www/src/pages/insights.tsx
+++ b/www/src/pages/insights.tsx
@@ -17,6 +17,7 @@ import SummaryUsageExamples, { ISummaryUsageExamples } from '../components/insig
 import ProjectUsageExamples, { IProjectUsageExamples } from '../components/insights/ProjectUsageExamples';
 import ComponentUsageExamples, { IComponentUsageExamples } from '../components/insights/ComponentUsageExamples';
 import getGithubProjectUrl from '../utils/getGithubProjectUrl';
+// @ts-ignore
 import dependentProjectsAnalysis from '../../../dependent-usage.json'; // eslint-disable-line
 import { INSIGHTS_TABS, INSIGHTS_PAGES } from '../config';
 import InsightsContext from '../context/InsightsContext';
@@ -84,7 +85,7 @@ export interface IComponentUsage {
 
 const dependentProjects: IDependentUsage[] = [];
 
-const componentsUsage: Record<string, IComponentUsage[]> = dependentProjectsUsages
+const componentsUsage: Record<string, IComponentUsageData[]> = dependentProjectsUsages
   .reduce((accumulator: any, project: any) => {
     dependentProjects.push({
       ...project,

--- a/www/tsconfig.json
+++ b/www/tsconfig.json
@@ -1,35 +1,14 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "disableSourceOfProjectReferenceRedirect": true,
-    "disableSolutionSearching": true,
-    "target": "es6",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "es6"
-    ],
-    "jsx": "react",
-    "module": "es6",
-    "moduleResolution": "node",
-    "preserveSymlinks": true,
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+    "rootDir": "src",
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": false,
-    "baseUrl": "src",
+    "noImplicitAny": false,
     "paths": {
-      "~paragon-react": ["../../src"],
-      "~paragon-style": ["../../scss"],
-      "~paragon-icons": ["../../icons"]
+      "~paragon-react": ["../src"],
+      "~paragon-style": ["../scss"],
+      "~paragon-icons": ["../icons"],
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Description

Adds type check step to CI, simplifies typescript configs and fixes `target` to be `es6`.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
