### PR TITLE
build: skip CI for automation sync PR

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,9 @@
 name: Lint Commit Messages
 
 on:
-  - pull_request
+  pull_request:
+    branches-ignore:
+      - 'automation/sync-alpha-master'
 
 jobs:
   commitlint:

--- a/.github/workflows/sync-alpha-master.yml
+++ b/.github/workflows/sync-alpha-master.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           token: ${{ secrets.requirements_bot_github_token }}
           branch: automation/sync-alpha-master
-          title: "chore(release): sync from master to alpha"
+          title: "[skip ci] chore(release): sync from master to alpha"
           body: "Sync changes from `master` to `alpha`."
       - name: Enable Pull Request Auto Merge
         uses: peter-evans/enable-pull-request-automerge@v2

--- a/.github/workflows/sync-alpha-master.yml
+++ b/.github/workflows/sync-alpha-master.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           token: ${{ secrets.requirements_bot_github_token }}
           branch: automation/sync-alpha-master
-          title: "[skip ci] chore(release): sync from master to alpha"
+          title: "chore(release): sync from master to alpha"
           body: "Sync changes from `master` to `alpha`."
       - name: Enable Pull Request Auto Merge
         uses: peter-evans/enable-pull-request-automerge@v2


### PR DESCRIPTION
## Description

The previously generated PR failed CI due to failing commit lint. This PR excludes running the commit lint check on the `automation/sync-alpha-master` branch that is used to generate the PR.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
