### PR TITLE
[BD-46] docs: renamed Paragon Segment events

### DIFF
--- a/www/netlify/functions/trackGenerateComponent.js
+++ b/www/netlify/functions/trackGenerateComponent.js
@@ -12,7 +12,7 @@ exports.handler = async function eventHandler(event) {
   // dispatch event to Segment
   analytics.track({
     anonymousId: uuidv4(),
-    event: 'edx.paragon.generate-component',
+    event: 'openedx.paragon.functions.track-generate-component.created',
     properties: { componentName },
   });
 

--- a/www/src/components/IconsTable.jsx
+++ b/www/src/components/IconsTable.jsx
@@ -78,14 +78,14 @@ function IconsTable() {
   const copyToClipboard = (content) => {
     navigator.clipboard.writeText(content);
     setShowToast(true);
-    global.analytics.track('openedx.paragon.icons-table.selected-icon.copied', { name: currentIcon });
+    global.analytics.track('openedx.paragon.docs.icons-table.selected-icon.copied', { name: currentIcon });
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedSetIconsList = useCallback(
     debounce(
       (list) => {
-        global.analytics.track('openedx.paragon.icons-table.search', { value: searchValue });
+        global.analytics.track('openedx.paragon.docs.icons-table.search', { value: searchValue });
         setData({ rowsCount: ROWS_PER_WINDOW, iconsList: list });
       },
       250,

--- a/www/src/components/Menu.tsx
+++ b/www/src/components/Menu.tsx
@@ -128,7 +128,7 @@ function MenuComponentListCategory({ children, title }: IMenuComponentListCatego
 }
 
 const handlePlaygroundClick = () => {
-  global.analytics.track('openedx.paragon.menu.playground.visit_playground.clicked');
+  global.analytics.track('openedx.paragon.docs.menu.playground.visit_playground.clicked');
 };
 
 MenuComponentListCategory.propTypes = {

--- a/www/src/context/SettingsContext.tsx
+++ b/www/src/context/SettingsContext.tsx
@@ -49,9 +49,7 @@ function SettingsContextProvider({ children }) {
 
   const toggleSettings = (value: boolean) => {
     setShowSettings(value);
-    global.analytics.track(`openedx.paragon.docs.settings.${value ? 'opened' : 'closed'}`, {
-      value: value ? 'show' : 'hide',
-    });
+    global.analytics.track(`openedx.paragon.docs.settings.${value ? 'opened' : 'closed'}`);
   };
 
   // this hook will be called after the first render, so we can safely access localStorage

--- a/www/src/context/SettingsContext.tsx
+++ b/www/src/context/SettingsContext.tsx
@@ -44,12 +44,14 @@ function SettingsContextProvider({ children }) {
     }
     setSettings(prevState => ({ ...prevState, [key]: value }));
     global.localStorage.setItem('pgn__settings', JSON.stringify({ ...settings, [key]: value }));
-    global.analytics.track(`${key[0].toUpperCase() + key.slice(1)} change`, { [key]: value });
+    global.analytics.track(`openedx.paragon.docs.settings.${key}.changed`, { [key]: value });
   };
 
   const toggleSettings = (value: boolean) => {
     setShowSettings(value);
-    global.analytics.track('Toggle Settings', { value: value ? 'show' : 'hide' });
+    global.analytics.track(`openedx.paragon.docs.settings.${value ? 'opened' : 'closed'}`, {
+      value: value ? 'show' : 'hide',
+    });
   };
 
   // this hook will be called after the first render, so we can safely access localStorage

--- a/www/src/pages/foundations/elevation.jsx
+++ b/www/src/pages/foundations/elevation.jsx
@@ -79,7 +79,7 @@ function BoxShadowToolkit({
   });
 
   const updateBoxShadowModel = (property, value) => {
-    global.analytics.track('openedx.paragon.elevation.generator.updated', { property, value });
+    global.analytics.track('openedx.paragon.docs.elevation.generator.updated', { property, value });
 
     const newBoxShadowModel = {
       ...boxShadowModel,

--- a/www/src/pages/insights.tsx
+++ b/www/src/pages/insights.tsx
@@ -365,7 +365,7 @@ export default function InsightsPage({ pageContext: { tab } }: { pageContext: { 
 
   const handleOnSelect = (value: string) => {
     if (value !== tab) {
-      global.analytics.track(`openedx.paragon.docs.insights.tabs.${value.toLowerCase().trim()}.clicked`, { tab: value });
+      global.analytics.track(`openedx.paragon.docs.insights.tabs.${value.toLowerCase().trim()}.clicked`);
       navigate(INSIGHTS_PAGES.find(item => item.tab === value)!.path);
     }
   };

--- a/www/src/pages/insights.tsx
+++ b/www/src/pages/insights.tsx
@@ -365,7 +365,7 @@ export default function InsightsPage({ pageContext: { tab } }: { pageContext: { 
 
   const handleOnSelect = (value: string) => {
     if (value !== tab) {
-      global.analytics.track('Usage Insights', { tab: value });
+      global.analytics.track(`openedx.paragon.docs.insights.tabs.${value.toLowerCase().trim()}.clicked`, { tab: value });
       navigate(INSIGHTS_PAGES.find(item => item.tab === value)!.path);
     }
   };


### PR DESCRIPTION
## Description

Rename Segment events to follow a common convention: `openedx.paragon.{module}.{event descriptor}.{action} # action in past tense`

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
