### PR TITLE
build: use tretuna/sync-branches to sync alpha with master

### DIFF
--- a/.github/workflows/sync-master-alpha.yml
+++ b/.github/workflows/sync-master-alpha.yml
@@ -28,4 +28,3 @@ jobs:
         with:
           token: ${{ secrets.requirements_bot_github_token }}
           pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
-          merge-method: squash

--- a/.github/workflows/sync-master-alpha.yml
+++ b/.github/workflows/sync-master-alpha.yml
@@ -1,0 +1,31 @@
+name: Sync alpha with master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - name: Create Pull Request
+        id: cpr
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
+          FROM_BRANCH: master
+          TO_BRANCH: alpha
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.requirements_bot_github_token }}
+          pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
+          merge-method: squash


### PR DESCRIPTION
## Description

Adds a Github Action workflow file for syncing `alpha` with `master` on any commit to `master` (using https://github.com/TreTuna/sync-branches)

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
