### PR TITLE
test: fix coverage for Button class

### DIFF
--- a/src/Button/Button.test.jsx
+++ b/src/Button/Button.test.jsx
@@ -18,6 +18,18 @@ describe('<Button />', () => {
       const tooltip = wrapper.find('.btn');
       expect(tooltip.hasClass('btn-brand')).toEqual(true);
     });
+    it('renders with props iconBefore and size', () => {
+      const tree = renderer.create((
+        <Button iconBefore={Close} size="md">Button</Button>
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it('renders with props iconAfter and size', () => {
+      const tree = renderer.create((
+        <Button iconAfter={Close} size="md">Button</Button>
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
     it('renders with props iconBefore', () => {
       const tree = renderer.create((
         <Button iconBefore={Close}>Button</Button>

--- a/src/Button/ButtonGroup.test.jsx
+++ b/src/Button/ButtonGroup.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Button, { ButtonGroup } from './index';
+
+describe('<ButtonGroup />', () => {
+  describe('correct rendering', () => {
+    it('renders without props', () => {
+      const tree = renderer.create((
+        <ButtonGroup />
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('renders with children', () => {
+      const tree = renderer.create((
+        <ButtonGroup size="lg">
+          <Button variant="primary">Left</Button>
+          <Button variant="primary">Middle</Button>
+          <Button variant="primary">Right</Button>
+        </ButtonGroup>
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/Button/ButtonToolbar.test.jsx
+++ b/src/Button/ButtonToolbar.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { ButtonToolbar } from './index';
+
+describe('<ButtonToolbar />', () => {
+  describe('correct rendering', () => {
+    it('renders without props', () => {
+      const tree = renderer.create((
+        <ButtonToolbar />
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/Button/__snapshots__/Button.test.jsx.snap
+++ b/src/Button/__snapshots__/Button.test.jsx.snap
@@ -53,6 +53,35 @@ exports[`<Button /> correct rendering renders with props iconAfter 1`] = `
 </button>
 `;
 
+exports[`<Button /> correct rendering renders with props iconAfter and size 1`] = `
+<button
+  className="btn btn-primary btn-md"
+  disabled={false}
+  type="button"
+>
+  Button
+  <span
+    className="pgn__icon pgn__icon__md btn-icon-after"
+  >
+    <svg
+      aria-hidden={true}
+      fill="none"
+      focusable={false}
+      height={24}
+      role="img"
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+</button>
+`;
+
 exports[`<Button /> correct rendering renders with props iconBefore 1`] = `
 <button
   className="btn btn-primary"
@@ -127,6 +156,35 @@ exports[`<Button /> correct rendering renders with props iconBefore and iconAfte
       />
     </svg>
   </span>
+</button>
+`;
+
+exports[`<Button /> correct rendering renders with props iconBefore and size 1`] = `
+<button
+  className="btn btn-primary btn-md"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="pgn__icon pgn__icon__md btn-icon-before"
+  >
+    <svg
+      aria-hidden={true}
+      fill="none"
+      focusable={false}
+      height={24}
+      role="img"
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+  Button
 </button>
 `;
 

--- a/src/Button/__snapshots__/ButtonGroup.test.jsx.snap
+++ b/src/Button/__snapshots__/ButtonGroup.test.jsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonGroup /> correct rendering renders with children 1`] = `
+<div
+  className="btn-group btn-group-lg"
+  role="group"
+>
+  <button
+    className="btn btn-primary"
+    disabled={false}
+    type="button"
+  >
+    Left
+  </button>
+  <button
+    className="btn btn-primary"
+    disabled={false}
+    type="button"
+  >
+    Middle
+  </button>
+  <button
+    className="btn btn-primary"
+    disabled={false}
+    type="button"
+  >
+    Right
+  </button>
+</div>
+`;
+
+exports[`<ButtonGroup /> correct rendering renders without props 1`] = `
+<div
+  className="btn-group btn-group-md"
+  role="group"
+/>
+`;

--- a/src/Button/__snapshots__/ButtonToolbar.test.jsx.snap
+++ b/src/Button/__snapshots__/ButtonToolbar.test.jsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonToolbar /> correct rendering renders without props 1`] = `
+<div
+  className="btn-toolbar"
+  role="toolbar"
+/>
+`;

--- a/src/Icon/Icon.test.jsx
+++ b/src/Icon/Icon.test.jsx
@@ -10,6 +10,10 @@ const classNames = [
 ];
 const srTest = 'srTest';
 
+function BlankSrc() {
+  return <div />;
+}
+
 let wrapper;
 
 describe('<Icon />', () => {
@@ -52,6 +56,13 @@ describe('<Icon />', () => {
       expect(iconSpans.length).toEqual(2);
       expect(iconSpans.at(0).prop('id')).toEqual(testId);
       expect(iconSpans.at(1).hasClass('sr-only')).toEqual(true);
+    });
+    it('receives size prop correctly', () => {
+      wrapper = mount(<Icon src={BlankSrc} className={classNames} size="xs" />);
+      const iconSpans = wrapper.find('span');
+      const iconSpan = iconSpans.at(0);
+
+      expect(iconSpan.hasClass('pgn__icon__xs')).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes the decrease in test coverage introduced by https://github.com/openedx/paragon/pull/2149

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
