### PR TITLE
[BD-46] fix: fixed misaligned form validation text with icon

### DIFF
--- a/src/Form/_FormText.scss
+++ b/src/Form/_FormText.scss
@@ -7,6 +7,7 @@
     margin-inline-end: .25em;
     width: 1em;
     display: inline-block;
+    vertical-align: text-bottom;
   }
 
   & ~ .pgn__form-text {

--- a/src/Form/_FormText.scss
+++ b/src/Form/_FormText.scss
@@ -1,5 +1,6 @@
 .pgn__form-text {
   font-size: $small-font-size;
+  display: flex;
   align-items: center;
 
   .pgn__icon {
@@ -7,7 +8,6 @@
     margin-inline-end: .25em;
     width: 1em;
     display: inline-block;
-    vertical-align: text-bottom;
   }
 
   & ~ .pgn__form-text {


### PR DESCRIPTION
## Description

The Form.Group component allows you to include a form validation message under the Form.Control. However, the icon (either an "X" or a check) is not vertically aligned with each other (in both Open edX theme and edX.org theme).

Issue: https://github.com/openedx/paragon/issues/2197

### Deploy Preview

[Form.Group component](https://deploy-preview-2202--paragon-openedx.netlify.app/components/form/form-group/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
