### PR TITLE
[BD-46] feat: added CSS custom media query transformer

### DIFF
--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -1,5 +1,5 @@
 @import "css/variables";
-@import "css/custom-media";
+@import "css/custom-media-breakpoints";
 @import "functions";
 @import "variables";
 @import "~bootstrap/scss/mixins";

--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -1,4 +1,5 @@
 @import "css/variables";
+@import "css/custom-media";
 @import "functions";
 @import "variables";
 @import "~bootstrap/scss/mixins";

--- a/scss/core/css/custom-media-breakpoints.css
+++ b/scss/core/css/custom-media-breakpoints.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Tue, 21 Feb 2023 18:00:46 GMT
+ * Generated on Fri, 24 Feb 2023 11:38:50 GMT
  */
 
 @custom-media --pgn-size-breakpoint-xs (max-width: 0); 

--- a/scss/core/css/custom-media.css
+++ b/scss/core/css/custom-media.css
@@ -1,0 +1,12 @@
+/**
+ * IMPORTANT: This file is the result of assembling design tokens
+ * Do not edit directly
+ * Generated on Tue, 21 Feb 2023 18:00:46 GMT
+ */
+
+@custom-media --pgn-size-breakpoint-xs (max-width: 0); 
+@custom-media --pgn-size-breakpoint-sm (max-width: 576px); 
+@custom-media --pgn-size-breakpoint-md (max-width: 768px); 
+@custom-media --pgn-size-breakpoint-lg (max-width: 992px); 
+@custom-media --pgn-size-breakpoint-xl (max-width: 1200px); 
+@custom-media --pgn-size-breakpoint-xxl (max-width: 1400px); 

--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -42,6 +42,13 @@ const config = {
             outputReferences: true,
           },
         },
+        {
+          format: 'css/custom-media',
+          destination: 'custom-media.css',
+          options: {
+            outputReferences: true,
+          },
+        },
       ],
       transforms: StyleDictionary.transformGroup.css.filter(item => item !== 'size/rem').concat('color/sass-color-functions', 'str-replace'),
       options: {

--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -43,8 +43,8 @@ const config = {
           },
         },
         {
-          format: 'css/custom-media',
-          destination: 'custom-media.css',
+          format: 'css/custom-media-breakpoints',
+          destination: 'custom-media-breakpoints.css',
           options: {
             outputReferences: true,
           },

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -155,12 +155,12 @@ StyleDictionary.registerFormat({
 });
 
 /**
- * Formatter to generate CSS custom media queries.
+ * Formatter to generate CSS custom media queries for responsive breakpoints.
  * Gets input about existing tokens of the 'size' category,
  * 'breakpoints' subcategory, and generates a CSS custom media queries.
  */
 StyleDictionary.registerFormat({
-  name: 'css/custom-media',
+  name: 'css/custom-media-breakpoints',
   formatter({ dictionary, file }) {
     const { size: { breakpoint } } = dictionary.properties;
 

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -166,8 +166,8 @@ StyleDictionary.registerFormat({
 
     let customMediaVariables = '';
 
-    Object.keys(breakpoint).forEach(key => {
-      customMediaVariables += `@custom-media --${breakpoint[key].name} (max-width: ${breakpoint[key].value}); \n`;
+    Object.values(breakpoint).forEach(item => {
+      customMediaVariables += `@custom-media --${item.name} (max-width: ${item.value}); \n`;
     });
 
     return fileHeader({ file }) + customMediaVariables;

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -154,4 +154,24 @@ StyleDictionary.registerFormat({
   },
 });
 
+/**
+ * Formatter to generate CSS custom media queries.
+ * Gets input about existing tokens of the 'size' category,
+ * 'breakpoints' subcategory, and generates a CSS custom media queries.
+ */
+StyleDictionary.registerFormat({
+  name: 'css/custom-media',
+  formatter({ dictionary, file }) {
+    const { size: { breakpoint } } = dictionary.properties;
+
+    let customMediaVariables = '';
+
+    Object.keys(breakpoint).forEach(key => {
+      customMediaVariables += `@custom-media --${breakpoint[key].name} (max-width: ${breakpoint[key].value}); \n`;
+    });
+
+    return fileHeader({ file }) + customMediaVariables;
+  },
+});
+
 module.exports = StyleDictionary;


### PR DESCRIPTION
## Description

- Ensure we can generate `@custom-media` from design tokens with style-dictionary.
- Ensure we add support for `postcss-custom-media` to @edx/frontend-build's default Webpack configs for all MFEs.

Issue: https://github.com/openedx/paragon/issues/2015

Relative link: [Frontend build](https://github.com/openedx/frontend-build/pull/306)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
