### PR TITLE
[BD-46] fix: fixed Copy code example button

### DIFF
--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -32,12 +32,11 @@ const {
 export type CollapsibleLiveEditorTypes = {
   children: React.ReactNode;
   clickToCopy: (arg: string) => void;
-  defaultCodeExample: string;
+  handleCodeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
-function CollapsibleLiveEditor({ children, clickToCopy, defaultCodeExample }: CollapsibleLiveEditorTypes) {
+function CollapsibleLiveEditor({ children, clickToCopy, handleCodeChange }: CollapsibleLiveEditorTypes) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
-  const [codeExample, setCodeExample] = useState(defaultCodeExample);
 
   const getCodeBlockHeading = (element: HTMLElement): HTMLHeadElement | null => {
     const codeBlockWrapper = element.closest<HTMLDivElement>('.pgn-doc__code-block');
@@ -57,10 +56,6 @@ function CollapsibleLiveEditor({ children, clickToCopy, defaultCodeExample }: Co
     }
 
     return node;
-  };
-
-  const handleChange = (e) => {
-    setCodeExample(e.target.value);
   };
 
   const submitSegmentEvent = (e: React.MouseEvent & { target: HTMLElement }) => {
@@ -88,7 +83,7 @@ function CollapsibleLiveEditor({ children, clickToCopy, defaultCodeExample }: Co
         styling="card-lg"
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
-        onChange={handleChange}
+        onChange={handleCodeChange}
         onClick={submitSegmentEvent}
         title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} editable code example</strong>}
       >
@@ -100,7 +95,7 @@ function CollapsibleLiveEditor({ children, clickToCopy, defaultCodeExample }: Co
             src={ContentCopy}
             iconAs={Icon}
             alt="Copy code example"
-            onClick={() => clickToCopy(codeExample)}
+            onClick={clickToCopy}
             invertColors
           />
         </div>
@@ -108,10 +103,6 @@ function CollapsibleLiveEditor({ children, clickToCopy, defaultCodeExample }: Co
     </div>
   );
 }
-
-CollapsibleLiveEditor.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export interface ICodeBlock {
   children: string,
@@ -127,8 +118,11 @@ function CodeBlock({
   const intl = useIntl();
   const language: any = className ? className.replace(/language-/, '') : 'jsx';
   const [showToast, setShowToast] = useState(false);
+  const [codeExample, setCodeExample] = useState(children);
 
-  const isCodeExampleCopied = (codeExample: string) => {
+  const handleCodeChange = (e) => setCodeExample(e.target.value);
+
+  const handleCopyCodeExample = () => {
     navigator.clipboard.writeText(codeExample);
     setShowToast(true);
   };
@@ -137,7 +131,7 @@ function CodeBlock({
     return (
       <div className="pgn-doc__code-block">
         <LiveProvider
-          code={children}
+          code={codeExample}
           scope={{
             ...ParagonIcons,
             ...ParagonReact,
@@ -162,7 +156,7 @@ function CodeBlock({
           theme={theme}
         >
           <LivePreview className="pgn-doc__code-block-preview" />
-          <CollapsibleLiveEditor defaultCodeExample={children} clickToCopy={isCodeExampleCopied}>
+          <CollapsibleLiveEditor handleCodeChange={handleCodeChange} clickToCopy={handleCopyCodeExample}>
             <LiveEditor className="pgn-doc__code-block-editor" />
           </CollapsibleLiveEditor>
           <LiveError className="pgn-doc__code-block-error" />

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -31,11 +31,13 @@ const {
 
 export type CollapsibleLiveEditorTypes = {
   children: React.ReactNode;
-  clickToCopy: () => void;
+  clickToCopy: (arg: string) => void;
+  defaultCodeExample: string;
 };
 
-function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorTypes) {
+function CollapsibleLiveEditor({ children, clickToCopy, defaultCodeExample }: CollapsibleLiveEditorTypes) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
+  const [codeExample, setCodeExample] = useState(defaultCodeExample);
 
   const getCodeBlockHeading = (element: HTMLElement): HTMLHeadElement | null => {
     const codeBlockWrapper = element.closest<HTMLDivElement>('.pgn-doc__code-block');
@@ -55,6 +57,10 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
     }
 
     return node;
+  };
+
+  const handleChange = (e) => {
+    setCodeExample(e.target.value);
   };
 
   const submitSegmentEvent = (e: React.MouseEvent & { target: HTMLElement }) => {
@@ -82,6 +88,7 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
         styling="card-lg"
         open={collapseIsOpen}
         onToggle={(isOpen: boolean) => setCollapseIsOpen(isOpen)}
+        onChange={handleChange}
         onClick={submitSegmentEvent}
         title={<strong>{collapseIsOpen ? 'Hide' : 'Show'} editable code example</strong>}
       >
@@ -93,7 +100,7 @@ function CollapsibleLiveEditor({ children, clickToCopy }: CollapsibleLiveEditorT
             src={ContentCopy}
             iconAs={Icon}
             alt="Copy code example"
-            onClick={clickToCopy}
+            onClick={() => clickToCopy(codeExample)}
             invertColors
           />
         </div>
@@ -121,8 +128,8 @@ function CodeBlock({
   const language: any = className ? className.replace(/language-/, '') : 'jsx';
   const [showToast, setShowToast] = useState(false);
 
-  const isCodeExampleCopied = () => {
-    navigator.clipboard.writeText(children);
+  const isCodeExampleCopied = (codeExample: string) => {
+    navigator.clipboard.writeText(codeExample);
     setShowToast(true);
   };
 
@@ -155,7 +162,7 @@ function CodeBlock({
           theme={theme}
         >
           <LivePreview className="pgn-doc__code-block-preview" />
-          <CollapsibleLiveEditor clickToCopy={isCodeExampleCopied}>
+          <CollapsibleLiveEditor defaultCodeExample={children} clickToCopy={isCodeExampleCopied}>
             <LiveEditor className="pgn-doc__code-block-editor" />
           </CollapsibleLiveEditor>
           <LiveError className="pgn-doc__code-block-error" />


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2263

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
