### PR TITLE
fix: link typo for bootstrap Stack

### DIFF
--- a/src/Stack/README.md
+++ b/src/Stack/README.md
@@ -11,7 +11,7 @@ devStatus: 'In progress'
 notes: |
 ---
 
-Shorthand helpers that build on top of our flexbox utilities to make component layout faster and easier than ever. Similar to the [Boostrap Stack](https://react-bootstrap.github.io/layout/stack/) component.
+Shorthand helpers that build on top of our flexbox utilities to make component layout faster and easier than ever. Similar to the [Bootstrap Stack](https://react-bootstrap.github.io/docs/layout/stack/) component.
 
 ## Basic Usage
 

--- a/www/src/pages/foundations/responsive.jsx
+++ b/www/src/pages/foundations/responsive.jsx
@@ -7,7 +7,7 @@ import CodeBlock from '../../components/CodeBlock';
 
 const BREAKPOINT_DESCRIPTIONS = {
   extraSmall: { name: 'Extra small', identifier: 'xs' },
-  small: { name: 'Small', identifier: 'xs' },
+  small: { name: 'Small', identifier: 'sm' },
   medium: { name: 'Medium', identifier: 'md' },
   large: { name: 'Large', identifier: 'lg' },
   extraLarge: { name: 'Extra large', identifier: 'xl' },


### PR DESCRIPTION
## Description

This is a quick fix for two typos that were found while browsing the Paragon site. 

1. The [Responsive breakpoints](https://paragon-openedx.netlify.app/foundations/responsive) have the identifier for "Small" set to "xs" when it should be "sm". 
2. The link for the `Stack` component in Bootstrap's documentation has been updated

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
