### PR TITLE
feat: add `enableEqualColumnHeights` prop to `CardGrid` and `CardDeck`

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -68,7 +68,7 @@ a .pgn__card {
     display: flex;
     flex: 1 0 auto;
 
-    &.pgn__card__disable-equal-height {
+    &.pgn__card__disable-equal-column-heights {
       display: block;
     }
   }

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -67,6 +67,10 @@ a .pgn__card {
   .row > div[class*="col-"] {
     display: flex;
     flex: 1 0 auto;
+
+    &.pgn__card__disable-equal-height {
+      display: block;
+    }
   }
 }
 

--- a/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
+++ b/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
@@ -99,7 +99,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -147,7 +147,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -195,7 +195,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -243,7 +243,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -291,7 +291,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -445,7 +445,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -493,7 +493,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -541,7 +541,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -589,7 +589,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -637,7 +637,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -780,7 +780,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -828,7 +828,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -876,7 +876,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -924,7 +924,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -972,7 +972,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"

--- a/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
+++ b/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
@@ -99,7 +99,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -147,7 +147,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -195,7 +195,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -243,7 +243,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -291,7 +291,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -445,7 +445,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -493,7 +493,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -541,7 +541,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -589,7 +589,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -637,7 +637,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -780,7 +780,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -828,7 +828,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -876,7 +876,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -924,7 +924,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -972,7 +972,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"

--- a/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
+++ b/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
@@ -99,7 +99,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -147,7 +147,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -195,7 +195,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -243,7 +243,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -291,7 +291,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -445,7 +445,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -493,7 +493,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -541,7 +541,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -589,7 +589,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -637,7 +637,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -780,7 +780,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
         tabIndex={0}
       >
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -828,7 +828,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -876,7 +876,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -924,7 +924,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"
@@ -972,7 +972,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
           </div>
         </div>
         <div
-          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+          className="pgn__overflow-scroll-item pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
         >
           <div
             className="pgn__card pgn__card-light card"

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -13,7 +13,7 @@ const CardDeck = React.forwardRef(({
   hasInteractiveChildren,
   canScrollHorizontal,
   hasOverflowScrollItems,
-  disableEqualHeight,
+  hasEqualColumnHeights,
 }, ref) => {
   const cards = useMemo(
     () => Children.map(children, (card) => (
@@ -22,14 +22,14 @@ const CardDeck = React.forwardRef(({
         className={classNames(
           'pgn__card-deck__card-item',
           {
-            'pgn__card__disable-equal-height': disableEqualHeight,
+            'pgn__card__disable-equal-height': !hasEqualColumnHeights,
           },
         )}
       >
         {card}
       </Col>
     )),
-    [children, columnSizes, disableEqualHeight],
+    [children, columnSizes, hasEqualColumnHeights],
   );
   const overflowCardDeckItems = useOverflowScrollItems(cards);
 
@@ -86,7 +86,7 @@ CardDeck.propTypes = {
    * each child a known/stable CSS classname */
   hasOverflowScrollItems: PropTypes.bool,
   /** Whether to disable the default equal height cards across rows in the card grid */
-  disableEqualHeight: PropTypes.bool,
+  hasEqualColumnHeights: PropTypes.bool,
 };
 
 CardDeck.defaultProps = {
@@ -99,7 +99,7 @@ CardDeck.defaultProps = {
   hasInteractiveChildren: false,
   canScrollHorizontal: true,
   hasOverflowScrollItems: false,
-  disableEqualHeight: false,
+  hasEqualColumnHeights: false,
 };
 
 CardDeck.Deprecated = BaseCardDeck;

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -22,7 +22,7 @@ const CardDeck = React.forwardRef(({
         className={classNames(
           'pgn__card-deck__card-item',
           {
-            'pgn__card__disable-equal-height': !hasEqualColumnHeights,
+            'pgn__card__disable-equal-column-heights': !hasEqualColumnHeights,
           },
         )}
       >

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -16,23 +16,19 @@ const CardDeck = React.forwardRef(({
   disableEqualHeight,
 }, ref) => {
   const cards = useMemo(
-    () => Children.map(children, (card) => {
-      const { className: cardClassName } = card.props;
-      return (
-        <Col
-          {...columnSizes}
-          className={classNames(
-            'pgn__card-deck__card-item',
-            cardClassName,
-            {
-              'pgn__card__disable-equal-height': disableEqualHeight,
-            },
-          )}
-        >
-          {card}
-        </Col>
-      );
-    }),
+    () => Children.map(children, (card) => (
+      <Col
+        {...columnSizes}
+        className={classNames(
+          'pgn__card-deck__card-item',
+          {
+            'pgn__card__disable-equal-height': disableEqualHeight,
+          },
+        )}
+      >
+        {card}
+      </Col>
+    )),
     [children, columnSizes, disableEqualHeight],
   );
   const overflowCardDeckItems = useOverflowScrollItems(cards);

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -85,7 +85,7 @@ CardDeck.propTypes = {
   /** Whether the children of CardDeck should be processed by `useOverflowScrollItems` to give
    * each child a known/stable CSS classname */
   hasOverflowScrollItems: PropTypes.bool,
-  /** Whether to disable the default equal height cards across rows in the card grid */
+  /** Whether to disable the default equal height cards */
   hasEqualColumnHeights: PropTypes.bool,
 };
 
@@ -99,7 +99,7 @@ CardDeck.defaultProps = {
   hasInteractiveChildren: false,
   canScrollHorizontal: true,
   hasOverflowScrollItems: false,
-  hasEqualColumnHeights: false,
+  hasEqualColumnHeights: true,
 };
 
 CardDeck.Deprecated = BaseCardDeck;

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -6,8 +6,6 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import { useOverflowScrollItems } from '../OverflowScroll';
 
-export const CARD_DECK_ITEM_CLASS_NAME = 'pgn__card-deck-card-item';
-
 const CardDeck = React.forwardRef(({
   className,
   children,
@@ -15,14 +13,27 @@ const CardDeck = React.forwardRef(({
   hasInteractiveChildren,
   canScrollHorizontal,
   hasOverflowScrollItems,
+  disableEqualHeight,
 }, ref) => {
   const cards = useMemo(
-    () => Children.map(Children.toArray(children), child => (
-      <Col className={classNames(CARD_DECK_ITEM_CLASS_NAME, child.props.className)} {...columnSizes}>
-        {child}
-      </Col>
-    )),
-    [children, columnSizes],
+    () => Children.map(children, (card) => {
+      const { className: cardClassName } = card.props;
+      return (
+        <Col
+          {...columnSizes}
+          className={classNames(
+            'pgn__card-deck__card-item',
+            cardClassName,
+            {
+              'pgn__card__disable-equal-height': disableEqualHeight,
+            },
+          )}
+        >
+          {card}
+        </Col>
+      );
+    }),
+    [children, columnSizes, disableEqualHeight],
   );
   const overflowCardDeckItems = useOverflowScrollItems(cards);
 
@@ -78,6 +89,8 @@ CardDeck.propTypes = {
   /** Whether the children of CardDeck should be processed by `useOverflowScrollItems` to give
    * each child a known/stable CSS classname */
   hasOverflowScrollItems: PropTypes.bool,
+  /** Whether to disable the default equal height cards across rows in the card grid */
+  disableEqualHeight: PropTypes.bool,
 };
 
 CardDeck.defaultProps = {
@@ -90,6 +103,7 @@ CardDeck.defaultProps = {
   hasInteractiveChildren: false,
   canScrollHorizontal: true,
   hasOverflowScrollItems: false,
+  disableEqualHeight: false,
 };
 
 CardDeck.Deprecated = BaseCardDeck;

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -11,11 +11,23 @@ function CardGrid({
   disableEqualHeight,
 }) {
   const cards = useMemo(
-    () => React.Children.map(children, card => (
-      <Col {...columnSizes} className={classNames({ 'pgn__card__disable-equal-height': disableEqualHeight })}>
-        {card}
-      </Col>
-    )),
+    () => React.Children.map(children, (card) => {
+      const { className: cardClassName } = card.props;
+      return (
+        <Col
+          {...columnSizes}
+          className={classNames(
+            'pgn__card-grid__card-item',
+            cardClassName,
+            {
+              'pgn__card__disable-equal-height': disableEqualHeight,
+            },
+          )}
+        >
+          {card}
+        </Col>
+      );
+    }),
     [children, columnSizes, disableEqualHeight],
   );
 

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -17,7 +17,7 @@ function CardGrid({
         className={classNames(
           'pgn__card-grid__card-item',
           {
-            'pgn__card__disable-equal-height': !hasEqualColumnHeights,
+            'pgn__card__disable-equal-column-heights': !hasEqualColumnHeights,
           },
         )}
       >

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -8,15 +8,15 @@ function CardGrid({
   className,
   children,
   columnSizes,
-  disableEqualHeightCards,
+  disableEqualHeight,
 }) {
   const cards = useMemo(
     () => React.Children.map(children, card => (
-      <Col {...columnSizes} className={classNames({ 'pgn__card__disable-equal-height': disableEqualHeightCards })}>
+      <Col {...columnSizes} className={classNames({ 'pgn__card__disable-equal-height': disableEqualHeight })}>
         {card}
       </Col>
     )),
-    [children, columnSizes, disableEqualHeightCards],
+    [children, columnSizes, disableEqualHeight],
   );
 
   return (
@@ -45,7 +45,7 @@ CardGrid.propTypes = {
     xl: PropTypes.number,
   }),
   /** Whether to disable the default equal height cards across rows in the card grid */
-  disableEqualHeightCards: PropTypes.bool,
+  disableEqualHeight: PropTypes.bool,
 };
 
 CardGrid.defaultProps = {
@@ -55,7 +55,7 @@ CardGrid.defaultProps = {
     lg: 6,
     xl: 4,
   },
-  disableEqualHeightCards: false,
+  disableEqualHeight: false,
 };
 
 export default CardGrid;

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -63,7 +63,7 @@ CardGrid.defaultProps = {
     lg: 6,
     xl: 4,
   },
-  hasEqualColumnHeights: false,
+  hasEqualColumnHeights: true,
 };
 
 export default CardGrid;

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -11,23 +11,19 @@ function CardGrid({
   disableEqualHeight,
 }) {
   const cards = useMemo(
-    () => React.Children.map(children, (card) => {
-      const { className: cardClassName } = card.props;
-      return (
-        <Col
-          {...columnSizes}
-          className={classNames(
-            'pgn__card-grid__card-item',
-            cardClassName,
-            {
-              'pgn__card__disable-equal-height': disableEqualHeight,
-            },
-          )}
-        >
-          {card}
-        </Col>
-      );
-    }),
+    () => React.Children.map(children, (card) => (
+      <Col
+        {...columnSizes}
+        className={classNames(
+          'pgn__card-grid__card-item',
+          {
+            'pgn__card__disable-equal-height': disableEqualHeight,
+          },
+        )}
+      >
+        {card}
+      </Col>
+    )),
     [children, columnSizes, disableEqualHeight],
   );
 

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -8,14 +8,15 @@ function CardGrid({
   className,
   children,
   columnSizes,
+  disableEqualHeightCards,
 }) {
   const cards = useMemo(
     () => React.Children.map(children, card => (
-      <Col {...columnSizes}>
+      <Col {...columnSizes} className={classNames({ 'pgn__card__disable-equal-height': disableEqualHeightCards })}>
         {card}
       </Col>
     )),
-    [children, columnSizes],
+    [children, columnSizes, disableEqualHeightCards],
   );
 
   return (
@@ -43,6 +44,8 @@ CardGrid.propTypes = {
     lg: PropTypes.number,
     xl: PropTypes.number,
   }),
+  /** Whether to disable the default equal height cards across rows in the card grid */
+  disableEqualHeightCards: PropTypes.bool,
 };
 
 CardGrid.defaultProps = {
@@ -52,6 +55,7 @@ CardGrid.defaultProps = {
     lg: 6,
     xl: 4,
   },
+  disableEqualHeightCards: false,
 };
 
 export default CardGrid;

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -8,7 +8,7 @@ function CardGrid({
   className,
   children,
   columnSizes,
-  disableEqualHeight,
+  hasEqualColumnHeights,
 }) {
   const cards = useMemo(
     () => React.Children.map(children, (card) => (
@@ -17,14 +17,14 @@ function CardGrid({
         className={classNames(
           'pgn__card-grid__card-item',
           {
-            'pgn__card__disable-equal-height': disableEqualHeight,
+            'pgn__card__disable-equal-height': !hasEqualColumnHeights,
           },
         )}
       >
         {card}
       </Col>
     )),
-    [children, columnSizes, disableEqualHeight],
+    [children, columnSizes, hasEqualColumnHeights],
   );
 
   return (
@@ -53,7 +53,7 @@ CardGrid.propTypes = {
     xl: PropTypes.number,
   }),
   /** Whether to disable the default equal height cards across rows in the card grid */
-  disableEqualHeight: PropTypes.bool,
+  hasEqualColumnHeights: PropTypes.bool,
 };
 
 CardGrid.defaultProps = {
@@ -63,7 +63,7 @@ CardGrid.defaultProps = {
     lg: 6,
     xl: 4,
   },
-  disableEqualHeight: false,
+  hasEqualColumnHeights: false,
 };
 
 export default CardGrid;

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -721,114 +721,55 @@ all cards in a given row have equal height. Try shrinking the width of your brow
 behavior.
 
 ```jsx live
-<CardGrid
-  columnSizes={{
-    xs: 12,
-    lg: 6,
-    xl: 4,
-  }}
->
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This card has even longer content than the first to 
-      show that equal height action.
-    </Card.Section>
-    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This content is a little bit longer.
-    </Card.Section>
-    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This card has even longer content than the first to 
-      show that equal height action.
-    </Card.Section>
-    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This card has even longer content than the first to 
-      show that equal height action.
-    </Card.Section>
-    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This content is a little bit longer.
-    </Card.Section>
-    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
-  </Card>
-  <Card>
-    <Card.ImageCap
-      src="https://picsum.photos/360/200/"
-      srcAlt="Card image"
-    />
-    <Card.Header
-      title="Card title"
-    />
-    <Card.Section 
-      title="Section title"
-    >
-      This is a wider card with supporting text below as a natural lead-in to 
-      additional content. This card has even longer content than the first to 
-      show that equal height action.
-    </Card.Section>
-    <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
-  </Card>
-</CardGrid>
+() => {
+  const [shouldDisableEqualHeight, setShouldDisableEqualHeight] = useState('false');
+
+  const ExampleCard = () => (
+    <Card>
+      <Card.ImageCap
+        src="https://picsum.photos/360/200/"
+        srcAlt="Card image"
+      />
+      <Card.Header
+        title="Card title"
+      />
+      <Card.Section 
+        title="Section title"
+      >
+        <HipsterIpsum numShortParagraphs={1} />
+      </Card.Section>
+      <Card.Footer textElement={<small className="text-muted">Last updated 3 mins ago</small>} />
+    </Card>
+  );
+
+  return (
+    <>
+      {/* start example form block */}
+      <ExamplePropsForm
+        inputs={[
+          { value: shouldDisableEqualHeight, setValue: setShouldDisableEqualHeight, options: ['true', 'false'], name: 'Disable equal height' },
+        ]}
+      />
+      {/* end example form block */}
+
+      <CardGrid
+        columnSizes={{
+          xs: 12,
+          lg: 6,
+          xl: 4,
+        }}
+        disableEqualHeight={shouldDisableEqualHeight === 'true'}
+      >
+        <ExampleCard />
+        <ExampleCard />
+        <ExampleCard />
+        <ExampleCard />
+        <ExampleCard />
+        <ExampleCard />
+      </CardGrid>
+    </>
+  );
+}
 ```
 
 ## CardDeck

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -722,7 +722,7 @@ behavior.
 
 ```jsx live
 () => {
-  const [shouldDisableEqualHeight, setShouldDisableEqualHeight] = useState('false');
+  const [hasEqualColumnHeights, setHasEqualColumnHeights] = useState('true');
 
   const ExampleCard = () => (
     <Card>
@@ -748,10 +748,10 @@ behavior.
       <ExamplePropsForm
         inputs={[
           {
-            value: shouldDisableEqualHeight,
-            setValue: setShouldDisableEqualHeight,
+            value: hasEqualColumnHeights,
+            setValue: setHasEqualColumnHeights,
             options: ['true', 'false'],
-            name: 'Disable equal card grid height',
+            name: 'Has equal card grid column heights',
           },
         ]}
       />
@@ -763,7 +763,7 @@ behavior.
           lg: 6,
           xl: 4,
         }}
-        disableEqualHeight={shouldDisableEqualHeight === 'true'}
+        hasEqualColumnHeights={hasEqualColumnHeights === 'true'}
       >
         <ExampleCard />
         <ExampleCard />
@@ -786,7 +786,7 @@ For accessibility, if the child `Card` components are interactive (e.g., `isClic
 ```jsx live
 () => {
   const [hasInteractiveChildren, setHasInteractiveChildren] = useState('false');
-  const [shouldDisableEqualHeight, setShouldDisableEqualHeight] = useState('false');
+  const [hasEqualColumnHeights, setHasEqualColumnHeights] = useState('true');
 
   const CardComponent = () => (
     <Card isClickable={hasInteractiveChildren === 'true'}>
@@ -813,10 +813,10 @@ For accessibility, if the child `Card` components are interactive (e.g., `isClic
             name: 'Has interactive children',
           },
           {
-            value: shouldDisableEqualHeight,
-            setValue: setShouldDisableEqualHeight,
+            value: hasEqualColumnHeights,
+            setValue: setHasEqualColumnHeights,
             options: ['true', 'false'],
-            name: 'Disable equal card deck height',
+            name: 'Has equal card deck column heights',
           },
         ]}
       />
@@ -824,7 +824,7 @@ For accessibility, if the child `Card` components are interactive (e.g., `isClic
 
       <CardDeck
         hasInteractiveChildren={hasInteractiveChildren === 'true'}
-        disableEqualHeight={shouldDisableEqualHeight === 'true' }
+        hasEqualColumnHeights={hasEqualColumnHeights === 'true'}
       >
         <CardComponent />
         <CardComponent />

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -747,7 +747,12 @@ behavior.
       {/* start example form block */}
       <ExamplePropsForm
         inputs={[
-          { value: shouldDisableEqualHeight, setValue: setShouldDisableEqualHeight, options: ['true', 'false'], name: 'Disable equal height' },
+          {
+            value: shouldDisableEqualHeight,
+            setValue: setShouldDisableEqualHeight,
+            options: ['true', 'false'],
+            name: 'Disable equal card grid height',
+          },
         ]}
       />
       {/* end example form block */}
@@ -781,6 +786,7 @@ For accessibility, if the child `Card` components are interactive (e.g., `isClic
 ```jsx live
 () => {
   const [hasInteractiveChildren, setHasInteractiveChildren] = useState('false');
+  const [shouldDisableEqualHeight, setShouldDisableEqualHeight] = useState('false');
 
   const CardComponent = () => (
     <Card isClickable={hasInteractiveChildren === 'true'}>
@@ -789,7 +795,7 @@ For accessibility, if the child `Card` components are interactive (e.g., `isClic
         srcAlt="Card image"
       />
       <Card.Header title="Card title" />
-      <Card.Section  title="Section title">
+      <Card.Section>
         <HipsterIpsum numShortParagraphs={1} />
       </Card.Section>
     </Card>
@@ -804,13 +810,22 @@ For accessibility, if the child `Card` components are interactive (e.g., `isClic
             value: hasInteractiveChildren,
             setValue: setHasInteractiveChildren,
             options: ['true', 'false'],
-            name: 'hasInteractiveChildren',
+            name: 'Has interactive children',
+          },
+          {
+            value: shouldDisableEqualHeight,
+            setValue: setShouldDisableEqualHeight,
+            options: ['true', 'false'],
+            name: 'Disable equal card deck height',
           },
         ]}
       />
       {/* end example form block */}
 
-      <CardDeck hasInteractiveChildren={hasInteractiveChildren === 'true'}>
+      <CardDeck
+        hasInteractiveChildren={hasInteractiveChildren === 'true'}
+        disableEqualHeight={shouldDisableEqualHeight === 'true' }
+      >
         <CardComponent />
         <CardComponent />
         <CardComponent />

--- a/src/Card/tests/CardDeck.test.jsx
+++ b/src/Card/tests/CardDeck.test.jsx
@@ -62,4 +62,14 @@ describe('<CardDeck />', () => {
     )).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with disabled equal height', () => {
+    const cardContent = getCardContent();
+    const tree = renderer.create((
+      <CardDeck disableEqualHeight>
+        {cardContent}
+      </CardDeck>
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/Card/tests/CardDeck.test.jsx
+++ b/src/Card/tests/CardDeck.test.jsx
@@ -66,7 +66,7 @@ describe('<CardDeck />', () => {
   it('renders with disabled equal height', () => {
     const cardContent = getCardContent();
     const tree = renderer.create((
-      <CardDeck disableEqualHeight>
+      <CardDeck hasEqualColumnHeights={false}>
         {cardContent}
       </CardDeck>
     )).toJSON();

--- a/src/Card/tests/CardGrid.test.jsx
+++ b/src/Card/tests/CardGrid.test.jsx
@@ -51,7 +51,7 @@ describe('<CardGrid />', () => {
 
     it('renders with disabled equal height', () => {
       const tree = renderer.create((
-        <CardGrid disableEqualHeight>
+        <CardGrid hasEqualColumnHeights={false}>
           {cardContent}
         </CardGrid>
       )).toJSON();

--- a/src/Card/tests/CardGrid.test.jsx
+++ b/src/Card/tests/CardGrid.test.jsx
@@ -48,5 +48,14 @@ describe('<CardGrid />', () => {
       )).toJSON();
       expect(tree).toMatchSnapshot();
     });
+
+    it('renders with disabled equal height', () => {
+      const tree = renderer.create((
+        <CardGrid disableEqualHeight>
+          {cardContent}
+        </CardGrid>
+      )).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
   });
 });

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
     tabIndex={-1}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -57,7 +57,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -105,7 +105,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -153,7 +153,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -201,7 +201,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -261,7 +261,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -309,7 +309,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -357,7 +357,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -405,7 +405,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -453,7 +453,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -513,7 +513,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -561,7 +561,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -609,7 +609,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -657,7 +657,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -705,7 +705,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -765,7 +765,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -813,7 +813,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -861,7 +861,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -909,7 +909,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -957,7 +957,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
     tabIndex={-1}
   >
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -57,7 +57,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -105,7 +105,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -153,7 +153,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -201,7 +201,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -261,7 +261,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -309,7 +309,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -357,7 +357,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -405,7 +405,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -453,7 +453,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -513,7 +513,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck-card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -561,7 +561,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -609,7 +609,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -657,7 +657,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -705,7 +705,259 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck-card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CardDeck /> renders with disabled equal height 1`] = `
+<div
+  className="pgn__card-deck pgn__card-deck-has-horizontal-scroll"
+>
+  <div
+    className="pgn__card-deck-row row"
+    tabIndex={0}
+  >
+    <div
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <div
+            className="pgn__card-footer-text vertical"
+          >
+            <small
+              className="text-muted"
+            >
+              Last updated 3 mins ago
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
     tabIndex={-1}
   >
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -57,7 +57,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -105,7 +105,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -153,7 +153,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -201,7 +201,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -261,7 +261,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -309,7 +309,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -357,7 +357,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -405,7 +405,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -453,7 +453,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -513,7 +513,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -561,7 +561,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -609,7 +609,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -657,7 +657,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -705,7 +705,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
     tabIndex={-1}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -57,7 +57,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -105,7 +105,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -153,7 +153,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -201,7 +201,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card clickable pgn__card-light card"
@@ -261,7 +261,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -309,7 +309,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -357,7 +357,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -405,7 +405,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -453,7 +453,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-deck__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -513,7 +513,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
     tabIndex={0}
   >
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -561,7 +561,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -609,7 +609,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -657,7 +657,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -705,7 +705,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
       </div>
     </div>
     <div
-      className="pgn__card-deck__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-deck__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
     className="row"
   >
     <div
-      className="pgn__card-grid__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-grid__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -63,7 +63,7 @@ exports[`<CardGrid /> Controlled Rendering renders with disabled equal height 1`
     className="row"
   >
     <div
-      className="pgn__card-grid__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-grid__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -118,7 +118,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
     className="row"
   >
     <div
-      className="pgn__card-grid__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-grid__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -55,6 +55,61 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
 </div>
 `;
 
+exports[`<CardGrid /> Controlled Rendering renders with disabled equal height 1`] = `
+<div
+  className="pgn__card-grid"
+>
+  <div
+    className="row"
+  >
+    <div
+      className="pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+    >
+      <div
+        className="pgn__card pgn__card-light card"
+        tabIndex={-1}
+      >
+        <div
+          className="pgn__card-wrapper-image-cap vertical"
+        >
+          <img
+            className="pgn__card-image-cap"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="http://fake.image"
+          />
+        </div>
+        <div
+          className="pgn__card-body"
+        >
+          <div
+            className="pgn__card-header"
+          >
+            <div
+              className="pgn__card-header-content"
+            />
+          </div>
+          <div
+            className="pgn__card-section"
+          >
+            This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.
+          </div>
+        </div>
+        <div
+          className="pgn__card-footer vertical"
+        >
+          <small
+            className="text-muted"
+          >
+            Last updated 3 mins ago
+          </small>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
 <div
   className="pgn__card-grid"

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
     className="row"
   >
     <div
-      className="col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-grid__card-item pgn__card__disable-equal-height col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -63,7 +63,7 @@ exports[`<CardGrid /> Controlled Rendering renders with disabled equal height 1`
     className="row"
   >
     <div
-      className="pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-grid__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -118,7 +118,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
     className="row"
   >
     <div
-      className="col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-grid__card-item pgn__card__disable-equal-height col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
     className="row"
   >
     <div
-      className="pgn__card-grid__card-item pgn__card__disable-equal-column-heights col-xl-3 col-lg-4 col-md-6 col-12"
+      className="pgn__card-grid__card-item col-xl-3 col-lg-4 col-md-6 col-12"
     >
       <div
         className="pgn__card pgn__card-light card"
@@ -118,7 +118,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
     className="row"
   >
     <div
-      className="pgn__card-grid__card-item pgn__card__disable-equal-column-heights col-xl-4 col-lg-6 col-sm-12"
+      className="pgn__card-grid__card-item col-xl-4 col-lg-6 col-sm-12"
     >
       <div
         className="pgn__card pgn__card-light card"


### PR DESCRIPTION
# Description

Ran into a use case where it seems valid to use `CardGrid` _without_ equal height cards in each row. For example, in the case of using a grid of cards where only one or more cards may have a `Card.Status`, e.g.:

## Before

Lots of unnecessary whitespace in the card since it expands to take up the full height of the row.

```jsx
<CardGrid>
  {/* cards */}
</CardGrid>
```

<img width="560" alt="image" src="https://github.com/openedx/paragon/assets/2828721/517b578e-076e-4f91-97da-732050bb65b3">

## After (with optional `enableEqualColumnHeights ` prop)

Each card only takes up the height it needs on its own.

```jsx
<CardGrid enableEqualColumnHeights={false}>
  {/* cards */}
</CardGrid>
```

<img width="562" alt="image" src="https://github.com/openedx/paragon/assets/2828721/c4525d96-4b1c-48e9-a3b9-878906c631ec">

### Deploy Preview

https://deploy-preview-2287--paragon-openedx.netlify.app/components/card/#cardgrid
https://deploy-preview-2287--paragon-openedx.netlify.app/components/card/#carddeck

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
