### PR TITLE
[BD-46] feat: added custom title for CSS output files

### DIFF
--- a/scss/core/css/utility-classes.css
+++ b/scss/core/css/utility-classes.css
@@ -1,3 +1,9 @@
+/**
+ * IMPORTANT: This file is the result of assembling design tokens, contained in the project's "tokens/src" folder
+ * Do not edit directly
+ * Generated on Tue, 31 Jan 2023 01:39:48 GMT
+ */
+
 .bg-dark {
   background-color: #273F2FFF !important;
 }

--- a/scss/core/css/utility-classes.css
+++ b/scss/core/css/utility-classes.css
@@ -1,7 +1,7 @@
 /**
- * IMPORTANT: This file is the result of assembling design tokens, contained in the project's "tokens/src" folder
+ * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Tue, 31 Jan 2023 01:39:48 GMT
+ * Generated on Tue, 31 Jan 2023 09:38:46 GMT
  */
 
 .bg-dark {

--- a/scss/core/css/variables.css
+++ b/scss/core/css/variables.css
@@ -1,3 +1,9 @@
+/**
+ * IMPORTANT: This file is the result of assembling design tokens, contained in the project's "tokens/src" folder
+ * Do not edit directly
+ * Generated on Tue, 31 Jan 2023 01:39:48 GMT
+ */
+
 :root {
   --pgn-theme-interval: 8%;
   --pgn-other-tooltip-opacity: 1;

--- a/scss/core/css/variables.css
+++ b/scss/core/css/variables.css
@@ -1,7 +1,7 @@
 /**
- * IMPORTANT: This file is the result of assembling design tokens, contained in the project's "tokens/src" folder
+ * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Tue, 31 Jan 2023 01:39:48 GMT
+ * Generated on Tue, 31 Jan 2023 09:38:46 GMT
  */
 
 :root {

--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -17,7 +17,7 @@ const config = {
   include: [path.resolve(__dirname, 'src/**/*.json')],
   fileHeader: {
     customFileHeader: (defaultMessage) => [
-      'IMPORTANT: This file is the result of assembling design tokens, contained in the project\'s "tokens/src" folder',
+      'IMPORTANT: This file is the result of assembling design tokens',
       ...defaultMessage,
     ],
   },

--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -15,6 +15,12 @@ const source = tokensSource ? [tokensSource] : [];
 
 const config = {
   include: [path.resolve(__dirname, 'src/**/*.json')],
+  fileHeader: {
+    customFileHeader: (defaultMessage) => [
+      'IMPORTANT: This file is the result of assembling design tokens, contained in the project\'s "tokens/src" folder',
+      ...defaultMessage,
+    ],
+  },
   source,
   platforms: {
     css: {
@@ -39,7 +45,7 @@ const config = {
       ],
       transforms: StyleDictionary.transformGroup.css.filter(item => item !== 'size/rem').concat('color/sass-color-functions', 'str-replace'),
       options: {
-        showFileHeader: false,
+        fileHeader: 'customFileHeader',
       },
     },
   },

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -91,7 +91,7 @@ StyleDictionary.registerFormat({
  */
 StyleDictionary.registerFormat({
   name: 'css/custom-variables',
-  formatter({ dictionary, options }) {
+  formatter({ dictionary, options, file }) {
     const variables = dictionary.allTokens.sort(sortByReference(dictionary)).map(token => {
       let { value } = token;
       const outputReferencesForToken = token.original.outputReferences === false ? false : options.outputReferences;
@@ -106,7 +106,7 @@ StyleDictionary.registerFormat({
       return `  --${token.name}: ${value};`;
     }).join('\n');
 
-    return `:root {\n${variables}\n}\n`;
+    return `${fileHeader({ file })}:root {\n${variables}\n}\n`;
   },
 });
 
@@ -119,7 +119,7 @@ StyleDictionary.registerFormat({
  */
 StyleDictionary.registerFormat({
   name: 'css/utility-classes',
-  formatter({ dictionary }) {
+  formatter({ dictionary, file }) {
     const { utilities } = dictionary.properties;
 
     if (!utilities) {
@@ -144,7 +144,7 @@ StyleDictionary.registerFormat({
       }
     });
 
-    return utilityClasses;
+    return fileHeader({ file }) + utilityClasses;
   },
 });
 


### PR DESCRIPTION
## Description

By default, style-dictionary appears to include a file header at the top of its automatically generated output files to indicate to contributors that those output files are not intended to be manually edited.

Example:

```
// Do not edit directly
// Generated on Fri, 27 Jan 2023 16:54:59 GMT
```

```
:root {
  --pgn-color-primary-base: #FF0000FF;
}
```
Consider creating a custom file header with more details as well.

Without the file header, we run the risk of contributors wanting to manually edit the output files instead of editing the underlying design tokens instead.

The below config option may be related:

```
options: {
  showFileHeader: false,
},
```

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
