### PR TITLE
[BD-46] fix: fixed undefined/null image logo src

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -341,6 +341,11 @@ a .pgn__card {
   width: 100%;
   border-top-left-radius: $card-image-border-radius;
   border-top-right-radius: $card-image-border-radius;
+  display: none;
+
+  &.show {
+    display: block;
+  }
 }
 
 .pgn__card-logo-cap {
@@ -353,6 +358,11 @@ a .pgn__card {
   box-shadow: $level-1-box-shadow;
   padding: map_get($spacers, 2);
   background-color: $white;
+  display: none;
+
+  &.show {
+    display: block;
+  }
 }
 
 %pgn__card-focused {

--- a/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
+++ b/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
@@ -111,6 +111,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -158,6 +159,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -205,6 +207,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -252,6 +255,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -299,6 +303,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -452,6 +457,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -499,6 +505,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -546,6 +553,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -593,6 +601,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -640,6 +649,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -782,6 +792,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -829,6 +840,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -876,6 +888,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -923,6 +936,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>
@@ -970,6 +984,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
               <img
                 className="pgn__card-image-cap"
                 onError={[Function]}
+                onLoad={[Function]}
                 src="http://fake.image"
               />
             </div>

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -46,14 +46,20 @@ const CardImageCap = React.forwardRef(({
     );
   }
 
-  const handleSrcFallback = (event, altSrc) => {
+  const handleSrcFallback = (event, altSrc, imageKey) => {
     const { currentTarget } = event;
 
     if (!altSrc || currentTarget.src.endsWith(altSrc)) {
-      currentTarget.style.display = 'none';
-    } else if (currentTarget.src !== altSrc) {
-      currentTarget.src = altSrc;
+      if (imageKey === 'imageCap') {
+        currentTarget.src = cardSrcFallbackImg;
+      } else {
+        setShow(s => ({ ...s, logoCap: false }));
+      }
+
+      return;
     }
+
+    currentTarget.src = altSrc;
   };
 
   return (
@@ -61,16 +67,16 @@ const CardImageCap = React.forwardRef(({
       <img
         className={classNames('pgn__card-image-cap', { show: show.imageCap })}
         src={src}
-        onError={(event) => handleSrcFallback(event, fallbackSrc)}
-        onLoad={() => setShow({ ...show, imageCap: src })}
+        onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
+        onLoad={() => setShow(s => ({ ...s, imageCap: !!src }))}
         alt={srcAlt}
       />
       {!!logoSrc && (
         <img
           className={classNames('pgn__card-logo-cap', { show: show.logoCap })}
           src={logoSrc}
-          onError={(event) => handleSrcFallback(event, fallbackLogoSrc)}
-          onLoad={() => setShow({ ...show, logoCap: logoSrc })}
+          onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
+          onLoad={() => setShow(s => ({ ...s, logoCap: !!logoSrc }))}
           alt={logoAlt}
         />
       )}

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -23,7 +23,8 @@ const CardImageCap = React.forwardRef(({
   className,
 }, ref) => {
   const { orientation, isLoading } = useContext(CardContext);
-  const [show, setShow] = useState({ imageCap: false, logoCap: false });
+  const [showImageCap, setShowImageCap] = useState(false);
+  const [showLogoCap, setShowLogoCap] = useState(false);
   const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
 
   if (isLoading) {
@@ -53,7 +54,7 @@ const CardImageCap = React.forwardRef(({
       if (imageKey === 'imageCap') {
         currentTarget.src = cardSrcFallbackImg;
       } else {
-        setShow(s => ({ ...s, logoCap: false }));
+        setShowLogoCap(false);
       }
 
       return;
@@ -66,19 +67,19 @@ const CardImageCap = React.forwardRef(({
     <div className={classNames(className, wrapperClassName)} ref={ref}>
       {!!src && (
         <img
-          className={classNames('pgn__card-image-cap', { show: show.imageCap })}
+          className={classNames('pgn__card-image-cap', { show: showImageCap })}
           src={src}
           onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
-          onLoad={() => setShow(s => ({ ...s, imageCap: true }))}
+          onLoad={() => setShowImageCap(true)}
           alt={srcAlt}
         />
       )}
       {!!logoSrc && (
         <img
-          className={classNames('pgn__card-logo-cap', { show: show.logoCap })}
+          className={classNames('pgn__card-logo-cap', { show: showLogoCap })}
           src={logoSrc}
           onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
-          onLoad={() => setShow(s => ({ ...s, logoCap: true }))}
+          onLoad={() => setShowLogoCap(true)}
           alt={logoAlt}
         />
       )}

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -23,6 +23,7 @@ const CardImageCap = React.forwardRef(({
   className,
 }, ref) => {
   const { orientation, isLoading } = useContext(CardContext);
+  const [show, setShow] = useState({ imageCap: false, logoCap: false });
   const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
 
   if (isLoading) {
@@ -58,16 +59,18 @@ const CardImageCap = React.forwardRef(({
   return (
     <div className={classNames(className, wrapperClassName)} ref={ref}>
       <img
-        className="pgn__card-image-cap"
+        className={classNames('pgn__card-image-cap', { show: show.imageCap })}
         src={src}
         onError={(event) => handleSrcFallback(event, fallbackSrc)}
+        onLoad={() => setShow({ ...show, imageCap: src })}
         alt={srcAlt}
       />
       {!!logoSrc && (
         <img
-          className="pgn__card-logo-cap"
+          className={classNames('pgn__card-logo-cap', { show: show.logoCap })}
           src={logoSrc}
           onError={(event) => handleSrcFallback(event, fallbackLogoSrc)}
+          onLoad={() => setShow({ ...show, logoCap: logoSrc })}
           alt={logoAlt}
         />
       )}

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -64,19 +64,21 @@ const CardImageCap = React.forwardRef(({
 
   return (
     <div className={classNames(className, wrapperClassName)} ref={ref}>
-      <img
-        className={classNames('pgn__card-image-cap', { show: show.imageCap })}
-        src={src}
-        onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
-        onLoad={() => setShow(s => ({ ...s, imageCap: !!src }))}
-        alt={srcAlt}
-      />
+      {!!src && (
+        <img
+          className={classNames('pgn__card-image-cap', { show: show.imageCap })}
+          src={src}
+          onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
+          onLoad={() => setShow(s => ({ ...s, imageCap: true }))}
+          alt={srcAlt}
+        />
+      )}
       {!!logoSrc && (
         <img
           className={classNames('pgn__card-logo-cap', { show: show.logoCap })}
           src={logoSrc}
           onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
-          onLoad={() => setShow(s => ({ ...s, logoCap: !!logoSrc }))}
+          onLoad={() => setShow(s => ({ ...s, logoCap: true }))}
           alt={logoAlt}
         />
       )}

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -47,7 +47,9 @@ const CardImageCap = React.forwardRef(({
 
   const handleSrcFallback = (event, altSrc) => {
     const { currentTarget } = event;
-    if (currentTarget.src !== altSrc) {
+    if (!altSrc) {
+      currentTarget.style.display = 'none';
+    } else if (currentTarget.src !== altSrc) {
       currentTarget.src = altSrc;
     }
   };

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -47,7 +47,8 @@ const CardImageCap = React.forwardRef(({
 
   const handleSrcFallback = (event, altSrc) => {
     const { currentTarget } = event;
-    if (!altSrc) {
+
+    if (!altSrc || currentTarget.src.endsWith(altSrc)) {
       currentTarget.style.display = 'none';
     } else if (currentTarget.src !== altSrc) {
       currentTarget.src = altSrc;

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -610,20 +610,20 @@ A fallback source is available for both the main `ImageCap` component image and 
   return (
     <Card style={{width: isExtraSmall ? "100%" : "40%"}}>
       <Card.ImageCap
-          src="fakeURL"
-          fallbackSrc="https://picsum.photos/360/200/"
-          srcAlt="Card image"
-          logoSrc="fakeURL"
-          fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
-          logoAlt="Card logo"
+        src="fakeURL"
+        fallbackSrc="https://picsum.photos/360/200/"
+        srcAlt="Card image"
+        logoSrc="fakeURL"
+        fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
+        logoAlt="Card logo"
       />
       <Card.Header title="Title" subtitle="Subtitle" />
       <Card.Section title="Section title">
-          This is a card section. It can contain anything but usually text, a list, or list of links.
-          Multiple sections have a card divider between them.
+        This is a card section. It can contain anything but usually text, a list, or list of links.
+        Multiple sections have a card divider between them.
       </Card.Section>
       <Card.Footer>
-          <Button>Action 1</Button>
+        <Button>Action 1</Button>
       </Card.Footer>
   </Card>
 )}
@@ -639,20 +639,20 @@ The default fallback image will be displayed if `fallbackSrc` is not specified.
 
   return (
     <Card style={{width: isExtraSmall ? "100%" : "40%"}}>
-      <Card.ImageCap
-          src="fakeURL"
-          srcAlt="Card image"
-          logoSrc="fakeURL"
-          fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
-          logoAlt="Card logo"
+      <Card.ImageCap 
+        src="fakeURL"
+        srcAlt="Card image"
+        logoSrc="fakeURL"
+        fallbackLogoSrc="https://www.edx.org/images/logos/edx-logo-elm.svg"
+        logoAlt="Card logo"
       />
       <Card.Header title="Title" subtitle="Subtitle" />
       <Card.Section title="Section title">
-          This is a card section. It can contain anything but usually text, a list, or list of links.
-          Multiple sections have a card divider between them.
+        This is a card section. It can contain anything but usually text, a list, or list of links.
+        Multiple sections have a card divider between them.
       </Card.Section>
       <Card.Footer>
-          <Button>Action 1</Button>
+        <Button>Action 1</Button>
       </Card.Footer>
   </Card>
 )}

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -108,7 +108,8 @@ describe('<CardImageCap />', () => {
 
     const logoImg = screen.getByAltText('Logo alt text');
     fireEvent.load(logoImg);
+    expect(logoImg.className).toEqual('pgn__card-logo-cap show');
     fireEvent.error(logoImg);
-    expect(logoImg.style.display).toEqual('none');
+    expect(logoImg.className).toEqual('pgn__card-logo-cap');
   });
 });

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -100,4 +100,12 @@ describe('<CardImageCap />', () => {
     fireEvent.error(logoImg);
     expect(logoImg.src).toEqual('http://logo.image.fallback/');
   });
+
+  it('hiding component if it isn`t fallbackLogoSrc and logoSrc don`t work', () => {
+    render(<CardImageCapWrapper logoSrc="fakeURL" logoAlt="Logo alt text" />);
+
+    const logoImg = screen.getByAltText('Logo alt text');
+    fireEvent.error(logoImg);
+    expect(logoImg.style.display).toEqual('none');
+  });
 });

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -112,4 +112,14 @@ describe('<CardImageCap />', () => {
     fireEvent.error(logoImg);
     expect(logoImg.className).toEqual('pgn__card-logo-cap');
   });
+
+  it('hiding component if it isn`t fallbackSrc and src don`t work', () => {
+    render(<CardImageCapWrapper src="fakeURL" fallbackSrc="fakeURL" srcAlt="Src alt text" />);
+
+    const srcImg = screen.getByAltText('Src alt text');
+    fireEvent.load(srcImg);
+    fireEvent.error(srcImg);
+    // test-file-stub is what our fileMock.js returns for all images
+    expect(srcImg.src.endsWith('test-file-stub')).toEqual(true);
+  });
 });

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -92,11 +92,13 @@ describe('<CardImageCap />', () => {
     );
     const srcImg = screen.getByAltText('Src alt text');
     expect(srcImg.src).toEqual('http://src.image/');
+    fireEvent.load(srcImg);
     fireEvent.error(srcImg);
     expect(srcImg.src).toEqual('http://src.image.fallback/');
 
     const logoImg = screen.getByAltText('Logo alt text');
     expect(logoImg.src).toEqual('http://logo.image/');
+    fireEvent.load(srcImg);
     fireEvent.error(logoImg);
     expect(logoImg.src).toEqual('http://logo.image.fallback/');
   });
@@ -105,6 +107,7 @@ describe('<CardImageCap />', () => {
     render(<CardImageCapWrapper logoSrc="fakeURL" logoAlt="Logo alt text" />);
 
     const logoImg = screen.getByAltText('Logo alt text');
+    fireEvent.load(logoImg);
     fireEvent.error(logoImg);
     expect(logoImg.style.display).toEqual('none');
   });

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -68,6 +69,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -115,6 +117,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -162,6 +165,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -209,6 +213,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -268,6 +273,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -315,6 +321,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -362,6 +369,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -409,6 +417,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -456,6 +465,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -515,6 +525,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -562,6 +573,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -609,6 +621,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -656,6 +669,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -703,6 +717,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>
@@ -74,6 +75,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
           <img
             className="pgn__card-image-cap"
             onError={[Function]}
+            onLoad={[Function]}
             src="http://fake.image"
           />
         </div>

--- a/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`<CardImageCap /> renders with scr prop and srcAlt 1`] = `
     alt="Alt text"
     className="pgn__card-image-cap"
     onError={[Function]}
+    onLoad={[Function]}
     src="http://fake.image"
   />
 </div>
@@ -20,6 +21,7 @@ exports[`<CardImageCap /> renders with scr prop in horizontal orientation 1`] = 
   <img
     className="pgn__card-image-cap"
     onError={[Function]}
+    onLoad={[Function]}
     src="http://fake.image"
   />
 </div>
@@ -32,11 +34,13 @@ exports[`<CardImageCap /> renders with src and logoSrc prop in horizontal orient
   <img
     className="pgn__card-image-cap"
     onError={[Function]}
+    onLoad={[Function]}
     src="http://fake.image"
   />
   <img
     className="pgn__card-logo-cap"
     onError={[Function]}
+    onLoad={[Function]}
     src="http://fake.image"
   />
 </div>
@@ -49,12 +53,14 @@ exports[`<CardImageCap /> renders with src, logoSrc and logoAlt props 1`] = `
   <img
     className="pgn__card-image-cap"
     onError={[Function]}
+    onLoad={[Function]}
     src="http://fake.image"
   />
   <img
     alt="Logo alt"
     className="pgn__card-logo-cap"
     onError={[Function]}
+    onLoad={[Function]}
     src="http://fake.image"
   />
 </div>


### PR DESCRIPTION
## Description

The fallbackLogoSrc is incorrectly calling the image URL when the logoSrc prop is not correctly fetching the image.
Issue: https://github.com/openedx/paragon/issues/1967

### Deploy Preview

[Card Fallback example](https://deploy-preview-1994--paragon-openedx.netlify.app/components/card/#fallback-image)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
