### PR TITLE
feat: add icon size xs that looks good against a 1rem font

### DIFF
--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -19,9 +19,9 @@ const WrappedButton = React.forwardRef(({
     className={classNames(props.className)}
     ref={ref}
   >
-    {iconBefore && <Icon className={classNames('btn-icon-before', props.size && `pgn__icon__${props.size}`)} src={iconBefore} />}
+    {iconBefore && <Icon className="btn-icon-before" size={props.size} src={iconBefore} />}
     {children}
-    {iconAfter && <Icon className={classNames('btn-icon-after', props.size && `pgn__icon__${props.size}`)} src={iconAfter} />}
+    {iconAfter && <Icon className="btn-icon-after" size={props.size} src={iconAfter} />}
   </Button>
 ));
 

--- a/src/Icon/Icon.scss
+++ b/src/Icon/Icon.scss
@@ -12,6 +12,11 @@
     height: $icon-inline;
   }
 
+  &.pgn__icon__xs {
+    width: $icon-xs;
+    height: $icon-xs;
+  }
+
   &.pgn__icon__sm {
     width: $icon-sm;
     height: $icon-sm;

--- a/src/Icon/README.md
+++ b/src/Icon/README.md
@@ -26,10 +26,10 @@ HTML attributes can be passed to this component allowing for customization of th
 // import { Add, AddCircle } from '@edx/paragon/icons';
 <div className="d-flex align-items-center bg-dark">
   <Icon src={Add} className="mx-3 text-white" />
-  <Icon src={Add} className="mx-3 text-white pgn__icon__xs" />
-  <Icon src={Add} className="mx-3 text-white pgn__icon__sm" />
-  <Icon src={Add} className="mx-3 text-white pgn__icon__md" />
-  <Icon src={Add} className="mx-3 text-white pgn__icon__lg" />
+  <Icon src={Add} className="mx-3 text-white" size="xs" />
+  <Icon src={Add} className="mx-3 text-white" size="sm" />
+  <Icon src={Add} className="mx-3 text-white" size="md" />
+  <Icon src={Add} className="mx-3 text-white" size="lg" />
   <Icon src={Add} className="text-white" style={{ height: '48px', width: '48px' }} />
 </div>
 ```

--- a/src/Icon/README.md
+++ b/src/Icon/README.md
@@ -26,6 +26,10 @@ HTML attributes can be passed to this component allowing for customization of th
 // import { Add, AddCircle } from '@edx/paragon/icons';
 <div className="d-flex align-items-center bg-dark">
   <Icon src={Add} className="mx-3 text-white" />
+  <Icon src={Add} className="mx-3 text-white pgn__icon__xs" />
+  <Icon src={Add} className="mx-3 text-white pgn__icon__sm" />
+  <Icon src={Add} className="mx-3 text-white pgn__icon__md" />
+  <Icon src={Add} className="mx-3 text-white pgn__icon__lg" />
   <Icon src={Add} className="text-white" style={{ height: '48px', width: '48px' }} />
 </div>
 ```

--- a/src/Icon/_variables.scss
+++ b/src/Icon/_variables.scss
@@ -1,6 +1,7 @@
 // Icons sizes
 
 $icon-inline: .8em !default;
+$icon-xs: 1rem !default;
 $icon-sm: 1.25rem !default;
 $icon-md: 1.5rem !default;
 $icon-lg: 1.75rem !default;

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -19,6 +19,7 @@ function Icon({
   hidden,
   screenReaderText,
   svgAttrs,
+  size,
   ...attrs
 }) {
   if (Component) {
@@ -34,7 +35,7 @@ function Icon({
 
     return (
       <span
-        className={classNames('pgn__icon', className)}
+        className={classNames('pgn__icon', { [`pgn__icon__${size}`]: !!size }, className)}
         id={id}
         {...attrs}
       >
@@ -81,6 +82,9 @@ Icon.propTypes = {
   /** the `id` property of the Icon element, by default this value is generated with the `newId` function with the `prefix` of `Icon`. */
   id: PropTypes.string,
   // eslint-disable-next-line max-len
+  /** The size of the icon. */
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+  // eslint-disable-next-line max-len
   /** A class name that will define what the Icon looks like. */
   className: PropTypes.string,
   // eslint-disable-next-line max-len
@@ -98,6 +102,7 @@ Icon.defaultProps = {
   id: undefined,
   hidden: true,
   screenReaderText: undefined,
+  size: undefined,
   className: undefined,
 };
 


### PR DESCRIPTION
## Description

Adds a `size` parameter to the Icon class so that the user can choose from one of the predefined sizes: `xs`, `sm', 'md', `lg`. Updated the button component to use this parameter instead for `iconBefore` and `iconAfter`

### Deploy Preview

- https://deploy-preview-2149--paragon-openedx.netlify.app/components/icon
- https://deploy-preview-2149--paragon-openedx.netlify.app/components/button/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
