### PR TITLE
[SEO-478] feat: allows users to set loading type to images on CardImageCap comp…

### DIFF
--- a/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
+++ b/src/Card/CardCarousel/tests/__snapshots__/CardCarousel.test.jsx.snap
@@ -110,6 +110,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -158,6 +159,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -206,6 +208,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -254,6 +257,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -302,6 +306,7 @@ exports[`<CardCarousel /> renders card carousel with custom title and subtitles 
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -456,6 +461,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -504,6 +510,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -552,6 +559,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -600,6 +608,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -648,6 +657,7 @@ exports[`<CardCarousel /> renders card carousel with title and subtitles 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -791,6 +801,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -839,6 +850,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -887,6 +899,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -935,6 +948,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"
@@ -983,6 +997,7 @@ exports[`<CardCarousel /> renders default card carousel 1`] = `
             >
               <img
                 className="pgn__card-image-cap"
+                loading="eager"
                 onError={[Function]}
                 onLoad={[Function]}
                 src="http://fake.image"

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -135,7 +135,7 @@ CardImageCap.defaultProps = {
   logoSkeletonHeight: LOGO_SKELETON_HEIGHT_VALUE,
   skeletonWidth: undefined,
   logoSkeletonWidth: undefined,
-  imageLoadingType: undefined,
+  imageLoadingType: 'eager',
 };
 
 export default CardImageCap;

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -21,6 +21,7 @@ const CardImageCap = React.forwardRef(({
   logoSkeletonHeight,
   logoSkeletonWidth,
   className,
+  imageLoadingType,
 }, ref) => {
   const { orientation, isLoading } = useContext(CardContext);
   const [showImageCap, setShowImageCap] = useState(false);
@@ -75,6 +76,7 @@ const CardImageCap = React.forwardRef(({
           onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
           onLoad={() => setShowImageCap(true)}
           alt={srcAlt}
+          loading={imageLoadingType}
         />
       )}
       {!!logoSrc && (
@@ -84,6 +86,7 @@ const CardImageCap = React.forwardRef(({
           onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
           onLoad={() => setShowLogoCap(true)}
           alt={logoAlt}
+          loading={imageLoadingType}
         />
       )}
     </div>
@@ -115,6 +118,8 @@ CardImageCap.propTypes = {
   logoSkeletonHeight: PropTypes.number,
   /** Specifies width of Logo skeleton in loading state. */
   logoSkeletonWidth: PropTypes.number,
+  /** Specifies loading type for images */
+  imageLoadingType: PropTypes.oneOf(['eager', 'lazy']),
 };
 
 CardImageCap.defaultProps = {
@@ -130,6 +135,7 @@ CardImageCap.defaultProps = {
   logoSkeletonHeight: LOGO_SKELETON_HEIGHT_VALUE,
   skeletonWidth: undefined,
   logoSkeletonWidth: undefined,
+  imageLoadingType: undefined,
 };
 
 export default CardImageCap;

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -39,6 +39,13 @@ describe('<CardImageCap />', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders with loading equals lazy', () => {
+    const tree = renderer.create((
+      <CardImageCapWrapper src="http://fake.image" logoSrc="http://fake.image" logoAlt="Logo alt" imageLoadingType="lazy" />
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders with correct horizontal class', async () => {
     const { container } = render(<CardImageCapWrapper orientation="horizontal" src="http://fake.image" />);
 

--- a/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardDeck.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -68,6 +69,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -116,6 +118,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -164,6 +167,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -212,6 +216,7 @@ exports[`<CardDeck /> has tabIndex="-1" when \`hasInteractiveChildren\` is true 
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -272,6 +277,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -320,6 +326,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -368,6 +375,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -416,6 +424,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -464,6 +473,7 @@ exports[`<CardDeck /> renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -524,6 +534,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -572,6 +583,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -620,6 +632,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -668,6 +681,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -716,6 +730,7 @@ exports[`<CardDeck /> renders with controlled columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -776,6 +791,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -824,6 +840,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -872,6 +889,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -920,6 +938,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -968,6 +987,7 @@ exports[`<CardDeck /> renders with disabled equal height 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"

--- a/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardGrid.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<CardGrid /> Controlled Rendering renders with controlled columnSizes 1
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -74,6 +75,7 @@ exports[`<CardGrid /> Controlled Rendering renders with disabled equal height 1`
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"
@@ -129,6 +131,7 @@ exports[`<CardGrid /> Uncontrolled Rendering renders default columnSizes 1`] = `
         >
           <img
             className="pgn__card-image-cap"
+            loading="eager"
             onError={[Function]}
             onLoad={[Function]}
             src="http://fake.image"

--- a/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`<CardImageCap /> renders with scr prop and srcAlt 1`] = `
   <img
     alt="Alt text"
     className="pgn__card-image-cap"
+    loading="eager"
     onError={[Function]}
     onLoad={[Function]}
     src="http://fake.image"
@@ -20,6 +21,7 @@ exports[`<CardImageCap /> renders with scr prop in horizontal orientation 1`] = 
 >
   <img
     className="pgn__card-image-cap"
+    loading="eager"
     onError={[Function]}
     onLoad={[Function]}
     src="http://fake.image"
@@ -33,12 +35,14 @@ exports[`<CardImageCap /> renders with src and logoSrc prop in horizontal orient
 >
   <img
     className="pgn__card-image-cap"
+    loading="eager"
     onError={[Function]}
     onLoad={[Function]}
     src="http://fake.image"
   />
   <img
     className="pgn__card-logo-cap"
+    loading="eager"
     onError={[Function]}
     onLoad={[Function]}
     src="http://fake.image"
@@ -52,6 +56,7 @@ exports[`<CardImageCap /> renders with src, logoSrc and logoAlt props 1`] = `
 >
   <img
     className="pgn__card-image-cap"
+    loading="eager"
     onError={[Function]}
     onLoad={[Function]}
     src="http://fake.image"
@@ -59,6 +64,7 @@ exports[`<CardImageCap /> renders with src, logoSrc and logoAlt props 1`] = `
   <img
     alt="Logo alt"
     className="pgn__card-logo-cap"
+    loading="eager"
     onError={[Function]}
     onLoad={[Function]}
     src="http://fake.image"

--- a/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
+++ b/src/Card/tests/__snapshots__/CardImageCap.test.jsx.snap
@@ -65,3 +65,25 @@ exports[`<CardImageCap /> renders with src, logoSrc and logoAlt props 1`] = `
   />
 </div>
 `;
+
+exports[`<CardImageCap /> renders with loading equals lazy 1`] = `
+<div
+  className="pgn__card-wrapper-image-cap vertical"
+>
+  <img
+    className="pgn__card-image-cap"
+    loading="lazy"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="http://fake.image"
+  />
+  <img
+    alt="Logo alt"
+    className="pgn__card-logo-cap"
+    loading="lazy"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="http://fake.image"
+  />
+</div>
+`;


### PR DESCRIPTION
## Description

[SEO-478](https://2u-internal.atlassian.net/browse/SEO-478)

In the interest of LCP we want to lazy load images that are not in the view port. Browser level lazy loading with suffice for a first pass.

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.

