### PR TITLE
[BD-46] feat: added variants for the Select Menu component

### DIFF
--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -60,12 +60,14 @@ function SelectMenu({
   const prevOpenRef = React.useRef();
 
   useEffect(() => {
-    const numItems = children.length;
-    if (isOpen && selected > 1 && numItems - selected > 2) {
-      // on "middle elements", set offset to center of block and scroll to center
-      itemsCollection[selected].current.children[0].scrollIntoView({
-        block: 'center',
-      });
+    if (isOpen && selected) {
+      const numItems = children.length;
+      if (selected > 1 && numItems - selected > 2) {
+        // on "middle elements", set offset to center of block and scroll to center
+        itemsCollection[selected].current.children[0].scrollIntoView({
+          block: 'center',
+        });
+      }
     }
     // set focus on open
     if (isOpen && !prevOpenRef.current && selected) {

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -62,7 +62,7 @@ function SelectMenu({
   useEffect(() => {
     if (isOpen && selected) {
       const numItems = children.length;
-      if (selected > 1 && numItems - selected > 2) {
+      if (numItems > 6 && selected > 1 && numItems - selected > 2) {
         // on "middle elements", set offset to center of block and scroll to center
         itemsCollection[selected].current.children[0].scrollIntoView({
           block: 'center',
@@ -94,9 +94,20 @@ function SelectMenu({
       </Button>
       <div className="pgn__menu-select-popup">
         <ModalPopup
+          placement="bottom-start"
           positionRef={triggerTarget}
           isOpen={isOpen}
           onClose={close}
+          modifiers={
+            [
+              {
+                name: 'flip',
+                options: {
+                  padding: { top: 150, bottom: 150 },
+                },
+              },
+            ]
+          }
         >
           <Menu aria-label="Select Menu">
             {createMenuItems().map((child, index) => (

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -12,7 +12,6 @@ export const SELECT_MENU_DEFAULT_MESSAGE = 'Select...';
 
 function SelectMenu({
   defaultMessage,
-  isLink,
   children,
   className,
   variant,
@@ -116,7 +115,7 @@ function SelectMenu({
         aria-haspopup="true"
         aria-expanded={isOpen}
         ref={triggerTarget}
-        variant={isLink ? 'link' : variant}
+        variant={variant}
         iconAfter={ExpandMore}
         onClick={open}
       >
@@ -160,8 +159,6 @@ function SelectMenu({
 SelectMenu.propTypes = {
   /** String that is displayed for default value of the ``SelectMenu`` */
   defaultMessage: PropTypes.string,
-  /** Displays chosen value of the ``SelectMenu`` as a link */
-  isLink: PropTypes.bool,
   /** Specifies the content of the ``SelectMenu`` */
   children: PropTypes.node.isRequired,
   /** Specifies class name to append to the base element */
@@ -172,15 +169,16 @@ SelectMenu.propTypes = {
 
 SelectMenu.defaultProps = {
   defaultMessage: SELECT_MENU_DEFAULT_MESSAGE,
-  isLink: false,
   className: undefined,
   variant: 'outline-primary',
 };
 
 const SelectMenuWithDeprecatedProp = withDeprecatedProps(SelectMenu, 'SelectMenu', {
   isLink: {
-    deprType: DeprTypes.REMOVED,
+    deprType: DeprTypes.MOVED_AND_FORMAT,
     message: 'Use "variant" prop instead, i.e. variant="link"',
+    newName: 'variant',
+    transform: () => 'link',
   },
 });
 

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -6,6 +6,7 @@ import Button from '../Button';
 import ModalPopup from '../Modal/ModalPopup';
 import useToggle from '../hooks/useToggle';
 import Menu from '.';
+import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 
 export const SELECT_MENU_DEFAULT_MESSAGE = 'Select...';
 
@@ -58,7 +59,6 @@ function SelectMenu({
     return React.cloneElement(child, newProps);
   });
 
-  const link = isLink; // allow inline link styling
   const prevOpenRef = React.useRef();
 
   useEffect(() => {
@@ -116,7 +116,7 @@ function SelectMenu({
         aria-haspopup="true"
         aria-expanded={isOpen}
         ref={triggerTarget}
-        variant={link ? 'link' : variant}
+        variant={isLink ? 'link' : variant}
         iconAfter={ExpandMore}
         onClick={open}
       >
@@ -177,4 +177,11 @@ SelectMenu.defaultProps = {
   variant: 'outline-primary',
 };
 
-export default SelectMenu;
+const SelectMenuWithDeprecatedProp = withDeprecatedProps(SelectMenu, 'SelectMenu', {
+  isLink: {
+    deprType: DeprTypes.REMOVED,
+    message: 'Use "variant" prop instead, i.e. variant="link"',
+  },
+});
+
+export default SelectMenuWithDeprecatedProp;

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -14,6 +14,7 @@ function SelectMenu({
   isLink,
   children,
   className,
+  variant,
   ...props
 }) {
   const triggerTarget = React.useRef(null);
@@ -115,7 +116,7 @@ function SelectMenu({
         aria-haspopup="true"
         aria-expanded={isOpen}
         ref={triggerTarget}
-        variant={link ? 'link' : 'outline-primary'}
+        variant={link ? 'link' : variant}
         iconAfter={ExpandMore}
         onClick={open}
       >
@@ -165,12 +166,15 @@ SelectMenu.propTypes = {
   children: PropTypes.node.isRequired,
   /** Specifies class name to append to the base element */
   className: PropTypes.string,
+  /** Specifies variant to use. */
+  variant: PropTypes.string,
 };
 
 SelectMenu.defaultProps = {
   defaultMessage: SELECT_MENU_DEFAULT_MESSAGE,
   isLink: false,
   className: undefined,
+  variant: 'outline-primary',
 };
 
 export default SelectMenu;

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -60,12 +60,19 @@ function SelectMenu({
   const prevOpenRef = React.useRef();
 
   useEffect(() => {
+    const numItems = children.length;
+    if (isOpen && selected > 1 && numItems - selected > 2) {
+      // on "middle elements", set offset to center of block and scroll to center
+      itemsCollection[selected].current.children[0].scrollIntoView({
+        block: 'center',
+      });
+    }
     // set focus on open
     if (isOpen && !prevOpenRef.current && selected) {
       itemsCollection[selected].current.children[0].focus({ preventScroll: (defaultIndex() === selected) });
     }
     if (focusMenuRef.current) {
-      triggerTarget?.current?.focus();
+      triggerTarget.focus();
       focusMenuRef.current = false;
     }
     prevOpenRef.current = isOpen;

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -86,6 +86,19 @@ describe('keyboard Interactions', () => {
     expect(menuItems.at(0) === document.activeElement);
   });
 
+  it('should center focus element', () => {
+    menuItems.at(2).simulate('click');
+    // menuTrigger.simulate('click'); // Open
+    const centerIndex = Math.floor(menuItems.length / 2);
+    const centerItem = menuItems.at(centerIndex);
+    const centerItemTopOffset = centerItem.getDOMNode().offsetTop;
+    const centerItemHeight = centerItem.getDOMNode().offsetHeight;
+    const menuContainerHeight = menuContainer.getDOMNode().offsetHeight;
+    expect(menuContainer.getDOMNode().scrollTop).toBe(
+      centerItemTopOffset - menuContainerHeight / 2 + centerItemHeight / 2,
+    );
+  });
+
   it('should focus the next item after ArrowDown keyDown', () => {
     menuContainer.simulate('keyDown', { key: 'ArrowDown' });
     expect(menuItems.at(1) === document.activeElement);

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -48,6 +48,10 @@ describe('correct rendering', () => {
     const wrapper = mount(<DefaultSelectMenu defaultMessage="Pick Me" />);
     expect(wrapper.find(Button).text()).toEqual('Pick Me');
   });
+  it('renders with a button as link', () => {
+    const wrapper = mount(<DefaultSelectMenu isLink />);
+    expect(wrapper.find(Button).prop('variant')).toEqual('link');
+  });
   it('rendering with Brand button variant', () => {
     const wrapper = mount(<DefaultSelectMenu variant="brand" />);
     expect(wrapper.find(Button).prop('variant')).toEqual('brand');

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -48,10 +48,6 @@ describe('correct rendering', () => {
     const wrapper = mount(<DefaultSelectMenu defaultMessage="Pick Me" />);
     expect(wrapper.find(Button).text()).toEqual('Pick Me');
   });
-  it('renders with a button as link', () => {
-    const wrapper = mount(<DefaultSelectMenu isLink />);
-    expect(wrapper.find(Button).prop('variant')).toEqual('link');
-  });
   it('rendering with Brand button variant', () => {
     const wrapper = mount(<DefaultSelectMenu variant="brand" />);
     expect(wrapper.find(Button).prop('variant')).toEqual('brand');

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -52,6 +52,11 @@ describe('correct rendering', () => {
     const wrapper = mount(<DefaultSelectMenu isLink />);
     expect(wrapper.find(Button).prop('variant')).toEqual('link');
   });
+  it('rendering with Brand button variant', () => {
+    const wrapper = mount(<DefaultSelectMenu variant="brand" />);
+    expect(wrapper.find(Button).prop('variant')).toEqual('brand');
+    expect(wrapper.find('button').hasClass('btn-brand')).toEqual(true);
+  });
 });
 
 describe('mouse behavior & keyboard behavior', () => {

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -85,20 +85,6 @@ describe('keyboard Interactions', () => {
   it('should focus on the first item after opening', () => {
     expect(menuItems.at(0) === document.activeElement);
   });
-
-  it('should center focus element', () => {
-    menuItems.at(2).simulate('click');
-    // menuTrigger.simulate('click'); // Open
-    const centerIndex = Math.floor(menuItems.length / 2);
-    const centerItem = menuItems.at(centerIndex);
-    const centerItemTopOffset = centerItem.getDOMNode().offsetTop;
-    const centerItemHeight = centerItem.getDOMNode().offsetHeight;
-    const menuContainerHeight = menuContainer.getDOMNode().offsetHeight;
-    expect(menuContainer.getDOMNode().scrollTop).toBe(
-      centerItemTopOffset - menuContainerHeight / 2 + centerItemHeight / 2,
-    );
-  });
-
   it('should focus the next item after ArrowDown keyDown', () => {
     menuContainer.simulate('keyDown', { key: 'ArrowDown' });
     expect(menuItems.at(1) === document.activeElement);

--- a/src/Menu/__snapshots__/SelectMenu.test.jsx.snap
+++ b/src/Menu/__snapshots__/SelectMenu.test.jsx.snap
@@ -35,56 +35,6 @@ exports[`correct rendering renders as expected 1`] = `
   </button>
   <div
     className="pgn__menu-select-popup"
-  >
-    <div
-      style={
-        Object {
-          "left": "0",
-          "position": "absolute",
-          "top": "0",
-          "zIndex": 2000,
-        }
-      }
-    >
-      <div
-        data-focus-guard={true}
-        style={
-          Object {
-            "height": "0px",
-            "left": "1px",
-            "overflow": "hidden",
-            "padding": 0,
-            "position": "fixed",
-            "top": "1px",
-            "width": "1px",
-          }
-        }
-        tabIndex={-1}
-      />
-      <div
-        data-focus-lock-disabled="disabled"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        onScrollCapture={[Function]}
-        onTouchMoveCapture={[Function]}
-        onWheelCapture={[Function]}
-      />
-      <div
-        data-focus-guard={true}
-        style={
-          Object {
-            "height": "0px",
-            "left": "1px",
-            "overflow": "hidden",
-            "padding": 0,
-            "position": "fixed",
-            "top": "1px",
-            "width": "1px",
-          }
-        }
-        tabIndex={-1}
-      />
-    </div>
-  </div>
+  />
 </div>
 `;

--- a/src/Menu/select-menu.md
+++ b/src/Menu/select-menu.md
@@ -12,7 +12,7 @@ devStatus: 'Done'
 notes: ''
 ---
 
-The ``SelectMenu`` component is triggered on the click of a button or your choice of a standalone link using the `isLink` prop, and expands from the center if not close to the edge of the page. The ``Menu`` contains a list of ``MenuItems``, with a white background, and level 2 elevation. The ``Menu`` also remembers the user’s selection and displays it as the label for the button/link trigger.
+The ``SelectMenu`` component is triggered on the click of a button, and expands from the center if not close to the edge of the page. The ``Menu`` contains a list of ``MenuItems``, with a white background, and level 2 elevation. The ``Menu`` also remembers the user’s selection and displays it as the label for the button/link trigger.
 
 The ``Modal`` brings focus to the first menu element upon the click of the trigger, and can be escaped on click away or key press. Set a default message with the `defaultMessage` prop string. Use the `defaultSelected` prop to signify that a menuItem is the default to open to.
 
@@ -45,7 +45,7 @@ The ``Modal`` brings focus to the first menu element upon the click of the trigg
 ### Linked variant
 
 ```jsx live
-<SelectMenu isLink defaultMessage="Choose Your New Best Friend">
+<SelectMenu variant="link" defaultMessage="Choose Your New Best Friend">
   <MenuItem>Falstaff</MenuItem>
   <MenuItem>Scipio</MenuItem>
   <MenuItem defaultSelected>Faustus</MenuItem>

--- a/src/Menu/select-menu.md
+++ b/src/Menu/select-menu.md
@@ -28,6 +28,20 @@ The ``Modal`` brings focus to the first menu element upon the click of the trigg
 </SelectMenu>
 ```
 
+## Inverse variant
+
+```jsx live
+  <Stack className="bg-dark-700 p-4">
+    <SelectMenu variant="inverse-brand">
+      <MenuItem>A Menu Item</MenuItem>
+      <MenuItem iconBefore={Add}>A Menu Item With an Icon Before</MenuItem>
+      <MenuItem iconAfter={Check}>A Menu Item With an Icon After </MenuItem>
+      <MenuItem disabled>A Disabled Menu Item</MenuItem>
+      <MenuItem as={Hyperlink} destination="https://en.wikipedia.org/wiki/Hyperlink">A Link Menu Item</MenuItem>
+    </SelectMenu>
+</Stack>
+```
+
 ### Linked variant
 
 ```jsx live


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2275

### Deploy Preview

[Select Menu](https://deploy-preview-2291--paragon-openedx.netlify.app/components/menu/select-menu/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
