### PR TITLE
[BD-46] fix: fixed default container width in Settings menu

### DIFF
--- a/www/src/context/SettingsContext.tsx
+++ b/www/src/context/SettingsContext.tsx
@@ -34,7 +34,7 @@ function SettingsContextProvider({ children }) {
     theme: DEFAULT_THEME,
     direction: 'ltr',
     language: 'en',
-    containerWidth: undefined,
+    containerWidth: 'md',
   });
   const [showSettings, setShowSettings] = useState(false);
 


### PR DESCRIPTION
## Description

By default, the container width value equals `undefined` in the `Container width` property in the `Settings` menu. Need to indicate default value (`md`).

![Screenshot 2023-01-30 at 22 46 33](https://user-images.githubusercontent.com/93188219/215591537-a78217eb-de50-466f-ae2f-a1e0eac4be64.png)

### Deploy Preview

[Paragon site documentation](https://deploy-preview-1983--paragon-openedx.netlify.app/components/alert/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
