### PR TITLE
[BD-46] fix: fixed links width in Usage Insights Summary tables

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -1,13 +1,4 @@
-$data-table-background-color: $white !default;
-$data-table-border: 1px solid $gray-200 !default;
-$data-table-box-shadow: $box-shadow-sm !default;
-$data-table-padding-x: .75rem !default;
-$data-table-padding-y: .75rem !default;
-$data-table-padding-small: .5rem !default;
-$data-table-cell-padding: .5rem .75rem !default;
-$data-table-footer-position: center !default;
-$data-table-pagination-dropdown-max-height: 60vh !default;
-$data-table-pagination-dropdown-min-width: 6rem !default;
+@import "variables";
 
 .pgn__data-table-wrapper {
   font-size: $font-size-sm;
@@ -107,7 +98,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
     box-shadow: $data-table-box-shadow;
     padding: $data-table-padding-small;
     margin-right: map_get($spacers, 4);
-    flex-grow: 0;
+    flex: 0 0 $data-table-layout-sidebar-width;
   }
 
   .pgn__data-table-side-filters {

--- a/src/DataTable/_variables.scss
+++ b/src/DataTable/_variables.scss
@@ -1,0 +1,11 @@
+$data-table-background-color: $white !default;
+$data-table-border: 1px solid $gray-200 !default;
+$data-table-box-shadow: $box-shadow-sm !default;
+$data-table-padding-x: .75rem !default;
+$data-table-padding-y: .75rem !default;
+$data-table-padding-small: .5rem !default;
+$data-table-cell-padding: .5rem .75rem !default;
+$data-table-footer-position: center !default;
+$data-table-pagination-dropdown-max-height: 60vh !default;
+$data-table-pagination-dropdown-min-width: 6rem !default;
+$data-table-layout-sidebar-width: 12rem !default;

--- a/www/src/components/insights/SummaryUsageExamples.tsx
+++ b/www/src/components/insights/SummaryUsageExamples.tsx
@@ -41,12 +41,12 @@ function SummaryUsageExamples({ row }: ISummaryUsageExamples) {
                   destination={`${repositoryUrl}/${filePath}#L${line}`}
                   target="_blank"
                 >
-                  {filePath}
+                  {filePath.split('/').slice(-1)}
                 </Hyperlink>
                 {' '}(line {line})
               </>
             ) : (
-              <>{filePath} (line {line})</>
+              <>{filePath.split('/').slice(-1)} (line {line})</>
             )}
           </li>
         ))}


### PR DESCRIPTION
## Description

- [x] Ensure the DataTable filters sidebar width does not shrink when the table content area's row(s) are expanded in the Usage Insights "Summary" tab.

- [x] Ensure the DataTable filters sidebar width does not shrink when the table content's area's row(s) are expanded in the DataTable documentation on the docs website.

- [x] Ensure the DataTable filters sidebar width does not shrink in consuming applications when the table content area's row(s) are expanded.

![image](https://user-images.githubusercontent.com/93188219/217695320-27a7b1fb-8dd5-4534-9132-8e6c8784763c.png)

### Deploy Preview

https://deploy-preview-2006--paragon-openedx.netlify.app/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
