### PR TITLE
fix: use min-width in custom-media breakpoint definitions

### DIFF
--- a/scss/core/css/custom-media-breakpoints.css
+++ b/scss/core/css/custom-media-breakpoints.css
@@ -1,12 +1,12 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Fri, 24 Feb 2023 11:38:50 GMT
+ * Generated on Sun, 26 Feb 2023 16:21:31 GMT
  */
 
-@custom-media --pgn-size-breakpoint-xs (max-width: 0); 
-@custom-media --pgn-size-breakpoint-sm (max-width: 576px); 
-@custom-media --pgn-size-breakpoint-md (max-width: 768px); 
-@custom-media --pgn-size-breakpoint-lg (max-width: 992px); 
-@custom-media --pgn-size-breakpoint-xl (max-width: 1200px); 
-@custom-media --pgn-size-breakpoint-xxl (max-width: 1400px); 
+@custom-media --pgn-size-breakpoint-xs (min-width: 0);
+@custom-media --pgn-size-breakpoint-sm (min-width: 576px);
+@custom-media --pgn-size-breakpoint-md (min-width: 768px);
+@custom-media --pgn-size-breakpoint-lg (min-width: 992px);
+@custom-media --pgn-size-breakpoint-xl (min-width: 1200px);
+@custom-media --pgn-size-breakpoint-xxl (min-width: 1400px);

--- a/scss/core/css/utility-classes.css
+++ b/scss/core/css/utility-classes.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Fri, 24 Feb 2023 12:30:21 GMT
+ * Generated on Sun, 26 Feb 2023 16:21:31 GMT
  */
 
 .bg-dark {

--- a/scss/core/css/variables.css
+++ b/scss/core/css/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Fri, 24 Feb 2023 12:30:21 GMT
+ * Generated on Sun, 26 Feb 2023 16:21:31 GMT
  */
 
 :root {

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -174,7 +174,7 @@ StyleDictionary.registerFormat({
     let customMediaVariables = '';
 
     Object.values(breakpoint).forEach(item => {
-      customMediaVariables += `@custom-media --${item.name} (max-width: ${item.value}); \n`;
+      customMediaVariables += `@custom-media --${item.name} (min-width: ${item.value});\n`;
     });
 
     return fileHeader({ file }) + customMediaVariables;


### PR DESCRIPTION
## Description

Use `min-width` in custom `css/custom-media-breakpoints` style-dictionary format.

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
