### PR TITLE
[BD-46] fix: revert PopperElement changes

### DIFF
--- a/src/Modal/PopperElement.jsx
+++ b/src/Modal/PopperElement.jsx
@@ -10,7 +10,7 @@ function PopperElement({
   const {
     styles,
     attributes,
-  } = usePopper(target?.current, popperElement, popperOptions);
+  } = usePopper(target, popperElement, popperOptions);
 
   if (!target) {
     return null;

--- a/src/Modal/PopperElement.test.jsx
+++ b/src/Modal/PopperElement.test.jsx
@@ -45,7 +45,7 @@ describe('<PopperElement />', () => {
       </PopperElement>
     ));
     const popperEl = wrapper.find('[data-test="someValue"]');
-    expect(usePopper).toHaveBeenCalledWith(targetRef.current, null, defaultPopperOptions);
+    expect(usePopper).toHaveBeenCalledWith(targetRef, null, defaultPopperOptions);
     expect(popperEl.length).toBe(1);
     expect(popperEl.props().style.someProperty).toBe('someValue');
   });


### PR DESCRIPTION
## Description

Changes in #2226 broke `ModalPopup` positioning.
![image](https://user-images.githubusercontent.com/52399399/234946233-6842d885-9c6f-44d0-b074-fe6203f55027.png)

Reverting them to fix it.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
