### PR TITLE
[BD-46] docs: add Segment event for when the 'Show code' block is opened/closed

### DIFF
--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -118,6 +118,7 @@ Use inline size buttons for when a button sits with a line of text.
 </>
 ```
 
+### With empty href
 For link to be `disabled`, it must have href defined with some value.
 
 ```jsx live
@@ -174,15 +175,15 @@ For link to be `disabled`, it must have href defined with some value.
 
 ***
 
-## Button/Deprecated
+## Button.Deprecated
 
-### Basic Usage
+### (Deprecated) basic usage
 
 ```jsx live
 <Button.Deprecated className="btn-primary">Hello World!</Button.Deprecated>
 ```
 
-### Color Variants
+### (Deprecated) color variants
 
 ```jsx live
 <div>
@@ -194,7 +195,7 @@ For link to be `disabled`, it must have href defined with some value.
 </div>
 ```
 
-### Outline Variants
+### (Deprecated) outline variants
 
 ```jsx live
 <div>
@@ -204,7 +205,7 @@ For link to be `disabled`, it must have href defined with some value.
 </div>
 ```
 
-### Inverse Variants
+### (Deprecated) inverse variants
 
 ```jsx live
 <div className="bg-gray-700 p-3">
@@ -214,7 +215,7 @@ For link to be `disabled`, it must have href defined with some value.
 </div>
 ```
 
-### Link Variant
+### (Deprecated) link variant
 
 ```jsx live
 <div className="bg-gray-200 p-3">

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -280,7 +280,7 @@ Add ``size="sm"`` for smaller header content and actions.
 `Card.Footer` is the bottom part of the card. Usually used to outline actions that can be taken on the card object.
 Note that `Card.Footer` has a separate `orientation` prop which will override the value from `CardContext`, this was implemented because there are some use cases where you would want to display `Card` with horizontal orientation containing footer with vertical orientation.
 
-### Vertical variant
+### Footer vertical variant
 
 ```jsx live
 () => {
@@ -322,7 +322,7 @@ Note that `Card.Footer` has a separate `orientation` prop which will override th
 }
 ```
 
-### Horizontal variant
+### Footer horizontal variant
 
 ```jsx live
 () => {

--- a/src/DataTable/tablefooter.mdx
+++ b/src/DataTable/tablefooter.mdx
@@ -20,6 +20,8 @@ By default, it shows how many items are being displayed on the left, pagination 
 navigation buttons on the right.
 Alternately, it will accept children.
 
+## Basic Usage
+
 ```jsx live
 <DataTable
   isPaginated

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -138,7 +138,7 @@ You can use `Dropdown.Toggle` with [IconButton](/components/iconbutton) componen
 </Dropdown.Deprecated>
 ```
 
-### with icon element
+### (Deprecated) with icon element
 
 ```jsx live
 <Dropdown.Deprecated>

--- a/src/Form/form-group.mdx
+++ b/src/Form/form-group.mdx
@@ -19,6 +19,7 @@ that enable these components to relate to each other according to WCAG guideline
 controlId if none is supplied and offers `size`, `isInvalid`, `isValid` in the
 context. `Form.Control`, `Form.Label`, and `Form.Control.Feedback` consume this context.
 
+## Basic Usage
 
 ```jsx live
   <Form.Group

--- a/src/Icon/README.md
+++ b/src/Icon/README.md
@@ -13,11 +13,14 @@ notes: |
 
 Displays an svg icon from `@edx/paragon/icons`. See [Icons Foundation Documentation](/foundations/icons) for a list of all available icons.
 
+## Basic Usage
+
 ```jsx live
 // Included in this live jsx scope:
 // import { Add, AddCircle } from '@edx/paragon/icons';
 <Icon src={Add} />
 ```
+### With HTML attributes
 
 HTML attributes can be passed to this component allowing for customization of the color, size, or addition of any necessary ARIA attributes.
 

--- a/src/Menu/README.md
+++ b/src/Menu/README.md
@@ -36,6 +36,8 @@ A ``MenuItem`` is its own distinct component that is used by any kind of menu ov
 }
 ```
 
+## With Form
+
 A ``Menu`` can include things like forms.
 
 ```jsx live
@@ -59,6 +61,8 @@ A ``Menu`` can include things like forms.
   );
 }
 ```
+
+## With Modal
 
 A ``Menu`` can be implemented to appear inside a `modalpopup` for a wide variety of use cases. The ``Modal`` brings focus to the first menu element upon the click of the trigger, and can be escaped on click away or key press.
 

--- a/src/Menu/select-menu.md
+++ b/src/Menu/select-menu.md
@@ -16,7 +16,7 @@ The ``SelectMenu`` component is triggered on the click of a button or your choic
 
 The ``Modal`` brings focus to the first menu element upon the click of the trigger, and can be escaped on click away or key press. Set a default message with the `defaultMessage` prop string. Use the `defaultSelected` prop to signify that a menuItem is the default to open to.
 
-### Basic usage
+## Basic usage
 
 ```jsx live
 <SelectMenu>
@@ -28,7 +28,7 @@ The ``Modal`` brings focus to the first menu element upon the click of the trigg
 </SelectMenu>
 ```
 
-#### Linked variant
+### Linked variant
 
 ```jsx live
 <SelectMenu isLink={true} defaultMessage="Choose Your New Best Friend">

--- a/src/Modal/alert-modal.mdx
+++ b/src/Modal/alert-modal.mdx
@@ -17,6 +17,7 @@ Alert Dialogs are used to block the user from moving forward in a particular wor
 
 This is the alert style `ModalDialog` composition. `AlertModal` passes all of its props through to an underlying `ModalDialog` component providing some limited customization. If you have unique needs, use the `ModalDialog` compound component family directly.
 
+## Basic usage
 
 ```jsx live
 () => {

--- a/src/Modal/fullscreen-modal.mdx
+++ b/src/Modal/fullscreen-modal.mdx
@@ -15,6 +15,8 @@ notes: |
 
 The fullscreen `ModalDialog` composition. `FullscreenModal` passes all of its props through to an underlying `ModalDialog` component providing some limited customization. If you have unique needs, use the `ModalDialog` compound component family directly.
 
+## Basic Usage
+
 ```jsx live
 () => {
   const [isOpen, open, close] = useToggle(false);

--- a/src/Modal/modal-dialog.mdx
+++ b/src/Modal/modal-dialog.mdx
@@ -22,6 +22,7 @@ A set of components for making all kinds of modal dialogs. Remember to supply
 the required `title` prop to `ModalDialog` in order ensure there is an accessible
 label for the dialog element.
 
+## Basic Usage
 
 ```jsx live
 () => {
@@ -91,6 +92,8 @@ label for the dialog element.
   )
 }
 ```
+
+## With header content
 
 ```jsx live
 () => {

--- a/src/Modal/modal-layer.mdx
+++ b/src/Modal/modal-layer.mdx
@@ -15,6 +15,8 @@ notes: |
 
 A generic component for creating accessibile modal layer objects. The modal layer provides a focus locked and scrollable overlay layer for a dialog. The child of a ModalLayer must have the role "dialog" and specify either an `aria-label` or `aria-labelledby` attribute.
 
+## Basic usage
+
 ```jsx live
 () => {
   const [isOpen, open, close] = useToggle(false);
@@ -53,6 +55,7 @@ A generic component for creating accessibile modal layer objects. The modal laye
 }
 ```
 
+## Small modal variant
 
 ```jsx live
 () => {

--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -18,6 +18,8 @@ A generic component for creating accessible modal popup objects.
 Note that `ModalPopup` expects DOM node, not ref, in order to be able to update when the node changes.
 A proper way to implement this is to use [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) with `useState` hook as in the example below.
 
+## Basic Usage
+
 ```jsx live
 () => {
   const [isOpen, open, close] = useToggle(false);

--- a/src/Pagination/README.md
+++ b/src/Pagination/README.md
@@ -71,7 +71,7 @@ Navigation between multiple pages of some set of results. Controls are provided 
 />
 ```
 
-## Secondary
+## Secondary (Small Size)
 
 ```jsx live
 <Pagination
@@ -83,7 +83,7 @@ Navigation between multiple pages of some set of results. Controls are provided 
 />
 ```
 
-## Reduced
+## Reduced (Small Size)
 
 ```jsx live
 <Pagination
@@ -95,7 +95,7 @@ Navigation between multiple pages of some set of results. Controls are provided 
 />
 ```
 
-## Minimal
+## Minimal (Small Size)
 
 ```jsx live
 <Pagination

--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -67,7 +67,7 @@ As ``Checkbox``
 }
 ```
 
-As ``Radio``
+## As Radio
 
 ```jsx live
 () => {
@@ -102,7 +102,7 @@ As ``Radio``
   );
 }
 ```
-
+## As Checkbox
 As ``Checkbox`` with ``isIndeterminate``
 
 ```jsx live

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -180,7 +180,7 @@ notes: |
 
 <br/>
 
-### Basic usage
+### (Deprecated) basic usage
 
 ```jsx live
 <Tabs.Deprecated

--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -71,11 +71,11 @@ TransitionReplace uses [CSSTransition from the ReactTransitionGroup package](htt
 
 If you change the timing in CSS you should also match it using the `enterDuration` and `exitDuration` props.
 
-## Note:
+### Note:
 
 Children are not required. When this component is empty, the a child inserted into it will not transition the height (from zero). No "replacement" transition will occur and new content will pop in like a normal insert. This behaviour makes it easier to work with asyncronously loaded content (for example: during the first load you don't have to do any special handling).
 
-## Example
+### Custom transition example usage
 
 ```jsx live
 function DemoTransitionReplace() {

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -36,6 +36,20 @@ export type CollapsibleLiveEditorTypes = {
 
 function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorTypes) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
+
+  const eventSegmentSubmitter = (e) => {
+    let elementBeforeUseCase = e.target.closest('.pgn-doc__code-block').parentNode.previousSibling;
+    const componentNameAndCategory = window.location.pathname.replace(/\//g, '.');
+
+    while (elementBeforeUseCase.className !== 'pgn-doc__heading') {
+      elementBeforeUseCase = elementBeforeUseCase.previousSibling;
+    }
+
+    global.analytics.track(`openedx.ui${componentNameAndCategory}${elementBeforeUseCase.id}.${collapseIsOpen ? 'close' : 'open'}`, {
+      value: `${componentNameAndCategory.replace(/.components./gi, '')}${elementBeforeUseCase.id}`,
+    });
+  };
+
   return (
     <div className="pgn-doc__collapsible-live-editor">
       <Collapsible
@@ -43,6 +57,7 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
         styling="card-lg"
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
+        onClick={(e) => eventSegmentSubmitter(e)}
         withIcon
         title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} editable code example</strong>}
       >

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -83,7 +83,6 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
         onClick={submitSegmentEvent}
-        withIcon
         title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} editable code example</strong>}
       >
         <p className="small text-gray mb-2">Any Paragon component or export may be added to the code example.</p>

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -37,42 +37,41 @@ export type CollapsibleLiveEditorTypes = {
 function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorTypes) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
 
-  const getCodeBlockHeading = (element: HTMLElement | null): HTMLHeadElement | null => {
-    if (!element) { return null; }
+  const getCodeBlockHeading = (element: HTMLElement): HTMLHeadElement | null => {
+    const codeBlockWrapper = element.closest<HTMLDivElement>('.pgn-doc__code-block');
 
-    const useCaseElement = element.closest<HTMLDivElement>('.pgn-doc__code-block');
+    if (!codeBlockWrapper) {
+      return null;
+    }
 
-    if (!useCaseElement || !useCaseElement.parentNode) { return null; }
-
-    const elementBeforeUseCase = useCaseElement.parentNode.previousSibling;
-
-    let node = elementBeforeUseCase as HTMLElement;
+    let node = codeBlockWrapper!.parentNode!.previousSibling as HTMLElement;
 
     while (node.className !== 'pgn-doc__heading') {
       node = node.previousSibling as HTMLElement;
+
+      if (!node) {
+        return null;
+      }
     }
 
     return node;
   };
 
   const submitSegmentEvent = (e: React.MouseEvent & { target: HTMLElement }) => {
-    const componentNameAndCategory: string = window.location.pathname.replace(/\//g, '.');
-    let headingElement;
+    const componentNameAndCategory = window.location.pathname.replace(/\//g, '.')
+      .replace(/.components./gi, '');
+    const headingElement = getCodeBlockHeading(e.target);
 
-    try {
-      headingElement = getCodeBlockHeading(e.target);
-    } catch (error) {
-      console.error(error);
-
+    if (!headingElement) {
       global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'close' : 'open'}`, {
-        value: `${componentNameAndCategory.replace(/.components./gi, '')}id-not-generated`,
+        value: `${componentNameAndCategory}id-not-generated`,
       });
 
       return;
     }
 
     global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'close' : 'open'}`, {
-      value: `${componentNameAndCategory.replace(/.components./gi, '')}${headingElement.id}`,
+      value: `${componentNameAndCategory}${headingElement.id}`,
     });
   };
 

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -63,14 +63,14 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
     const headingElement = getCodeBlockHeading(e.target);
 
     if (!headingElement) {
-      global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'close' : 'open'}`, {
+      global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'closed' : 'opened'}`, {
         value: `${componentNameAndCategory}id-not-generated`,
       });
 
       return;
     }
 
-    global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'close' : 'open'}`, {
+    global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'closed' : 'opened'}`, {
       value: `${componentNameAndCategory}${headingElement.id}`,
     });
   };

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -37,9 +37,12 @@ export type CollapsibleLiveEditorTypes = {
 function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorTypes) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
 
-  const eventSegmentSubmitter = (e) => {
-    let elementBeforeUseCase = e.target.closest('.pgn-doc__code-block').parentNode.previousSibling;
-    const componentNameAndCategory = window.location.pathname.replace(/\//g, '.');
+  const eventSegmentSubmitter = (e: Event & { target: HTMLElement }) => {
+    const useCaseElement: { parentNode: any } = e.target.closest('.pgn-doc__code-block') as HTMLElement;
+    let elementBeforeUseCase: {
+      className: string, id: string, previousSibling: any
+    } = useCaseElement.parentNode.previousSibling;
+    const componentNameAndCategory: string = window.location.pathname.replace(/\//g, '.');
 
     while (elementBeforeUseCase.className !== 'pgn-doc__heading') {
       elementBeforeUseCase = elementBeforeUseCase.previousSibling;


### PR DESCRIPTION
## Description

Issue https://github.com/openedx/paragon/issues/1937

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
