### PR TITLE
build: add GH workflow to sync alpha with master automatically

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -280,9 +280,9 @@ jobs:
       uses: hmarr/auto-approve-action@v2
       with:
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-        github-token: ${{ secrets.EDX_NETLIFY_PAT }}
+        github-token: ${{ secrets.requirements_bot_github_token }}
     - name: Auto-merge pull request for dependent project usages
       uses: pascalgn/automerge-action@v0.14.3
       env:
-        GITHUB_TOKEN: ${{ secrets.EDX_NETLIFY_PAT }}
+        GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
         MERGE_METHOD: squash

--- a/.github/workflows/sync-alpha-master.yml
+++ b/.github/workflows/sync-alpha-master.yml
@@ -1,0 +1,30 @@
+name: Sync alpha with master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - name: Create Pull Request
+        id: cpr
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
+          FROM_BRANCH: "master"
+          TO_BRANCH: "alpha"
+      - name: Enable Pull Request Auto Merge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.requirements_bot_github_token }}
+          pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
+          merge-method: squash


### PR DESCRIPTION
## Description

We are maintaining an `alpha` branch for the design tokens project. This PR proposes setting up automation to sync `alpha` whenever there are changes to `master` by automatically opening a PR that gets auto-merged to `master` once CI status checks pass.

Uses this Github Action: https://github.com/TreTuna/sync-branches

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
