### PR TITLE
[BD-46] docs: added missing props on the documentation site

### DIFF
--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -119,6 +119,27 @@ AlertHeading.defaultProps = {
 
 Alert.propTypes = {
   ...BaseAlert.propTypes,
+  /** Specifies class name to append to the base element */
+  className: PropTypes.string,
+  /** Overrides underlying component base CSS class name */
+  bsPrefix: PropTypes.string,
+  /** Specifies variant to use. */
+  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light']),
+  /**
+   * Animate the entering and exiting of the Alert. `true` will use the `<Fade>` transition,
+   * more detailed customization is also provided.
+   */
+  transition: PropTypes.oneOfType([PropTypes.bool, PropTypes.shape({
+    in: PropTypes.bool,
+    appear: PropTypes.bool,
+    children: PropTypes.node,
+    onEnter: PropTypes.func,
+    onEntered: PropTypes.func,
+    onEntering: PropTypes.func,
+    onExit: PropTypes.func,
+    onExited: PropTypes.func,
+    onExiting: PropTypes.func,
+  })]),
   /** Docstring for the children prop */
   children: PropTypes.node,
   /** Docstring for the icon prop... Icon that will be shown in the alert */

--- a/src/Button/deprecated/index.jsx
+++ b/src/Button/deprecated/index.jsx
@@ -113,7 +113,7 @@ export const buttonPropTypes = {
   /** Specifies variant to use. */
   variant: PropTypes.oneOf([
     'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light', 'link', 'outline-primary',
-    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light'
+    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light',
   ]),
 };
 

--- a/src/Button/deprecated/index.jsx
+++ b/src/Button/deprecated/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import withDeprecatedProps, { DeprTypes } from '../../withDeprecatedProps';
 
-class WrapperButton extends React.Component {
+class DeprecatedButton extends React.Component {
   constructor(props) {
     super(props);
 
@@ -113,18 +113,13 @@ export const buttonPropTypes = {
   /** Specifies variant to use. */
   variant: PropTypes.oneOf([
     'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light', 'link', 'outline-primary',
-    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light']),
-  /** An icon component to render.
-  * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
-  iconBefore: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-  /** An icon component to render.
-  * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
-  iconAfter: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light'
+  ]),
 };
 
-WrapperButton.propTypes = buttonPropTypes;
+DeprecatedButton.propTypes = buttonPropTypes;
 
-WrapperButton.defaultProps = {
+DeprecatedButton.defaultProps = {
   buttonType: undefined,
   className: undefined,
   inputRef: () => {},
@@ -134,11 +129,9 @@ WrapperButton.defaultProps = {
   onClick: () => {},
   type: 'button',
   variant: 'outline-primary',
-  iconBefore: undefined,
-  iconAfter: undefined,
 };
 
-export default withDeprecatedProps(WrapperButton, 'Button', {
+export default withDeprecatedProps(DeprecatedButton, 'Button', {
   label: {
     deprType: DeprTypes.MOVED,
     newName: 'children',

--- a/src/Button/deprecated/index.jsx
+++ b/src/Button/deprecated/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import withDeprecatedProps, { DeprTypes } from '../../withDeprecatedProps';
 
-class Button extends React.Component {
+class WrapperButton extends React.Component {
   constructor(props) {
     super(props);
 
@@ -122,9 +122,9 @@ export const buttonPropTypes = {
   iconAfter: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
-Button.propTypes = buttonPropTypes;
+WrapperButton.propTypes = buttonPropTypes;
 
-Button.defaultProps = {
+WrapperButton.defaultProps = {
   buttonType: undefined,
   className: undefined,
   inputRef: () => {},
@@ -138,7 +138,7 @@ Button.defaultProps = {
   iconAfter: undefined,
 };
 
-export default withDeprecatedProps(Button, 'Button', {
+export default withDeprecatedProps(WrapperButton, 'Button', {
   label: {
     deprType: DeprTypes.MOVED,
     newName: 'children',

--- a/src/Button/deprecated/index.jsx
+++ b/src/Button/deprecated/index.jsx
@@ -110,6 +110,16 @@ export const buttonPropTypes = {
   onKeyDown: PropTypes.func,
   /** Used to set the `type` attribute on the `button` tag.  The default type is `button`. */
   type: PropTypes.string,
+  /** Specifies variant to use. */
+  variant: PropTypes.oneOf([
+    'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light', 'link', 'outline-primary',
+    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light']),
+  /** An icon component to render.
+  * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
+  iconBefore: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  /** An icon component to render.
+  * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
+  iconAfter: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
 Button.propTypes = buttonPropTypes;
@@ -123,6 +133,9 @@ Button.defaultProps = {
   onKeyDown: () => {},
   onClick: () => {},
   type: 'button',
+  variant: 'outline-primary',
+  iconBefore: undefined,
+  iconAfter: undefined,
 };
 
 export default withDeprecatedProps(Button, 'Button', {

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -27,35 +27,31 @@ const Button = React.forwardRef(({
 
 Button.propTypes = {
   ...Button.propTypes,
-  /** Used to determine the type of button to be rendered.  See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable button types. For example, `buttonType="light"`. The default is `undefined`. */
-  buttonType: PropTypes.string,
-  /** Specifies Bootstrap class names to apply to the button. See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable class names. The default is an empty array. */
+  /** Specifies class name to apply to the button */
   className: PropTypes.string,
+  /** Disables the Button, preventing mouse events, even if the underlying component is an `<a>` element */
+  disabled: PropTypes.bool,
   /** Specifies the text that is displayed within the button. */
   children: PropTypes.node.isRequired,
-  // eslint-disable-next-line max-len
-  /** A function that defines a reference for the button. An example `inputRef` from the calling component could look something like: `inputRef={(input) => { this.button = input; }}`. The default is an empty function. */
-  inputRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
-  ]),
-  /** Used to determine if the button is a "Close" style button to leverage bootstrap styling. Example use case is with the Status Alert [dismiss button](https://getbootstrap.com/docs/4.0/components/alerts/#dismissing). The default is false. */
-  isClose: PropTypes.bool,
-  // eslint-disable-next-line max-len
-  /** A function that would specify what the button should do when the `onBlur` event is triggered. For example, the button could change in color or `buttonType` when focus is changed. The default is an empty function. */
-  onBlur: PropTypes.func,
-  // eslint-disable-next-line max-len
-  /** A function that would specify what the button should do when the `onClick` event is triggered. For example, the button could launch a `Modal`. The default is an empty function. */
+  /** A function that would specify what the button should do when the `onClick` event is triggered.
+   * For example, the button could launch a `Modal`. The default is an empty function. */
   onClick: PropTypes.func,
-  // eslint-disable-next-line max-len
-  /** A function that would specify what the button should do when the `onKeyDown` event is triggered.  For example, this could handle using the `Escape` key to trigger the button's action. The default is an empty function. */
+  /** Providing a `href` will render an `<a>` element, styled as a button. */
+  href: PropTypes.string,
+  /** A function that would specify what the button should do when the `onKeyDown` event is triggered.
+   * For example, this could handle using the `Escape` key to trigger the button's action.
+   * The default is an empty function. */
   onKeyDown: PropTypes.func,
   /** Used to set the `type` attribute on the `button` tag.  The default type is `button`. */
   type: PropTypes.string,
-  /** Specifies variant to use. */
-  variant: PropTypes.oneOf([
-    'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light', 'link', 'outline-primary',
-    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light']),
+  /** Specifies variant to use.
+   * Can be on of the base variants: `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `dark`,
+   * `light`, `link`
+   *
+   * as well as one of the customized variants (= base variant prefixed with `inverse-`, `outline-`
+   * or `inverse-outline-`)
+   * */
+  variant: PropTypes.string,
   /** An icon component to render.
   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
   iconBefore: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
@@ -70,6 +66,8 @@ Button.defaultProps = {
   className: undefined,
   iconBefore: undefined,
   iconAfter: undefined,
+  href: undefined,
+  disabled: false,
 };
 
 Button.Deprecated = ButtonDeprecated;

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Button from 'react-bootstrap/Button';
+import BaseButton from 'react-bootstrap/Button';
 import BaseButtonGroup from 'react-bootstrap/ButtonGroup';
 import BaseButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import ButtonDeprecated from './deprecated';
 
 import Icon from '../Icon';
 
-const WrappedButton = React.forwardRef(({
+const Button = React.forwardRef(({
   children,
   iconAfter,
   iconBefore,
   ...props
 }, ref) => (
-  <Button
+  <BaseButton
     {...props}
     className={classNames(props.className)}
     ref={ref}
@@ -22,24 +22,49 @@ const WrappedButton = React.forwardRef(({
     {iconBefore && <Icon className="btn-icon-before" size={props.size} src={iconBefore} />}
     {children}
     {iconAfter && <Icon className="btn-icon-after" size={props.size} src={iconAfter} />}
-  </Button>
+  </BaseButton>
 ));
 
-WrappedButton.propTypes = {
+Button.propTypes = {
   ...Button.propTypes,
-  /** Docstring for the children prop */
-  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-  /** Docstring for className... A class name to append to the button */
+  /** Used to determine the type of button to be rendered.  See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable button types. For example, `buttonType="light"`. The default is `undefined`. */
+  buttonType: PropTypes.string,
+  /** Specifies Bootstrap class names to apply to the button. See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable class names. The default is an empty array. */
   className: PropTypes.string,
+  /** Specifies the text that is displayed within the button. */
+  children: PropTypes.node.isRequired,
+  // eslint-disable-next-line max-len
+  /** A function that defines a reference for the button. An example `inputRef` from the calling component could look something like: `inputRef={(input) => { this.button = input; }}`. The default is an empty function. */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
+  ]),
+  /** Used to determine if the button is a "Close" style button to leverage bootstrap styling. Example use case is with the Status Alert [dismiss button](https://getbootstrap.com/docs/4.0/components/alerts/#dismissing). The default is false. */
+  isClose: PropTypes.bool,
+  // eslint-disable-next-line max-len
+  /** A function that would specify what the button should do when the `onBlur` event is triggered. For example, the button could change in color or `buttonType` when focus is changed. The default is an empty function. */
+  onBlur: PropTypes.func,
+  // eslint-disable-next-line max-len
+  /** A function that would specify what the button should do when the `onClick` event is triggered. For example, the button could launch a `Modal`. The default is an empty function. */
+  onClick: PropTypes.func,
+  // eslint-disable-next-line max-len
+  /** A function that would specify what the button should do when the `onKeyDown` event is triggered.  For example, this could handle using the `Escape` key to trigger the button's action. The default is an empty function. */
+  onKeyDown: PropTypes.func,
+  /** Used to set the `type` attribute on the `button` tag.  The default type is `button`. */
+  type: PropTypes.string,
+  /** Specifies variant to use. */
+  variant: PropTypes.oneOf([
+    'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light', 'link', 'outline-primary',
+    'outline-secondary', 'outline-success', 'outline-danger', 'outline-warning', 'outline-info', 'outline-dark', 'outline-light']),
   /** An icon component to render.
-   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
+  * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
   iconBefore: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   /** An icon component to render.
-   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
+  * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
   iconAfter: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
-WrappedButton.defaultProps = {
+Button.defaultProps = {
   ...Button.defaultProps,
   children: undefined,
   className: undefined,
@@ -47,7 +72,7 @@ WrappedButton.defaultProps = {
   iconAfter: undefined,
 };
 
-WrappedButton.Deprecated = ButtonDeprecated;
+Button.Deprecated = ButtonDeprecated;
 
 function ButtonGroup(props) {
   return <BaseButtonGroup {...props} />;
@@ -92,5 +117,5 @@ ButtonToolbar.defaultProps = {
   bsPrefix: 'btn-toolbar',
 };
 
-export default WrappedButton;
+export default Button;
 export { ButtonGroup, ButtonToolbar };

--- a/src/Card/CardCarousel/CardCarouselSubtitle.jsx
+++ b/src/Card/CardCarousel/CardCarouselSubtitle.jsx
@@ -12,8 +12,11 @@ function CardCarouselSubtitle({ children, as, className }) {
 }
 
 CardCarouselSubtitle.propTypes = {
+  /** Specifies contents of the component. */
   children: PropTypes.node.isRequired,
+  /** Specifies the base element */
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
+  /** A class name to append to the base element. */
   className: PropTypes.string,
 };
 

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -13,7 +13,6 @@ import CardStatus from './CardStatus';
 import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 
 export const CARD_VARIANTS = ['light', 'dark', 'muted'];
-export const COLOR_VARIANTS = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light'];
 
 const Card = React.forwardRef(({
   orientation,
@@ -54,12 +53,6 @@ export { default as CardGroup } from 'react-bootstrap/CardGroup';
 export { default as CardGrid } from './CardGrid';
 
 Card.propTypes = {
-  /** Specifies a text that is displayed on the Card. */
-  text: PropTypes.oneOf([...COLOR_VARIANTS, 'white', 'muted']),
-  /** Specifies a border-color that is displayed on the Card. */
-  border: PropTypes.oneOf(COLOR_VARIANTS),
-  /** The text displayed in the body of the Card */
-  body: PropTypes.bool,
   /** Specifies class name to append to the base element. */
   className: PropTypes.string,
   /** Specifies which orientation to use. */

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -54,8 +54,6 @@ export { default as CardGroup } from 'react-bootstrap/CardGroup';
 export { default as CardGrid } from './CardGrid';
 
 Card.propTypes = {
-  /** Specifies a background-color that is displayed on the Card. */
-  bg: PropTypes.oneOf(COLOR_VARIANTS),
   /** Specifies a text that is displayed on the Card. */
   text: PropTypes.oneOf([...COLOR_VARIANTS, 'white', 'muted']),
   /** Specifies a border-color that is displayed on the Card. */

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -13,6 +13,7 @@ import CardStatus from './CardStatus';
 import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 
 export const CARD_VARIANTS = ['light', 'dark', 'muted'];
+export const COLOR_VARIANTS = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light'];
 
 const Card = React.forwardRef(({
   orientation,
@@ -53,7 +54,14 @@ export { default as CardGroup } from 'react-bootstrap/CardGroup';
 export { default as CardGrid } from './CardGrid';
 
 Card.propTypes = {
-  ...BaseCard.propTypes,
+  /** Specifies a background-color that is displayed on the Card. */
+  bg: PropTypes.oneOf(COLOR_VARIANTS),
+  /** Specifies a text that is displayed on the Card. */
+  text: PropTypes.oneOf([...COLOR_VARIANTS, 'white', 'muted']),
+  /** Specifies a border-color that is displayed on the Card. */
+  border: PropTypes.oneOf(COLOR_VARIANTS),
+  /** The text displayed in the body of the Card */
+  body: PropTypes.bool,
   /** Specifies class name to append to the base element. */
   className: PropTypes.string,
   /** Specifies which orientation to use. */

--- a/src/Collapsible/index.jsx
+++ b/src/Collapsible/index.jsx
@@ -76,6 +76,7 @@ Collapsible.propTypes = {
   /** Unmount the component (remove it from the DOM) when it is collapsed */
   unmountOnExit: PropTypes.bool,
 };
+
 Collapsible.defaultProps = {
   className: undefined,
   defaultOpen: false,

--- a/src/DataTable/DataTableLayout.jsx
+++ b/src/DataTable/DataTableLayout.jsx
@@ -26,15 +26,18 @@ function DataTableLayout({
   );
 }
 
+DataTableLayout.propTypes = {
+  /** A class name to append to the base element. */
+  className: PropTypes.string,
+  /** Specifies contents of the component. */
+  children: PropTypes.node.isRequired,
+  /** Specifies title of the component. */
+  filtersTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+};
+
 DataTableLayout.defaultProps = {
   className: null,
   filtersTitle: undefined,
-};
-
-DataTableLayout.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  filtersTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default DataTableLayout;

--- a/src/Form/FormControlSet.jsx
+++ b/src/Form/FormControlSet.jsx
@@ -22,9 +22,13 @@ function FormControlSet({
 }
 
 FormControlSet.propTypes = {
+  /** Specifies the base element */
   as: PropTypes.elementType,
+  /** A class name to append to the base element. */
   className: PropTypes.string,
+  /** Specifies whether the component should be displayed with inline styling. */
   isInline: PropTypes.bool,
+  /** Specifies contents of the component. */
   children: PropTypes.node,
 };
 

--- a/src/Form/FormRadioSet.jsx
+++ b/src/Form/FormRadioSet.jsx
@@ -35,14 +35,23 @@ function FormRadioSet({
 }
 
 FormRadioSet.propTypes = {
+  /** Specifies contents of the component. */
   children: PropTypes.node.isRequired,
+  /** A class name to append to the base element. */
   className: PropTypes.string,
+  /** Specifies name for the component. */
   name: PropTypes.string.isRequired,
+  /** Specifies values for the FormRadioSet. */
   value: PropTypes.string,
+  /** Specifies default values. */
   defaultValue: PropTypes.string,
+  /** Specifies whether the component should be displayed with inline styling. */
   isInline: PropTypes.bool,
+  /** Specifies onChange event handler. */
   onChange: PropTypes.func,
+  /** Specifies onFocus event handler. */
   onFocus: PropTypes.func,
+  /** Specifies onBlur event handler. */
   onBlur: PropTypes.func,
 };
 

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -91,6 +91,7 @@ ModalLayer.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   /** Prevent clicking on the backdrop to close the modal */
   isBlocking: PropTypes.bool,
+  /** Specifies the z-index of the modal */
   zIndex: PropTypes.number,
 };
 

--- a/src/Nav/index.jsx
+++ b/src/Nav/index.jsx
@@ -25,14 +25,10 @@ function NavDropdownDivider(props) {
 }
 
 Nav.propTypes = {
-  /** Overrides underlying component base CSS class name */
-  navbarBsPrefix: PropTypes.string,
   /** Change the underlying component CSS base class name and modifier class names prefix. */
   cardHeaderBsPrefix: PropTypes.string,
   /** Specifies default active nav (uncontrolled usage). */
   defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Enable or disable scroll in the Navbar */
-  navbarScroll: PropTypes.bool,
   /** Marks the NavItem with a matching eventKey (or href if present) as active. */
   activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Set a custom element for this component. */

--- a/src/Nav/index.jsx
+++ b/src/Nav/index.jsx
@@ -25,7 +25,14 @@ function NavDropdownDivider(props) {
 }
 
 Nav.propTypes = {
-  ...Nav.propTypes,
+  /** Overrides underlying component base CSS class name */
+  navbarBsPrefix: PropTypes.string,
+  /** Change the underlying component CSS base class name and modifier class names prefix. */
+  cardHeaderBsPrefix: PropTypes.string,
+  /** Specifies default active nav (uncontrolled usage). */
+  defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Enable or disable scroll in the Navbar */
+  navbarScroll: PropTypes.bool,
   /** Marks the NavItem with a matching eventKey (or href if present) as active. */
   activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Set a custom element for this component. */
@@ -39,9 +46,10 @@ Nav.propTypes = {
    * This prop will be set automatically when the `Nav` is used inside a `Navbar`.
    */
   navbar: PropTypes.bool,
+  /** Callback fired when a key is pressed. */
   onKeyDown: PropTypes.func,
   /** A callback fired when a NavItem is selected. */
-  onSelect: PropTypes.string,
+  onSelect: PropTypes.func,
   /**
    * ARIA role for the `Nav`, in the context of a `TabContainer`,
    * the default will be set to "tablist", but can be overridden by the `Nav` when set explicitly.
@@ -54,7 +62,8 @@ Nav.propTypes = {
 };
 
 NavItem.propTypes = {
-  ...NavItem.propTypes,
+  /** The ARIA role for the `NavItem` */
+  role: PropTypes.string,
   /** Set a custom element for this component. */
   as: PropTypes.elementType,
   /** Change the underlying component CSS base class name and modifier class names prefix. */
@@ -62,7 +71,8 @@ NavItem.propTypes = {
 };
 
 NavLink.propTypes = {
-  ...NavLink.propTypes,
+  /** Callback fired when the active item changes. */
+  onSelect: PropTypes.string,
   /** The active state of the `NavItem` item. */
   active: PropTypes.bool,
   /** You can use a custom element type for this component. */
@@ -83,7 +93,6 @@ NavLink.propTypes = {
 };
 
 NavDropdown.propTypes = {
-  ...NavDropdown.propTypes,
   /** An html id attribute for the `Toggle` button, necessary for assistive technologies, such as screen readers. */
   id: PropTypes.string.isRequired,
   /** The content of the non-toggle Button. */

--- a/src/OverflowScroll/OverflowScroll.jsx
+++ b/src/OverflowScroll/OverflowScroll.jsx
@@ -63,13 +63,22 @@ function OverflowScroll({
 OverflowScroll.Items = OverflowScrollItems;
 
 OverflowScroll.propTypes = {
+  /** Text describing the OverflowScroll for screen readers */
   ariaLabel: PropTypes.string.isRequired,
+  /** Specifies the content of the `OverflowScroll`. */
   children: PropTypes.node.isRequired,
+  /** A CSS query selector to find all child elements within the overflow container. */
   childQuerySelector: PropTypes.string,
+  /** Whether the child `OverflowScroll` components are interactive/focusable. If not, a `tabindex="0"` is
+   * added to be a11y-compliant */
   hasInteractiveChildren: PropTypes.bool,
+  /** Whether users can scroll within the overflow container. */
   disableScroll: PropTypes.bool,
+  /** Whether the default opacity masks should be shown at the start/end, if applicable. */
   disableOpacityMasks: PropTypes.bool,
+  /** Callback function for when the user scrolls to the previous element. */
   onScrollPrevious: PropTypes.func,
+  /** Callback function for when the user scrolls to the next element. */
   onScrollNext: PropTypes.func,
 };
 

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -109,7 +109,7 @@ class StatusAlert extends React.Component {
 
 StatusAlert.propTypes = {
   /** specifies the type of alert that is being diplayed. It defaults to "warning".
-   * See the other available [bootstrap](https://v4-alpha.getbootstrap.com/components/alerts/) options. */
+   * See the other available [bootstrap](https://react-bootstrap-v4.netlify.app/components/alerts/) options. */
   alertType: PropTypes.string,
   /** is a string array that defines the classes to be used within the status alert. */
   className: PropTypes.string,

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -109,7 +108,8 @@ class StatusAlert extends React.Component {
 }
 
 StatusAlert.propTypes = {
-  /** specifies the type of alert that is being diplayed. It defaults to "warning".  See the other available [bootstrap](https://v4-alpha.getbootstrap.com/components/alerts/) options. */
+  /** specifies the type of alert that is being diplayed. It defaults to "warning".
+   * See the other available [bootstrap](https://v4-alpha.getbootstrap.com/components/alerts/) options. */
   alertType: PropTypes.string,
   /** is a string array that defines the classes to be used within the status alert. */
   className: PropTypes.string,
@@ -118,7 +118,9 @@ StatusAlert.propTypes = {
   dismissible: PropTypes.bool,
   /* eslint-disable react/require-default-props */
   closeButtonAriaLabel: PropTypes.string,
-  /** is a function that is called on close. It can be used to perform actions upon closing of the status alert, such as restoring focus to the previous logical focusable element.  It is only required if `dismissible` is set to `true` and not required if the alert is not `dismissible`. */
+  /** is a function that is called on close. It can be used to perform actions upon closing of the status alert,
+   * such as restoring focus to the previous logical focusable element.  It is only required if `dismissible`
+   * is set to `true` and not required if the alert is not `dismissible`. */
   onClose: isRequiredIf(PropTypes.func, props => props.dismissible),
   /** specifies whether the status alert renders open or closed on the initial render. It defaults to false. */
   open: PropTypes.bool,

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -182,6 +182,7 @@ function Tabs({
 }
 
 Tabs.propTypes = {
+  /** Specifies variant to use. */
   variant: PropTypes.oneOf(['tabs', 'pills', 'inverse-tabs', 'inverse-pills', 'button-group']),
   /** Specifies elements that is processed to create tabs. */
   children: PropTypes.node.isRequired,

--- a/src/Toast/ToastContainer.jsx
+++ b/src/Toast/ToastContainer.jsx
@@ -33,6 +33,7 @@ class ToastContainer extends React.Component {
 }
 
 ToastContainer.propTypes = {
+  /** Specifies contents of the component. */
   children: PropTypes.node.isRequired,
 };
 

--- a/src/ValidationFormGroup/index.jsx
+++ b/src/ValidationFormGroup/index.jsx
@@ -19,6 +19,7 @@ const propTypes = {
   invalidMessage: PropTypes.node,
   /** Help text for the form input */
   helpText: PropTypes.node,
+  /** Specifies contents of the component. */
   children: PropTypes.node,
 };
 

--- a/www/src/components/header/Navbar.tsx
+++ b/www/src/components/header/Navbar.tsx
@@ -9,7 +9,7 @@ import {
   IconButton,
   Button,
 } from '~paragon-react';
-import { Menu as MenuIcon, Close, Settings } from '~paragon-icons';
+import { MenuIcon, Close, Settings } from '~paragon-icons';
 import SiteTitle from './SiteTitle';
 import Search from '../Search';
 


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2111

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
