### PR TITLE
[BD-46] fix: use `currentTarget` in `FormAutosuggest` component to get selected option

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "commit": "commit",
     "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand --coverage",
     "stylelint": "stylelint \"src/**/*.scss\" \"scss/**/*.scss\" \"www/src/**/*.scss\" --config .stylelintrc.json",
-    "lint": "npm run stylelint && eslint --ext .js --ext .jsx --ext .ts --ext .tsx && npm run lint --workspaces --if-present",
+    "lint": "npm run stylelint && eslint --ext .js --ext .jsx --ext .ts --ext .tsx . && npm run lint --workspaces --if-present",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release",
     "snapshot": "jest --updateSnapshot",

--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -38,25 +38,17 @@ function FormAutosuggest({
     dropDownItems: [],
   });
 
-  const setValue = (itemValue, optValue) => {
-    if (value === itemValue) { return; }
+  const handleItemClick = (e, onClick) => {
+    const clickedValue = e.currentTarget.value;
 
-    if (onSelected) { onSelected(itemValue); }
-
-    if (optValue !== state.displayValue) {
-      setState(prevState => ({
-        ...prevState,
-        displayValue: optValue,
-      }));
+    if (onSelected && clickedValue !== value) {
+      onSelected(clickedValue);
     }
-  };
-
-  const handleItemClick = (e, optValue, onClick) => {
-    setValue(e.target.value, optValue);
 
     setState(prevState => ({
       ...prevState,
-      dropDownItems: '',
+      dropDownItems: [],
+      displayValue: clickedValue,
     }));
 
     setIsMenuClosed(true);
@@ -71,14 +63,12 @@ function FormAutosuggest({
       // eslint-disable-next-line no-shadow
       const { children, onClick, ...rest } = child.props;
 
-      const modifiedOpt = React.cloneElement(child, {
+      return React.cloneElement(child, {
         ...rest,
         children,
         value: children,
-        onClick: (e) => handleItemClick(e, children, onClick),
+        onClick: (e) => handleItemClick(e, onClick),
       });
-
-      return modifiedOpt;
     });
 
     if (strToFind.length > 0) {
@@ -125,7 +115,7 @@ function FormAutosuggest({
     if (parentRef.current && !parentRef.current.contains(e.target) && state.dropDownItems.length > 0) {
       setState(prevState => ({
         ...prevState,
-        dropDownItems: '',
+        dropDownItems: [],
         errorMessage: !state.displayValue ? errorMessageText : '',
       }));
 
@@ -139,7 +129,7 @@ function FormAutosuggest({
 
       setState(prevState => ({
         ...prevState,
-        dropDownItems: '',
+        dropDownItems: [],
         errorMessage: !state.displayValue ? errorMessageText : '',
       }));
 
@@ -158,7 +148,7 @@ function FormAutosuggest({
   });
 
   useEffect(() => {
-    if (value !== state.displayValue) {
+    if (value || value === '') {
       setState(prevState => ({
         ...prevState,
         displayValue: value,
@@ -176,17 +166,10 @@ function FormAutosuggest({
     const normalized = itemValue.toLowerCase();
     const opt = optValue.find((o) => o.toLowerCase() === normalized);
 
-    if (opt) {
-      setState(prevState => ({
-        ...prevState,
-        displayValue: opt,
-      }));
-    } else {
-      setState(prevState => ({
-        ...prevState,
-        displayValue: itemValue,
-      }));
-    }
+    setState(prevState => ({
+      ...prevState,
+      displayValue: opt || itemValue,
+    }));
   };
 
   const handleClick = (e) => {
@@ -220,7 +203,7 @@ function FormAutosuggest({
     } else {
       setState(prevState => ({
         ...prevState,
-        dropDownItems: '',
+        dropDownItems: [],
         errorMessageText,
       }));
 

--- a/src/Form/form-autosuggest.mdx
+++ b/src/Form/form-autosuggest.mdx
@@ -19,7 +19,7 @@ Form auto-suggest enables users to manually select or type to find matching opti
 
 ```jsx live
 () => {
-    const [selected, setSelected] = useState({ title: '' });
+    const [selected, setSelected] = useState('');
 
     return (
         <Form.Autosuggest
@@ -27,15 +27,13 @@ Form auto-suggest enables users to manually select or type to find matching opti
             aria-label="form autosuggest"
             helpMessage="Select language"
             errorMessageText="Error, no selected value"
-            value={selected.title}
-            onSelected={
-                (value) => setSelected(prevState => ({ selected: { ...prevState.selected, title: value } }))
-            }
+            value={selected}
+            onSelected={(value) => setSelected(value)}
         >
             <Form.AutosuggestOption>JavaScript</Form.AutosuggestOption>
             <Form.AutosuggestOption>Python</Form.AutosuggestOption>
             <Form.AutosuggestOption>Rube</Form.AutosuggestOption>
-            <Form.AutosuggestOption onClick={(e) => alert(e.target.value)}>
+            <Form.AutosuggestOption onClick={(e) => alert(e.currentTarget.value)}>
                 Option with custom onClick
             </Form.AutosuggestOption>
         </Form.Autosuggest>
@@ -47,7 +45,7 @@ Form auto-suggest enables users to manually select or type to find matching opti
 
 ```jsx live
 () => {
-    const [selected, setSelected] = useState({ title: '' });
+    const [selected, setSelected] = useState('');
 
     return (
         <Form.Autosuggest
@@ -55,10 +53,8 @@ Form auto-suggest enables users to manually select or type to find matching opti
             aria-label="form autosuggest"
             errorMessageText="Error, no selected value"
             helpMessage="Select language"
-            value={selected.title}
-            onSelected={
-                (value) => setSelected(prevState => ({ selected: { ...prevState.selected, title: value } }))
-            }
+            value={selected}
+            onSelected={(value) => setSelected(value)}
         >
             <Form.AutosuggestOption>PHP</Form.AutosuggestOption>
             <Form.AutosuggestOption>Java</Form.AutosuggestOption>

--- a/src/Modal/AlertModal.jsx
+++ b/src/Modal/AlertModal.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { requiredWhenNot } from '../utils/propTypes';
-import { Icon } from '..';
+import Icon from '../Icon';
 import ModalDialog from './ModalDialog';
 
 function AlertModal({


### PR DESCRIPTION
## Description

Fixes a bug with `Form.Autosuggest` component where clicking on `MenuItem`'s children would pass incorrect selected value to the `onSelected` function

### Deploy Preview

https://deploy-preview-2304--paragon-openedx.netlify.app/components/form/form-autosuggest/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
