### PR TITLE
build: set base branch to alpha

### DIFF
--- a/.github/workflows/sync-alpha-master.yml
+++ b/.github/workflows/sync-alpha-master.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 18
       - name: Sync changes
         run: |
-          git checkout alpha
+          git switch alpha
           git rebase master
       - name: Create Pull Request
         id: cpr

--- a/.github/workflows/sync-alpha-master.yml
+++ b/.github/workflows/sync-alpha-master.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           token: ${{ secrets.requirements_bot_github_token }}
           branch: automation/sync-alpha-master
+          base: alpha
           title: "chore(release): sync from master to alpha"
           body: "Sync changes from `master` to `alpha`."
       - name: Enable Pull Request Auto Merge


### PR DESCRIPTION
## Description

Sets `base` branch to `alpha` to ensure the changes are added on top of `alpha` as it exists today.

### Deploy Preview

n/a

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
