### PR TITLE
docs: add ability to use icons in the Playground

### DIFF
--- a/www/playroom.config.js
+++ b/www/playroom.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   baseUrl: '/playroom/',
-  components: '../src',
+  components: './playroom/components.js',
   outputPath: './public/playroom',
   frameComponent: './playroom/FrameComponent.jsx',
   themes: './playroom/themes.js',

--- a/www/playroom/components.js
+++ b/www/playroom/components.js
@@ -1,0 +1,26 @@
+const components = require('../../src');
+
+// Some icons have the same names as Paragon's components,
+// so we rename them here first before exporting to playroom
+const {
+  Badge: BadgeIcon,
+  CheckBox: CheckBoxIcon,
+  Image: ImageIcon,
+  Input: InputIcon,
+  Menu: MenuIcon,
+  Spinner: SpinnerIcon,
+  Tab: TabIcon,
+  ...restIcons
+} = require('../../icons');
+
+module.exports = {
+  BadgeIcon,
+  CheckBoxIcon,
+  InputIcon,
+  ImageIcon,
+  MenuIcon,
+  SpinnerIcon,
+  TabIcon,
+  ...restIcons,
+  ...components,
+};


### PR DESCRIPTION
## Description

Adds all of Paragon's icons to the Playground

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
