### PR TITLE
[BD-46] docs: changed text description code editable button in code example

### DIFF
--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -40,9 +40,10 @@ function CollapsibleLiveEditor({ children }: CollapsibleLiveEditorTypes) {
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
       >
         <Collapsible.Trigger tag={Button} variant="link">
-          <Collapsible.Visible whenClosed>Show code example</Collapsible.Visible>
-          <Collapsible.Visible whenOpen>Hide code example</Collapsible.Visible>
+          <Collapsible.Visible whenClosed>Show editable code example</Collapsible.Visible>
+          <Collapsible.Visible whenOpen>Hide editable code example</Collapsible.Visible>
         </Collapsible.Trigger>
+        <p className="small text-gray">Any Paragon component or export may be added to the code example.</p>
         <Collapsible.Body className="mt-2">
           {children}
         </Collapsible.Body>


### PR DESCRIPTION
## Description

- [ ] Replace "Show/hide code example" with "Show/hide editable code example"
- [ ] Add helper text describing the editable live code editor's capability (i.e., `<p className="small text-gray">Any Paragon component or export may be added to the code example.</p>`).

Issue: https://github.com/openedx/paragon/issues/2189

### Deploy Preview

[Paragon](https://deploy-preview-2192--paragon-openedx.netlify.app/components/actionrow/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
