### PR TITLE
[BD-46] docs: renamed code example Segment event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2489,9 +2489,9 @@
       }
     },
     "node_modules/@edx/brand-edx.org": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.1.tgz",
-      "integrity": "sha512-5W9aqss8NTGYUWuBDbxSGs4l6ysSv7ExPFFtNXVFten+Osh5gnGQ+KcvRbkEQhcqFuYNz3QUD72C9Q1axCs/MQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.2.tgz",
+      "integrity": "sha512-pBhUuegRg+2k63LWe3vyQDCdAiWTduaJ3hpHWqLZC3wYYyAyour6VGUbS1m9kg3+BmLz6AZR9P10BXT0iso6XQ=="
     },
     "node_modules/@edx/brand-openedx": {
       "version": "1.2.0",
@@ -44105,7 +44105,7 @@
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.1.0",
-        "@edx/brand-edx.org": "^2.0.6",
+        "@edx/brand-edx.org": "^2.1.2",
         "@edx/brand-openedx": "^1.1.0",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@mdx-js/mdx": "^1.6.22",
@@ -45796,9 +45796,9 @@
       }
     },
     "@edx/brand-edx.org": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.1.tgz",
-      "integrity": "sha512-5W9aqss8NTGYUWuBDbxSGs4l6ysSv7ExPFFtNXVFten+Osh5gnGQ+KcvRbkEQhcqFuYNz3QUD72C9Q1axCs/MQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.2.tgz",
+      "integrity": "sha512-pBhUuegRg+2k63LWe3vyQDCdAiWTduaJ3hpHWqLZC3wYYyAyour6VGUbS1m9kg3+BmLz6AZR9P10BXT0iso6XQ=="
     },
     "@edx/brand-openedx": {
       "version": "1.2.0",
@@ -69497,7 +69497,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
         "@docsearch/react": "^3.1.0",
-        "@edx/brand-edx.org": "^2.0.6",
+        "@edx/brand-edx.org": "^2.1.2",
         "@edx/brand-openedx": "^1.1.0",
         "@edx/eslint-config": "^3.1.0",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",

--- a/www/package.json
+++ b/www/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@docsearch/react": "^3.1.0",
-    "@edx/brand-edx.org": "^2.0.6",
+    "@edx/brand-edx.org": "^2.1.2",
     "@edx/brand-openedx": "^1.1.0",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@mdx-js/mdx": "^1.6.22",

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -63,14 +63,14 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
     const headingElement = getCodeBlockHeading(e.target);
 
     if (!headingElement) {
-      global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'closed' : 'opened'}`, {
+      global.analytics.track(`openedx.paragon.docs.ui.example-code-block.${collapseIsOpen ? 'closed' : 'opened'}`, {
         value: `${componentNameAndCategory}id-not-generated`,
       });
 
       return;
     }
 
-    global.analytics.track(`openedx.ui.example-code-block.${collapseIsOpen ? 'closed' : 'opened'}`, {
+    global.analytics.track(`openedx.paragon.docs.ui.example-code-block.${collapseIsOpen ? 'closed' : 'opened'}`, {
       value: `${componentNameAndCategory}${headingElement.id}`,
     });
   };


### PR DESCRIPTION
## Description

- Rename `openedx.ui.example-code-block.{closed|opened}` Segment event to `openedx.paragon.docs.ui.example-code-block.{closed|opened}`

Issue: https://github.com/openedx/paragon/issues/2261

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
