### PR TITLE
fix: wrap FormText children in div for flex styling

### DIFF
--- a/src/Form/FormText.jsx
+++ b/src/Form/FormText.jsx
@@ -66,7 +66,9 @@ function FormText({
   return (
     <div {...props} className={className}>
       {hasIcon && <FormTextIcon customIcon={icon} type={type} />}
-      {children}
+      <div>
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

**Before**

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/2828721/233725204-1b108f27-79c0-42e4-b5e4-336344462b4c.png">

**After**

<img width="972" alt="image" src="https://user-images.githubusercontent.com/2828721/233725035-59ff2b59-ef39-40d1-af54-e83cbe05c768.png">

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
