### PR TITLE
chore: cleanup unused i18n MFE pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ build:
 
 export TRANSIFEX_RESOURCE = paragon
 transifex_langs = "ar,ca,es_419,fr,he,id,ko_KR,pl,pt_BR,ru,th,uk,zh_CN"
-i18n = ./src/i18n
-transifex_input = $(i18n)/transifex_input.json
 
 NPM_TESTS=build i18n_extract lint test
 
@@ -36,10 +34,6 @@ i18n.extract:
 
 extract_translations: | requirements i18n.extract
 
-# Despite the name, we actually need this target to detect changes in the incoming translated message files as well.
-detect_changed_source_translations:
-	# Checking for changed translations...
-	git diff --exit-code $(i18n)
 
 # Pushes translations to Transifex.  You must run make extract_translations first.
 push_translations:


### PR DESCRIPTION
## Description

Standard MFE pattern cannot be used in `paragon` since it would introduce circular dependency between paragon and `@edx/frontend-platform`.

This PR cleans up some unused variables in Makefile.

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.
## Merge Checklist

* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
