### PR TITLE
[BD-46] docs: new component examples and editable live code blocks

### DIFF
--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -38,13 +38,14 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
   return (
     <div className="pgn-doc__collapsible-live-editor">
+      <p className="small text-gray ml-3.5 mb-1">Any Paragon component or export may be added to the code example.</p>
       <Collapsible
         unmountOnExit={false}
         styling="card-lg"
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
         withIcon
-        title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} code example</strong>}
+        title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} editable code example</strong>}
       >
         {children}
         <IconButton

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -20,10 +20,10 @@ import {
 import { FormattedMessage, useIntl } from 'react-intl';
 import * as ParagonReact from '~paragon-react';
 import * as ParagonIcons from '~paragon-icons';
+import { ContentCopy } from '~paragon-icons';
 import MiyazakiCard from './exampleComponents/MiyazakiCard';
 import HipsterIpsum from './exampleComponents/HipsterIpsum';
 import ExamplePropsForm from './exampleComponents/ExamplePropsForm';
-import { ContentCopy } from '../../../icons';
 
 const {
   Collapsible, Toast, IconButton, Icon,
@@ -38,7 +38,6 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
   return (
     <div className="pgn-doc__collapsible-live-editor">
-      <p className="small text-gray ml-3.5 mb-1">Any Paragon component or export may be added to the code example.</p>
       <Collapsible
         unmountOnExit={false}
         styling="card-lg"
@@ -47,15 +46,18 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
         withIcon
         title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} editable code example</strong>}
       >
-        {children}
-        <IconButton
-          className="pgn-doc__collapsible-live-editor-copy-btn"
-          src={ContentCopy}
-          iconAs={Icon}
-          alt="Copy code example"
-          onClick={clickToCopy}
-          invertColors
-        />
+        <p className="small text-gray mb-2">Any Paragon component or export may be added to the code example.</p>
+        <div className="pgn-doc__collapsible-code-wrapper">
+          {children}
+          <IconButton
+            className="pgn-doc__collapsible-live-editor-copy-btn"
+            src={ContentCopy}
+            iconAs={Icon}
+            alt="Copy code example"
+            onClick={clickToCopy}
+            invertColors
+          />
+        </div>
       </Collapsible>
     </div>
   );

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -39,6 +39,7 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
   return (
     <div className="pgn-doc__collapsible-live-editor">
       <Collapsible
+        unmountOnExit={false}
         styling="card-lg"
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
@@ -78,7 +79,7 @@ function CodeBlock({
   const language: any = className ? className.replace(/language-/, '') : 'jsx';
   const [showToast, setShowToast] = useState(false);
 
-  const isCodeSnippetCopied = () => {
+  const isCodeExampleCopied = () => {
     navigator.clipboard.writeText(children);
     setShowToast(true);
   };
@@ -112,7 +113,7 @@ function CodeBlock({
           theme={theme}
         >
           <LivePreview className="pgn-doc__code-block-preview" />
-          <CollapsibleLiveEditor clickToCopy={isCodeSnippetCopied}>
+          <CollapsibleLiveEditor clickToCopy={isCodeExampleCopied}>
             <LiveEditor className="pgn-doc__code-block-editor" />
           </CollapsibleLiveEditor>
           <LiveError className="pgn-doc__code-block-error" />
@@ -122,7 +123,7 @@ function CodeBlock({
           show={showToast}
           delay={2000}
         >
-          Code snippet copied to clipboard!
+          Code example copied to clipboard!
         </Toast>
       </div>
     );

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -23,30 +23,38 @@ import * as ParagonIcons from '~paragon-icons';
 import MiyazakiCard from './exampleComponents/MiyazakiCard';
 import HipsterIpsum from './exampleComponents/HipsterIpsum';
 import ExamplePropsForm from './exampleComponents/ExamplePropsForm';
+import { ContentCopy } from '../../../icons';
 
-const { Button, Collapsible } = ParagonReact;
+const {
+  Collapsible, Toast, IconButton, Icon,
+} = ParagonReact;
 
 export type CollapsibleLiveEditorTypes = {
-  children: React.ReactNode,
+  children: React.ReactNode;
+  clickToCopy: () => void;
 };
 
-function CollapsibleLiveEditor({ children }: CollapsibleLiveEditorTypes) {
+function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorTypes) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
   return (
     <div className="pgn-doc__collapsible-live-editor">
-      <Collapsible.Advanced
-        unmountOnExit={false}
+      <Collapsible
+        styling="card-lg"
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
+        withIcon
+        title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} code example</strong>}
       >
-        <Collapsible.Trigger tag={Button} variant="link">
-          <Collapsible.Visible whenClosed>Show code example</Collapsible.Visible>
-          <Collapsible.Visible whenOpen>Hide code example</Collapsible.Visible>
-        </Collapsible.Trigger>
-        <Collapsible.Body className="mt-2">
-          {children}
-        </Collapsible.Body>
-      </Collapsible.Advanced>
+        {children}
+        <IconButton
+          className="pgn-doc__collapsible-live-editor-copy-btn"
+          src={ContentCopy}
+          iconAs={Icon}
+          alt="Copy code example"
+          onClick={clickToCopy}
+          invertColors
+        />
+      </Collapsible>
     </div>
   );
 }
@@ -68,6 +76,12 @@ function CodeBlock({
 }: ICodeBlock) {
   const intl = useIntl();
   const language: any = className ? className.replace(/language-/, '') : 'jsx';
+  const [showToast, setShowToast] = useState(false);
+
+  const isCodeSnippetCopied = () => {
+    navigator.clipboard.writeText(children);
+    setShowToast(true);
+  };
 
   if (live) {
     return (
@@ -98,11 +112,18 @@ function CodeBlock({
           theme={theme}
         >
           <LivePreview className="pgn-doc__code-block-preview" />
-          <CollapsibleLiveEditor>
+          <CollapsibleLiveEditor clickToCopy={isCodeSnippetCopied}>
             <LiveEditor className="pgn-doc__code-block-editor" />
           </CollapsibleLiveEditor>
           <LiveError className="pgn-doc__code-block-error" />
         </LiveProvider>
+        <Toast
+          onClose={() => setShowToast(false)}
+          show={showToast}
+          delay={2000}
+        >
+          Code snippet copied to clipboard!
+        </Toast>
       </div>
     );
   }

--- a/www/src/components/_CodeBlock.scss
+++ b/www/src/components/_CodeBlock.scss
@@ -22,13 +22,13 @@
     margin: 0;
   }
 
-  .collapsible-body.collapse.show {
+  .pgn-doc__collapsible-code-wrapper {
     position: relative;
 
     .pgn-doc__collapsible-live-editor-copy-btn {
       position: absolute;
-      top: map-get($spacers, 4);
-      right: 2rem;
+      top: map-get($spacers, 2);
+      right: map-get($spacers, 2);
     }
   }
 }

--- a/www/src/components/_CodeBlock.scss
+++ b/www/src/components/_CodeBlock.scss
@@ -1,26 +1,30 @@
 .pgn-doc__code-block {
-  margin: 1rem 0 2rem;
-
-  // border: solid 2px $light-300;
+  margin: $spacer 0 2rem;
+  background-color: $light-200;
+  border: solid 2px $light-300;
   border-radius: $border-radius;
-}
 
-.pgn-doc__code-block-preview {
-  padding-bottom: 1rem;
-}
+  .pgn-doc__code-block-preview {
+    padding: $spacer;
+  }
 
-.pgn-doc__code-block-editor,
-.prism-code {
-  font-size: $font-size-base;
-  font-family: monospace;
+  .pgn-doc__code-block-editor,
+  .prism-code {
+    font-size: $font-size-base;
+    font-family: monospace;
+    border-radius: $input-border-radius;
+  }
 
-  // box-shadow: 1px 0 0 0 #282632, -1px 0 0 0 #282632;
-  border-radius: $input-border-radius;
-}
+  .pgn-doc__code-block-error {
+    background-color: $warning-200;
+    padding: $spacer;
+    font-size: $font-size-sm;
+    margin: 0;
+  }
 
-.pgn-doc__code-block-error {
-  background: $warning-200;
-  padding: 1rem;
-  font-size: $font-size-sm;
-  margin: 0;
+  .pgn-transition-replace-group .pgn-doc__collapsible-live-editor-copy-btn {
+    position: absolute;
+    top: map-get($spacers, 4);
+    right: 2rem;
+  }
 }

--- a/www/src/components/_CodeBlock.scss
+++ b/www/src/components/_CodeBlock.scss
@@ -22,9 +22,13 @@
     margin: 0;
   }
 
-  .pgn-transition-replace-group .pgn-doc__collapsible-live-editor-copy-btn {
-    position: absolute;
-    top: map-get($spacers, 4);
-    right: 2rem;
+  .collapsible-body.collapse.show {
+    position: relative;
+
+    .pgn-doc__collapsible-live-editor-copy-btn {
+      position: absolute;
+      top: map-get($spacers, 4);
+      right: 2rem;
+    }
   }
 }


### PR DESCRIPTION
## Description

- [x] Ensure rendered components for each live code blocks are rendered on a light background (e.g., gray-200, light-200) to more clearly delineate where the code examples are on the page.
- [x]  Ensure collapsible for showing the live code editor is rendered as the large card style (i.e., styling="card-lg").
- [x] Ensure an icon (default Collapsible icon is likely fine) is rendered as an affordance to indicate that the live code block may be collapsed/expanded.
- [x]  Discovery: make a recommendation for implementing a "Copy" to clipboard (icon)button for live code blocks to allow engineers/consumers to more easily copy/paste from the component code snippets on the docs site. If implemented, ensure it gets a Segment event when clicked where the event name follows the same convention as other Segment event names throughout the docs site.

Issue: https://github.com/openedx/paragon/issues/1981

### Deploy Preview

[Paragon](https://deploy-preview-2194--paragon-openedx.netlify.app/components/actionrow/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
