### PR TITLE
[BD-46] feat: finished FontAwesome deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,6 @@
         "dependent-usage-analyzer"
       ],
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.1.1",
-        "@fortawesome/react-fontawesome": "^0.1.18",
         "@popperjs/core": "^2.11.4",
         "bootstrap": "^4.6.2",
         "chroma-js": "^2.4.2",
@@ -25,7 +23,6 @@
         "commander": "^9.4.1",
         "email-prop-type": "^3.0.0",
         "file-selector": "^0.6.0",
-        "font-awesome": "^4.7.0",
         "glob": "^8.0.3",
         "lodash.uniqby": "^4.7.0",
         "mailto-link": "^2.0.0",
@@ -4880,6 +4877,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
       "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==",
       "hasInstallScript": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4889,30 +4887,10 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
       "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.1.2"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
-      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
-      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
-      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -4921,6 +4899,7 @@
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
       "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
+      "peer": true,
       "dependencies": {
         "prop-types": "^15.8.1"
       },
@@ -20063,6 +20042,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
       "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.3"
       }
@@ -44350,7 +44330,6 @@
       "dependencies": {
         "@docsearch/react": "^3.1.0",
         "@edx/brand-openedx": "^1.1.0",
-        "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
         "analytics-node": "^6.0.0",
@@ -47860,35 +47839,23 @@
     "@fortawesome/fontawesome-common-types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
-      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA=="
+      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==",
+      "peer": true
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
       "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
+      "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.1.2"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
-      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      },
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
-          "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ=="
-        }
       }
     },
     "@fortawesome/react-fontawesome": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
       "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
+      "peer": true,
       "requires": {
         "prop-types": "^15.8.1"
       }
@@ -59508,7 +59475,8 @@
     "font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg=="
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "peer": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -69745,7 +69713,6 @@
         "@docsearch/react": "^3.1.0",
         "@edx/brand-openedx": "^1.1.0",
         "@edx/eslint-config": "^3.1.0",
-        "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
         "@svgr/webpack": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
     "replace-variables-definition-with-css": "node tokens/replace-variables.js -p src -t definition"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.1.1",
-    "@fortawesome/react-fontawesome": "^0.1.18",
     "@popperjs/core": "^2.11.4",
     "bootstrap": "^4.6.2",
     "chroma-js": "^2.4.2",
@@ -60,7 +58,6 @@
     "commander": "^9.4.1",
     "email-prop-type": "^3.0.0",
     "file-selector": "^0.6.0",
-    "font-awesome": "^4.7.0",
     "glob": "^8.0.3",
     "lodash.uniqby": "^4.7.0",
     "mailto-link": "^2.0.0",

--- a/src/IconButton/README.md
+++ b/src/IconButton/README.md
@@ -20,7 +20,7 @@ notes: ''
   return (
     <div className="d-flex flex-wrap">
       {variants.map((variant) => (
-        <IconButton key={variant} src={Close} iconAs={Icon} alt="Close" onClick={() => {}} variant={variant} className="mr-2" />
+        <IconButton key={variant} src={Close} alt="Close" onClick={() => {}} variant={variant} className="mr-2" />
       ))}
     </div>
   );
@@ -40,7 +40,6 @@ notes: ''
           tooltipPlacement='top'
           tooltipContent={<div>a nice tooltip of {variant}!</div>}
           src={Close}
-          iconAs={Icon}
           alt="Close"
           onClick={() => {}}
           variant={variant}
@@ -64,7 +63,6 @@ notes: ''
           isActive
           key={variant}
           src={Close}
-          iconAs={Icon}
           alt="Close"
           onClick={() => {}}
           variant={variant}
@@ -89,7 +87,6 @@ notes: ''
           isActive
           key={variant}
           src={Close}
-          iconAs={Icon}
           alt="Close"
           onClick={() => {}}
           variant={variant}
@@ -109,7 +106,6 @@ notes: ''
   <div className="p-1 bg-brand">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="brand"
@@ -119,7 +115,6 @@ notes: ''
   <div className="p-1 bg-primary">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="primary"
@@ -129,7 +124,6 @@ notes: ''
   <div className="p-1 bg-secondary">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="secondary"
@@ -139,7 +133,6 @@ notes: ''
   <div className="p-1 bg-success">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="success"
@@ -149,7 +142,6 @@ notes: ''
   <div className="p-1 bg-warning">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="warning"
@@ -159,7 +151,6 @@ notes: ''
   <div className="p-1 bg-danger">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="danger"
@@ -169,7 +160,6 @@ notes: ''
   <div className="p-1 bg-light">
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="light"
@@ -179,7 +169,6 @@ notes: ''
   <div className="p-1" style={{ background: "black" }}>
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => console.log("You clicked the menu button")}
       variant="black"
@@ -197,7 +186,6 @@ notes: ''
     Small
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => {}}
       variant="primary"
@@ -208,7 +196,6 @@ notes: ''
     Inline:
     <IconButton
       src={MenuIcon}
-      iconAs={Icon}
       alt="Menu"
       onClick={() => {}}
       variant="primary"
@@ -220,7 +207,6 @@ notes: ''
     For example, applying className="x-small" will make the Icon Button look like this:
     <IconButton
       src={Favorite}
-      iconAs={Icon}
       alt="Favorite"
       onClick={() => {}}
       variant="primary"

--- a/src/IconButton/__snapshots__/IconButton.test.jsx.snap
+++ b/src/IconButton/__snapshots__/IconButton.test.jsx.snap
@@ -10,34 +10,11 @@ exports[`<IconButton /> renders with required props 1`] = `
   <span
     className="btn-icon__icon-container"
   >
-    <svg
-      aria-hidden="true"
-      className="svg-inline--fa fa-InfoOutlineIcon btn-icon__icon"
-      data-icon="InfoOutlineIcon"
-      data-prefix="pgn"
-      focusable="false"
-      role="img"
-      src={null}
-      style={Object {}}
-      viewBox="0 0 function SvgInfoOutline(props) {
-  return /*#__PURE__*/React.createElement(\\"svg\\", _extends({
-    width: 24,
-    height: 24,
-    viewBox: \\"0 0 24 24\\",
-    fill: \\"none\\",
-    xmlns: \\"http://www.w3.org/2000/svg\\"
-  }, props), /*#__PURE__*/React.createElement(\\"path\\", {
-    d: \\"M11 7h2v2h-2V7zm0 4h2v6h-2v-6zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z\\",
-    fill: \\"currentColor\\"
-  }));
-} undefined"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        fill="currentColor"
-        style={Object {}}
-      />
-    </svg>
+    <span
+      aria-hidden={true}
+      className="btn-icon__icon"
+      id="Icon1"
+    />
   </span>
 </button>
 `;

--- a/src/IconButton/index.jsx
+++ b/src/IconButton/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Icon from '../Icon';
 import { OverlayTrigger } from '../Overlay';
 import Tooltip from '../Tooltip';
 
@@ -22,14 +22,8 @@ const IconButton = React.forwardRef(({
 }, ref) => {
   const invert = invertColors ? 'inverse-' : '';
   const activeStyle = isActive ? `${variant}-` : '';
-  if (!iconAs && process.env.NODE_ENV === 'development' && console) {
-    const msg = '[Deprecated] IconButton: you have not provided a value for iconAs prop and '
-      + 'are using a default one - FontAwesomeIcon, the default value is going to be changed soon '
-      + 'as Paragon is moving away from FontAwesome, please use Paragon\'s icons instead.';
-    // eslint-disable-next-line no-console
-    console.warn(msg);
-  }
-  const IconComponent = iconAs || FontAwesomeIcon;
+  const IconComponent = iconAs;
+
   return (
     <button
       aria-label={alt}
@@ -59,7 +53,7 @@ const IconButton = React.forwardRef(({
 });
 
 IconButton.defaultProps = {
-  iconAs: undefined,
+  iconAs: Icon,
   src: null,
   icon: undefined,
   iconClassNames: undefined,
@@ -74,8 +68,7 @@ IconButton.defaultProps = {
 IconButton.propTypes = {
   /** A custom class name. */
   className: PropTypes.string,
-  /** Component that renders the icon, currently defaults to `FontAwesomeIcon`,
-   *  but is going to be deprecated soon, please use Paragon's icons instead. */
+  /** Component that renders the icon, currently defaults to `Icon` */
   iconAs: PropTypes.elementType,
   /** An icon component to render. Example import of a Paragon icon component:
    * `import { Check } from '@edx/paragon/dist/icon';`
@@ -87,7 +80,7 @@ IconButton.propTypes = {
   alt: PropTypes.string.isRequired,
   /** Changes icon styles for dark background */
   invertColors: PropTypes.bool,
-  /** Accepts a React fontawesome icon. https://fontawesome.com/how-to-use/on-the-web/using-with/react */
+  /** Accepts a [Paragon icon](https://paragon-openedx.netlify.app/foundations/icons) */
   icon: PropTypes.shape({
     prefix: PropTypes.string,
     iconName: PropTypes.string,

--- a/www/package.json
+++ b/www/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@docsearch/react": "^3.1.0",
     "@edx/brand-openedx": "^1.1.0",
-    "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "analytics-node": "^6.0.0",


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2235

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
