### PR TITLE
fix: updates the paragon-theme.json output

### DIFF
--- a/build-scss.js
+++ b/build-scss.js
@@ -27,19 +27,27 @@ const updateParagonThemeOutput = ({
   paragonThemeOutput,
   name,
   isThemeVariant,
+  isDefaultThemeVariant,
+  isDarkThemeVariant,
 }) => {
   if (isThemeVariant) {
     paragonThemeOutput.themeUrls.variants = {
       ...paragonThemeOutput.themeUrls.variants,
       [name]: {
-        default: `./${name}.css`,
-        minified: `./${name}.min.css`,
+        paths: {
+          default: `./${name}.css`,
+          minified: `./${name}.min.css`,
+        },
+        default: isDefaultThemeVariant,
+        dark: isDarkThemeVariant,
       },
     };
   } else {
     paragonThemeOutput.themeUrls[name] = {
-      default: `./${name}.css`,
-      minified: `./${name}.min.css`,
+      paths: {
+        default: `./${name}.css`,
+        minified: `./${name}.min.css`,
+      },
     };
   }
   return paragonThemeOutput;
@@ -61,6 +69,8 @@ const compileAndWriteStyleSheets = ({
   stylesPath,
   outDir,
   isThemeVariant = false,
+  isDefaultThemeVariant = true,
+  isDarkThemeVariant = false,
 }) => {
   const compiledStyleSheet = sass.compile(stylesPath, {
     importers: [{
@@ -93,6 +103,8 @@ const compileAndWriteStyleSheets = ({
           paragonThemeOutput: initialConfigOutput,
           name,
           isThemeVariant,
+          isDefaultThemeVariant,
+          isDarkThemeVariant,
         });
       } else {
         const existingParagonThemeOutput = JSON.parse(fs.readFileSync(`${outDir}/${paragonThemeOutputFilename}`, 'utf8'));
@@ -100,6 +112,8 @@ const compileAndWriteStyleSheets = ({
           paragonThemeOutput: existingParagonThemeOutput,
           name,
           isThemeVariant,
+          isDefaultThemeVariant,
+          isDarkThemeVariant,
         });
       }
       fs.writeFileSync(`${outDir}/${paragonThemeOutputFilename}`, `${JSON.stringify(paragonThemeOutput, null, 2)}\n`);
@@ -171,6 +185,9 @@ program
           stylesPath: `${themesPath}/${themeDir.name}/index.css`,
           outDir,
           isThemeVariant: true,
+          isDefaultThemeVariant: themeDir.name === 'light',
+          // "dark" theme dri does not exist yet, but no harm in having this here
+          isDarkThemeVariant: themeDir.name === 'dark',
         });
       });
   });

--- a/build-scss.js
+++ b/build-scss.js
@@ -186,7 +186,7 @@ program
           outDir,
           isThemeVariant: true,
           isDefaultThemeVariant: themeDir.name === 'light',
-          // "dark" theme dri does not exist yet, but no harm in having this here
+          // "dark" theme dir does not exist yet, but no harm in having this here
           isDarkThemeVariant: themeDir.name === 'dark',
         });
       });


### PR DESCRIPTION
## Description

Updates the `paragon-theme.json` output during `npm run build` to look like:

```json
{
  "themeUrls": {
    "core": {
      "paths": {
        "default": "./core.css",
        "minified": "./core.min.css"
      }
    },
    "variants": {
      "light": {
        "paths": {
          "default": "./light.css",
          "minified": "./light.min.css"
        },
        "default": true,
        "dark": false
      }
    }
  }
}
```

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
