### PR TITLE
[BD-46] fix: fixed double tab and styles clickable card component

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -1,6 +1,7 @@
 @import "variables";
 @import "~bootstrap/scss/card";
 
+a .pgn__card,
 a.pgn__card {
   color: $gray-700;
   display: inline-block;

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -121,8 +121,8 @@ You use `isClickable` prop to add additional `hover` and `focus` styling to the 
 ```
 
 ### As link
-You can also use `Card` as a link by wrapping it into appropriate component, note that `Card` will override default 
-link styling to make its content appear as a regular text.
+You can also use `Card` as a link by passing the value `HyperLink` (or `a`, `Link`) to the `as` property, note that
+`Card` will override the default link styling to make its content appear as regular text.
 
 ```jsx live
 () => {


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2264

### Deploy Preview

[Card component](https://deploy-preview-2290--paragon-openedx.netlify.app/components/card/)
## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
