### PR TITLE
[BD-46] fix: Segment event catches empty strings

### DIFF
--- a/www/src/components/IconsTable.jsx
+++ b/www/src/components/IconsTable.jsx
@@ -81,18 +81,16 @@ function IconsTable() {
     global.analytics.track('openedx.paragon.docs.icons-table.selected-icon.copied', { name: currentIcon });
   };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedSetIconsList = useCallback(
-    debounce(
-      (list) => {
-        global.analytics.track('openedx.paragon.docs.icons-table.search', { value: searchValue });
-        setData({ rowsCount: ROWS_PER_WINDOW, iconsList: list });
-      },
-      250,
-      { leading: false },
-    ),
-    [],
-  );
+  const submitSegmentEvent = useCallback(() => {
+    if (typeof searchValue === 'string' && searchValue.trim() !== '') {
+      global.analytics.track('openedx.paragon.docs.icons-table.search', { value: searchValue });
+    }
+  }, [searchValue]);
+
+  const handleChangeSearchValue = useMemo(() => {
+    submitSegmentEvent();
+    return debounce(setSearchValue, 500, { leading: false });
+  }, [submitSegmentEvent]);
 
   useEffect(() => {
     if (tableRef.current) {
@@ -122,10 +120,9 @@ function IconsTable() {
   }, []);
 
   useEffect(() => {
-    debouncedSetIconsList(
-      ICON_NAMES.filter(name => name.toLowerCase().includes(searchValue.toLowerCase())),
-    );
-  }, [searchValue, debouncedSetIconsList]);
+    const list = ICON_NAMES.filter(name => name.toLowerCase().includes(searchValue.toLowerCase()));
+    setData({ rowsCount: ROWS_PER_WINDOW, iconsList: list });
+  }, [searchValue]);
 
   const rowsIndices = useMemo(() => [...Array(rowsCount).keys()], [rowsCount]);
 
@@ -133,7 +130,7 @@ function IconsTable() {
     <>
       <SearchField
         onSubmit={() => {}}
-        onChange={value => setSearchValue(value)}
+        onChange={handleChangeSearchValue}
         placeholder="Search icons"
       />
       {currentIcon && (

--- a/www/src/components/IconsTable.jsx
+++ b/www/src/components/IconsTable.jsx
@@ -110,7 +110,7 @@ function IconsTable() {
 
   useEffect(() => {
     const list = ICON_NAMES.filter(name => name.toLowerCase().includes(searchValue.toLowerCase()));
-    if (typeof searchValue === 'string' && searchValue.trim() !== '') {
+    if (searchValue.trim() !== '') {
       global.analytics?.track('openedx.paragon.docs.icons-table.search', { value: searchValue, amount: list.length });
     }
     setData({ rowsCount: ROWS_PER_WINDOW, iconsList: list });

--- a/www/src/components/IconsTable.jsx
+++ b/www/src/components/IconsTable.jsx
@@ -1,6 +1,4 @@
-import React, {
-  useCallback, useEffect, useMemo, useState,
-} from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import { Icon, SearchField, Toast } from '~paragon-react';
@@ -81,16 +79,7 @@ function IconsTable() {
     global.analytics.track('openedx.paragon.docs.icons-table.selected-icon.copied', { name: currentIcon });
   };
 
-  const submitSegmentEvent = useCallback(() => {
-    if (typeof searchValue === 'string' && searchValue.trim() !== '') {
-      global.analytics.track('openedx.paragon.docs.icons-table.search', { value: searchValue });
-    }
-  }, [searchValue]);
-
-  const handleChangeSearchValue = useMemo(() => {
-    submitSegmentEvent();
-    return debounce(setSearchValue, 500, { leading: false });
-  }, [submitSegmentEvent]);
+  const handleChangeSearchValue = useMemo(() => debounce(setSearchValue, 500, { leading: false }), []);
 
   useEffect(() => {
     if (tableRef.current) {
@@ -121,6 +110,9 @@ function IconsTable() {
 
   useEffect(() => {
     const list = ICON_NAMES.filter(name => name.toLowerCase().includes(searchValue.toLowerCase()));
+    if (typeof searchValue === 'string' && searchValue.trim() !== '') {
+      global.analytics?.track('openedx.paragon.docs.icons-table.search', { value: searchValue, amount: list.length });
+    }
     setData({ rowsCount: ROWS_PER_WINDOW, iconsList: list });
   }, [searchValue]);
 


### PR DESCRIPTION
## Description

- [x] Ensure the openedx.paragon.icons-table.search Segment event contains the search query that was just executed.
- [x] Adding the number of search results given the specified query as an additional event property for this Segment event.

Issue: https://github.com/openedx/paragon/issues/1936

### Deploy Preview

[Icons page](https://deploy-preview-2011--paragon-openedx.netlify.app/foundations/icons)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
