### PR TITLE
feat: generate paragon-theme.json during npm run build with themeUrls

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,5 @@ node_modules/
 www/
 icons/
 dependent-usage-analyzer/
-build-scss.js
 component-generator/
 example/

--- a/build-scss.js
+++ b/build-scss.js
@@ -10,6 +10,8 @@ const { pathToFileURL } = require('url');
 const path = require('path');
 const { program, Option } = require('commander');
 
+const paragonThemeOutputFilename = 'paragon-theme.json';
+
 const updateParagonConfig = ({
   isThemeVariant,
   paragonConfig,
@@ -72,7 +74,7 @@ const compileAndWriteStyleSheets = ({
       fs.writeFileSync(`${outDir}/${name}.css`, result.css);
       fs.writeFileSync(`${outDir}/${name}.css.map`, result.map.toString());
 
-      const hasExistingParagonConfig = fs.existsSync(`${outDir}/paragon.config.json`);
+      const hasExistingParagonConfig = fs.existsSync(`${outDir}/${paragonThemeOutputFilename}`);
       let paragonConfig;
       if (!hasExistingParagonConfig) {
         const initialConfigOutput = { themeUrls: {} };
@@ -82,7 +84,7 @@ const compileAndWriteStyleSheets = ({
           name,
         });
       } else {
-        const existingParagonConfigRaw = fs.readFileSync(`${outDir}/paragon.config.json`, 'utf8');
+        const existingParagonConfigRaw = fs.readFileSync(`${outDir}/${paragonThemeOutputFilename}`, 'utf8');
         const existingParagonConfig = JSON.parse(existingParagonConfigRaw);
         paragonConfig = updateParagonConfig({
           isThemeVariant,
@@ -90,7 +92,7 @@ const compileAndWriteStyleSheets = ({
           name,
         });
       }
-      fs.writeFileSync(`${outDir}/paragon.config.json`, `${JSON.stringify(paragonConfig, null, 2)}\n`);
+      fs.writeFileSync(`${outDir}/${paragonThemeOutputFilename}`, `${JSON.stringify(paragonConfig, null, 2)}\n`);
     });
 
   postCSS([

--- a/build-scss.js
+++ b/build-scss.js
@@ -12,26 +12,37 @@ const { program, Option } = require('commander');
 
 const paragonThemeOutputFilename = 'paragon-theme.json';
 
-const updateParagonConfig = ({
-  isThemeVariant,
-  paragonConfig,
+/**
+ * Updates `paragonThemeOutput` object with appropriate name and URLs.
+ *
+ * @param {object} args
+ * @param {object} args.paragonThemeOutput Object containing the `themeUrls` pointing
+ *  to the core and theme variant CSS files.
+ * @param {string} args.name Name of the theme variant.
+ * @param {boolean} args.isThemeVariant Indicates whether the stylesheet is a theme variant.
+ *
+ * @returns Updated paragonThemeOutput object.
+ */
+const updateParagonThemeOutput = ({
+  paragonThemeOutput,
   name,
+  isThemeVariant,
 }) => {
   if (isThemeVariant) {
-    paragonConfig.themeUrls.variants = {
-      ...paragonConfig.themeUrls.variants,
+    paragonThemeOutput.themeUrls.variants = {
+      ...paragonThemeOutput.themeUrls.variants,
       [name]: {
         default: `./${name}.css`,
         minified: `./${name}.min.css`,
       },
     };
   } else {
-    paragonConfig.themeUrls[name] = {
+    paragonThemeOutput.themeUrls[name] = {
       default: `./${name}.css`,
       minified: `./${name}.min.css`,
     };
   }
-  return paragonConfig;
+  return paragonThemeOutput;
 };
 
 /**
@@ -74,25 +85,24 @@ const compileAndWriteStyleSheets = ({
       fs.writeFileSync(`${outDir}/${name}.css`, result.css);
       fs.writeFileSync(`${outDir}/${name}.css.map`, result.map.toString());
 
-      const hasExistingParagonConfig = fs.existsSync(`${outDir}/${paragonThemeOutputFilename}`);
-      let paragonConfig;
-      if (!hasExistingParagonConfig) {
+      const hasExistingParagonThemeOutput = fs.existsSync(`${outDir}/${paragonThemeOutputFilename}`);
+      let paragonThemeOutput;
+      if (!hasExistingParagonThemeOutput) {
         const initialConfigOutput = { themeUrls: {} };
-        paragonConfig = updateParagonConfig({
-          isThemeVariant,
-          paragonConfig: initialConfigOutput,
+        paragonThemeOutput = updateParagonThemeOutput({
+          paragonThemeOutput: initialConfigOutput,
           name,
+          isThemeVariant,
         });
       } else {
-        const existingParagonConfigRaw = fs.readFileSync(`${outDir}/${paragonThemeOutputFilename}`, 'utf8');
-        const existingParagonConfig = JSON.parse(existingParagonConfigRaw);
-        paragonConfig = updateParagonConfig({
-          isThemeVariant,
-          paragonConfig: existingParagonConfig,
+        const existingParagonThemeOutput = JSON.parse(fs.readFileSync(`${outDir}/${paragonThemeOutputFilename}`, 'utf8'));
+        paragonThemeOutput = updateParagonThemeOutput({
+          paragonThemeOutput: existingParagonThemeOutput,
           name,
+          isThemeVariant,
         });
       }
-      fs.writeFileSync(`${outDir}/${paragonThemeOutputFilename}`, `${JSON.stringify(paragonConfig, null, 2)}\n`);
+      fs.writeFileSync(`${outDir}/${paragonThemeOutputFilename}`, `${JSON.stringify(paragonThemeOutput, null, 2)}\n`);
     });
 
   postCSS([

--- a/build-scss.js
+++ b/build-scss.js
@@ -10,6 +10,28 @@ const { pathToFileURL } = require('url');
 const path = require('path');
 const { program, Option } = require('commander');
 
+const updateParagonConfig = ({
+  isThemeVariant,
+  paragonConfig,
+  name,
+}) => {
+  if (isThemeVariant) {
+    paragonConfig.themeUrls.variants = {
+      ...paragonConfig.themeUrls.variants,
+      [name]: {
+        default: `./${name}.css`,
+        minified: `./${name}.min.css`,
+      },
+    };
+  } else {
+    paragonConfig.themeUrls[name] = {
+      default: `./${name}.css`,
+      minified: `./${name}.min.css`,
+    };
+  }
+  return paragonConfig;
+};
+
 /**
  * Compiles SCSS file with sass and transforms resulting file with PostCSS:
  * 1. Resulting CSS file
@@ -17,40 +39,69 @@ const { program, Option } = require('commander');
  * 3. Minified version of resulting CSS file
  *
  * @param {string} name - base name of the resulting files
- * @param {string} path - path to the SCSS stylesheet
+ * @param {string} stylesPath - path to the stylesheet to be compiled
  * @param {string} outDir - indicates where to output compiled files
+ * @param {boolean} isThemeVariant - indicates whether the stylesheet is a theme variant
  */
-const compileAndWriteStyleSheets = (name, path, outDir) => {
-  const compiledStyleSheet = sass.compile(path, {
+const compileAndWriteStyleSheets = ({
+  name,
+  stylesPath,
+  outDir,
+  isThemeVariant = false,
+}) => {
+  const compiledStyleSheet = sass.compile(stylesPath, {
     importers: [{
       // An importer that redirects relative URLs starting with '~' to 'node_modules'.
       findFileUrl(url) {
         if (!url.startsWith('~')) {
           return null;
         }
-        return new URL(url.substring(1), `${pathToFileURL('node_modules')}/node_modules`)
-      }
-    }]
+        return new URL(url.substring(1), `${pathToFileURL('node_modules')}/node_modules`);
+      },
+    }],
   });
+  const commonPostCssPlugins = [
+    postCSSCustomMedia({ preserve: true }),
+    postCSSImport(),
+    combineSelectors({ removeDuplicatedProperties: true }),
+  ];
 
-  postCSS([
-    postCSSCustomMedia({ preserve: true }), 
-    postCSSImport(), 
-    combineSelectors({ removeDuplicatedProperties: true })])
-    .process(compiledStyleSheet.css, { from: path, map: { inline: false } })
+  postCSS(commonPostCssPlugins)
+    .process(compiledStyleSheet.css, { from: stylesPath, map: { inline: false } })
     .then(result => {
       fs.writeFileSync(`${outDir}/${name}.css`, result.css);
       fs.writeFileSync(`${outDir}/${name}.css.map`, result.map.toString());
+
+      const hasExistingParagonConfig = fs.existsSync(`${outDir}/paragon.config.json`);
+      let paragonConfig;
+      if (!hasExistingParagonConfig) {
+        const initialConfigOutput = { themeUrls: {} };
+        paragonConfig = updateParagonConfig({
+          isThemeVariant,
+          paragonConfig: initialConfigOutput,
+          name,
+        });
+      } else {
+        const existingParagonConfigRaw = fs.readFileSync(`${outDir}/paragon.config.json`, 'utf8');
+        const existingParagonConfig = JSON.parse(existingParagonConfigRaw);
+        paragonConfig = updateParagonConfig({
+          isThemeVariant,
+          paragonConfig: existingParagonConfig,
+          name,
+        });
+      }
+      fs.writeFileSync(`${outDir}/paragon.config.json`, `${JSON.stringify(paragonConfig, null, 2)}\n`);
     });
 
   postCSS([
-    postCSSCustomMedia({ preserve: true }), 
-    postCSSImport(), 
-    postCSSMinify(), 
-    combineSelectors({ removeDuplicatedProperties: true })])
-    .process(compiledStyleSheet.css, { from: path })
-    .then(result => fs.writeFileSync(`${outDir}/${name}.min.css`, result.css));
-}
+    ...commonPostCssPlugins,
+    postCSSMinify(),
+  ])
+    .process(compiledStyleSheet.css, { from: stylesPath, map: { inline: false } })
+    .then(result => {
+      fs.writeFileSync(`${outDir}/${name}.min.css`, result.css);
+    });
+};
 
 program
   .version('0.0.1')
@@ -58,7 +109,8 @@ program
   .addOption(
     new Option(
       '--corePath <corePath>',
-      'Path to the theme\'s core SCSS file, defaults to Paragon\'s core.scss.')
+      'Path to the theme\'s core SCSS file, defaults to Paragon\'s core.scss.',
+    ),
   )
   .addOption(
     new Option(
@@ -79,24 +131,36 @@ program
       where index.css has imported all other CSS files in the theme's subdirectory. The script will output
       light.css, dark.css and some_other_custom_theme.css files (together with maps and minified versions).
       You can provide any amount of themes. Default to paragon's themes.
-      `
-    ))
+      `,
+    ),
+  )
   .addOption(
     new Option(
       '--outDir <outDir>',
-      'Specifies directory where to out resulting CSS files.'
-    )
+      'Specifies directory where to out resulting CSS files.',
+    ),
   )
   .action(async (options) => {
     const {
       corePath = path.resolve(__dirname, 'styles/scss/core/core.scss'),
       themesPath = path.resolve(__dirname, 'styles/css/themes'),
-      outDir = './dist'
+      outDir = './dist',
     } = options;
-    compileAndWriteStyleSheets('core', corePath, outDir);
+    compileAndWriteStyleSheets({
+      name: 'core',
+      stylesPath: corePath,
+      outDir,
+    });
     fs.readdirSync(themesPath, { withFileTypes: true })
       .filter((item) => item.isDirectory())
-      .forEach((themeDir) => compileAndWriteStyleSheets(themeDir.name, `${themesPath}/${themeDir.name}/index.css`, outDir))
+      .forEach((themeDir) => {
+        compileAndWriteStyleSheets({
+          name: themeDir.name,
+          stylesPath: `${themesPath}/${themeDir.name}/index.css`,
+          outDir,
+          isThemeVariant: true,
+        });
+      });
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
## Description

Generates a `paragon-theme.json` file in `dist` output directory containing relative paths to the compiled core and theme variant CSS paths:

```json
{
  "themeUrls": {
    "core": {
      "default": "./core.css",
      "minified": "./core.min.css"
    },
    "variants": {
      "light": {
        "default": "./light.css",
        "minified": "./light.min.css"
      }
    }
  }
}
```

The `paragon.config.json` file will be parsed by `@edx/frontend-build` to avoid needing to hardcode `core.min.css` or `light.min.css` into its code explicitly, rather relying on the paths provided by Paragon itself.

Related PR: https://github.com/openedx/frontend-build/pull/365

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
