### PR TITLE
[BD-46] fix: fixed incorrect label in Select All button

### DIFF
--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -20,9 +20,13 @@ function BaseSelectionStatus({
   allSelectedText,
   selectedText,
 }) {
-  const { itemCount, isPaginated, state } = useContext(DataTableContext);
+  const {
+    itemCount, filteredRows, isPaginated, state,
+  } = useContext(DataTableContext);
   const hasAppliedFilters = state?.filters?.length > 0;
   const isAllRowsSelected = numSelectedRows === itemCount;
+  const filteredItems = filteredRows?.length || itemCount;
+
   const intlAllSelectedText = allSelectedText || (
     <FormattedMessage
       id="pgn.DataTable.BaseSelectionStatus.allSelectedText"
@@ -65,7 +69,7 @@ function BaseSelectionStatus({
               id="pgn.DataTable.BaseSelectionStatus.selectAllText"
               defaultMessage="Select all {itemCount}"
               description="A label for select all button."
-              values={{ itemCount }}
+              values={{ itemCount: filteredItems }}
             />
           )}
         </Button>

--- a/src/DataTable/selection/tests/SelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/SelectionStatus.test.jsx
@@ -15,6 +15,7 @@ const instance = {
   page: [1, 2, 3, 4],
   toggleAllRowsSelected: () => {},
   itemCount: 101,
+  filteredRows: [...new Array(27)],
   state: {
     selectedRowIds: {
       1: true,
@@ -69,6 +70,11 @@ describe('<SelectionStatus />', () => {
     button.simulate('click');
     expect(toggleAllRowsSpy).toHaveBeenCalledTimes(1);
     expect(toggleAllRowsSpy).toHaveBeenCalledWith(true);
+  });
+  it('button text after filtering and selecting all items', () => {
+    const wrapper = mount(<SelectionStatusWrapper value={{ ...instance }} />);
+    const button = wrapper.find(`button.${SELECT_ALL_TEST_ID}`);
+    expect(button.text()).toContain('Select all 27');
   });
   it('does not render the clear selection button if there are no selected rows', () => {
     const value = {

--- a/src/DataTable/selection/tests/SelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/SelectionStatus.test.jsx
@@ -71,10 +71,15 @@ describe('<SelectionStatus />', () => {
     expect(toggleAllRowsSpy).toHaveBeenCalledTimes(1);
     expect(toggleAllRowsSpy).toHaveBeenCalledWith(true);
   });
-  it('button text after filtering and selecting all items', () => {
+  it('updates select all button text after applying filters', () => {
     const wrapper = mount(<SelectionStatusWrapper value={{ ...instance }} />);
     const button = wrapper.find(`button.${SELECT_ALL_TEST_ID}`);
     expect(button.text()).toContain('Select all 27');
+  });
+  it('updates select all text if filters value is empty', () => {
+    const wrapper = mount(<SelectionStatusWrapper value={{ ...instance, filteredRows: 0 }} />);
+    const button = wrapper.find(`button.${SELECT_ALL_TEST_ID}`);
+    expect(button.text()).toContain('Select all 101');
   });
   it('does not render the clear selection button if there are no selected rows', () => {
     const value = {


### PR DESCRIPTION
## Description

- "Select all" button has "Select all 7" label even though there are only 2 rows displayed after applying filters

![image](https://user-images.githubusercontent.com/93188219/218699426-decf335f-f74a-4a0e-b3f9-35f9f9ab04ea.png)

Issue: https://github.com/openedx/paragon/issues/1837

### Deploy Preview

[Data Table](https://deploy-preview-2020--paragon-openedx.netlify.app/components/datatable/#frontend-filtering-and-sorting)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
