### PR TITLE
fix: re-add `build-scss-to-css-map` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "type-check:watch": "npm run type-check -- --watch",
     "build-types": "tsc --emitDeclarationOnly",
     "build-tokens": "node tokens/build-tokens.js --build-dir ./scss/core/css/",
+    "build-scss-to-css-map": "node tokens/map-scss-to-css.js",
     "replace-variables-usage-with-css": "node tokens/replace-variables.js -p src -t usage",
     "replace-variables-definition-with-css": "node tokens/replace-variables.js -p src -t definition"
   },


### PR DESCRIPTION
## Description

In https://github.com/openedx/paragon/tree/alpha#usage, one of the steps is running
```
npm run build-scss-to-css-map # creats scss-to-css-core.json and scss-to-css-components.json 
```
this was giving me a
```
npm ERR! Missing script: "build-scss-to-css-map"
```
error.

It seems it was removed in https://github.com/openedx/paragon/commit/9184d8082e35324d5b00d17529279c6f2912090c, if this was intentional, I will close this PR and make one updating the `README` instead.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
