### PR TITLE
[BD-46] docs: add copy URL and reset buttons to playground page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27202,7 +27202,8 @@
     },
     "node_modules/localforage": {
       "version": "1.10.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -41629,6 +41630,7 @@
         "gatsby-plugin-segment-js": "^3.7.1",
         "gatsby-source-filesystem": "^4.17.0",
         "gatsby-transformer-react-docgen": "^7.17.0",
+        "localforage": "^1.10.0",
         "lodash.debounce": "^4.0.8",
         "prism-react-renderer": "^1.3.3",
         "prop-types": "^15.8.1",

--- a/www/package.json
+++ b/www/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-segment-js": "^3.7.1",
     "gatsby-source-filesystem": "^4.17.0",
     "gatsby-transformer-react-docgen": "^7.17.0",
+    "localforage": "^1.10.0",
     "lodash.debounce": "^4.0.8",
     "prism-react-renderer": "^1.3.3",
     "prop-types": "^15.8.1",

--- a/www/playroom.config.js
+++ b/www/playroom.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { storageKey } = require('./playroom/constants');
 
 module.exports = {
   baseUrl: '/playroom/',
@@ -57,4 +58,5 @@ module.exports = {
     },
   }),
   iframeSandbox: 'allow-scripts allow-same-origin',
+  storageKey,
 };

--- a/www/playroom/constants.js
+++ b/www/playroom/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  storageKey: 'playroom__paragon',
+};

--- a/www/src/components/header/Header.scss
+++ b/www/src/components/header/Header.scss
@@ -1,6 +1,12 @@
 .pgn-doc__header {
   z-index: $zindex-header;
 
+  .pgn-doc__playground-title {
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+  }
+
   .pgn-doc__header-title {
     display: flex;
     align-items: center;

--- a/www/src/components/header/SiteTitle.tsx
+++ b/www/src/components/header/SiteTitle.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Link } from 'gatsby';
 // @ts-ignore
 import Logo from '../../images/diamond.svg';
@@ -7,14 +8,14 @@ import Logo from '../../images/diamond.svg';
 interface SiteTitleProps {
   title: string,
   isFullVersion: boolean,
+  className?: string,
 }
 
-export default function SiteTitle({ title, isFullVersion } : SiteTitleProps) {
+export default function SiteTitle({ title, isFullVersion, className } : SiteTitleProps) {
   return (
     <Link
       to="/"
-      style={{ textDecoration: 'none' }}
-      className="d-block"
+      className={classNames('d-block text-decoration-none', className)}
     >
       <div className="pgn-doc__header-title">
         <span
@@ -40,4 +41,9 @@ export default function SiteTitle({ title, isFullVersion } : SiteTitleProps) {
 SiteTitle.propTypes = {
   title: PropTypes.string.isRequired,
   isFullVersion: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+};
+
+SiteTitle.defaultProps = {
+  className: undefined,
 };

--- a/www/src/pages/playground.tsx
+++ b/www/src/pages/playground.tsx
@@ -4,6 +4,7 @@ import {
   StatefulButton,
   Button,
   Icon,
+  Stack,
 } from '~paragon-react';
 import { ContentCopy, Check } from '~paragon-icons';
 import PropTypes from 'prop-types';
@@ -17,6 +18,7 @@ import { storageKey } from '../../playroom/constants';
 const FEEDBACK_URL = 'https://github.com/openedx/paragon/issues/new?assignees=&labels=playground&template=feedback_template.md&title=[Playground]';
 
 const playroomStorage = localforage.createInstance({ name: storageKey });
+const EMPTY_PLAYROOM_URL_QUERY = '?code=N4XyA';
 
 export default function Playground({ location }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -54,12 +56,12 @@ export default function Playground({ location }) {
     <div className="d-flex flex-column w-100 vh-100 m-0 p-0">
       <SEO title="Playground" />
       <div className="pgn-doc__header py-3 bg-dark text-white sticky-top">
-        <div className="d-flex align-items-center justify-content-end px-4" style={{ gap: '16px' }}>
+        <Stack direction="horizontal" className="d-flex align-items-center justify-content-end px-4" gap={4}>
           <Button
             variant="inverse-tertiary"
             onClick={() => {
               playroomStorage.clear().then(() => {
-                iframeRef!.current!.contentWindow!.location.search = '?code=N4XyA';
+                iframeRef!.current!.contentWindow!.location.search = EMPTY_PLAYROOM_URL_QUERY;
               });
             }}
           >
@@ -94,7 +96,7 @@ export default function Playground({ location }) {
             isFullVersion
             className="pgn-doc__playground-title"
           />
-        </div>
+        </Stack>
       </div>
       <iframe
         title="Paragon Playground"


### PR DESCRIPTION
## Description

Adds `Copy URL` and `Reset` buttons to the Playground page.

### Deploy Preview

https://deploy-preview-2323--paragon-openedx.netlify.app/playground

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
