### PR TITLE
build: another attempt to auto-sync changes from master to alpha

### DIFF
--- a/.github/workflows/sync-alpha-master.yml
+++ b/.github/workflows/sync-alpha-master.yml
@@ -19,21 +19,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 18
-      - name: Sync changes
-        run: |
-          git switch alpha
-          git rebase master
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: tretuna/sync-branches@1
         with:
-          token: ${{ secrets.requirements_bot_github_token }}
-          branch: automation/sync-alpha-master
-          title: "chore(release): sync from master to alpha"
-          body: "Sync changes from `master` to `alpha`."
+          GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
+          FROM_BRANCH: "master"
+          TO_BRANCH: "alpha"
       - name: Enable Pull Request Auto Merge
         uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ secrets.requirements_bot_github_token }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
           merge-method: squash


### PR DESCRIPTION
## Description

`alpha` branch is now in a good place where there are no conflicts with `master` and latest `master` is on `alpha`. This PR attempts to use https://github.com/TreTuna/sync-branches again to bring commits to `master` into `alpha` branch automatically.

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
