### PR TITLE
[BD-46] fix: stretch the message block to the full width

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -417,12 +417,12 @@ a .pgn__card {
   line-height: 1.5rem;
   text-align: start;
   position: relative;
-  padding: 1.5rem;
+  padding: $card-spacer-y $card-spacer-x;
   border: 0 solid transparent;
-  border-radius: 0 0 .375rem .375rem;
+  border-radius: 0 0 $card-border-radius $card-border-radius;
 
   .pgn__card-status__message-content {
-    width: 100%;
+    flex-grow: 1;
 
     & > :last-child {
       margin-bottom: 0;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -422,6 +422,8 @@ a .pgn__card {
   border-radius: 0 0 .375rem .375rem;
 
   .pgn__card-status__message-content {
+    width: 100%;
+
     & > :last-child {
       margin-bottom: 0;
     }


### PR DESCRIPTION
## Description

Add stretching the message block to the full width

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [x] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [x] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [x] 🎉 🙌 Celebrate! Thanks for your contribution.
