### PR TITLE
fix: onChange behavior for `Form.Autosuggest`

### DIFF
--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -160,13 +160,11 @@ function FormAutosuggest({
     const opt = optValue.find((o) => o.toLowerCase() === normalized);
 
     if (opt) {
-      setValue(opt);
       setState(prevState => ({
         ...prevState,
         displayValue: opt,
       }));
     } else {
-      setValue(null);
       setState(prevState => ({
         ...prevState,
         displayValue: itemValue,


### PR DESCRIPTION
## Description

This PR is to update the `Form.Autosuggest` component.

The `onSelected` function is being called during any `onChange` event. See below:

`onChange` => `setDisplayValue` => `setValue` => `onSelected` — we only want to call `onSelected` when a selection is made, not during every onChange.

Unless the user's input is an exact match for an option, `onSelected` will be passed a `null` value.  Meaning after each character is entered in the input, `onSelected(null)` is called. 

In addition, if "Teacher" is an option, entering the word "teacher" will then call `onSelected("Teacher")` — auto-selecting "Teacher". Technically, the user hasn't actually made the selection at this point. This can lead to unintended results — imagine if "Teacher Assistant" was another option the user wanted to select.

This can be resolved by deleting the lines that call the `setValue` function inside `setDisplayValue`.

If the intent is to have "auto-selection" as an option for the `Autosuggest` component, then perhaps it should be added as an attribute. Developers would have the ability to turn the option on when needed.

#### JIRA
[APER-2298](https://2u-internal.atlassian.net/browse/APER-2298)

#### Github Issue
[`Form.Autosuggest` intended behavior](https://github.com/openedx/paragon/issues/2107)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
