### PR TITLE
feat: add customizability to the stepper header's compact view, so preferred max width can determine when compact view occurs

### DIFF
--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -5,6 +5,7 @@ import StepperHeaderStep from './StepperHeaderStep';
 import { StepperContext } from './StepperContext';
 import useWindowSize from '../hooks/useWindowSize';
 import breakpoints from '../utils/breakpoints';
+import { Size } from '../utils/constants';
 
 function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
@@ -34,7 +35,8 @@ const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex +
 function StepperHeader({ className, PageCountComponent, compactWidth }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
-  const breakpointWidth = breakpoints[compactWidth].maxWidth;
+  const size = Size[compactWidth] || 'small';
+  const breakpointWidth = breakpoints[size].maxWidth;
   const isCompactView = windowDimensions.width < breakpointWidth;
 
   if (isCompactView) {
@@ -72,16 +74,15 @@ StepperHeader.propTypes = {
   /** A component that receives `activeStepIndex` and `totalSteps` props to display them. */
   PageCountComponent: PropTypes.elementType,
   /** The max width in which the compact view of the header will switch to display the step number that is
-   * currently in progress. To change the max width, use 'extraSmall', 'medium', 'large',
-   * 'extraLarge', 'extraExtraLarge'
+   * currently in progress. Options include 'xs', 'sm', 'md', 'lg', 'xl', and 'xxl'.
    */
-  compactWidth: PropTypes.string,
+  compactWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', 'xxl']),
 };
 
 StepperHeader.defaultProps = {
   className: null,
   PageCountComponent: PageCount,
-  compactWidth: 'small',
+  compactWidth: 'sm',
 };
 
 StepList.propTypes = {

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -4,8 +4,7 @@ import classNames from 'classnames';
 import StepperHeaderStep from './StepperHeaderStep';
 import { StepperContext } from './StepperContext';
 import useWindowSize from '../hooks/useWindowSize';
-import breakpoints from '../utils/breakpoints';
-import { Size } from '../utils/constants';
+import breakpoints, { Size } from '../utils/breakpoints';
 
 function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import StepperHeaderStep from './StepperHeaderStep';
 import { StepperContext } from './StepperContext';
 import useWindowSize from '../hooks/useWindowSize';
+import breakpoints from '../utils/breakpoints';
 
 function StepListSeparator() {
   return <li aria-hidden="true" className="pgn__stepper-header-line" />;
@@ -30,11 +31,11 @@ function StepList({ steps, activeKey }) {
 
 const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex + 1} of ${totalSteps}`;
 
-function StepperHeader({ className, PageCountComponent }) {
+function StepperHeader({ className, PageCountComponent, compactWidth }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
-  // assume about 200px per step
-  const isCompactView = windowDimensions.width < (steps.length * 200);
+  const breakpointWidth = breakpoints[compactWidth].maxWidth;
+  const isCompactView = windowDimensions.width < breakpointWidth;
 
   if (isCompactView) {
     const activeStepIndex = steps.findIndex(step => step.eventKey === activeKey);
@@ -70,11 +71,17 @@ StepperHeader.propTypes = {
   className: PropTypes.string,
   /** A component that receives `activeStepIndex` and `totalSteps` props to display them. */
   PageCountComponent: PropTypes.elementType,
+  /** The max width in which the compact view of the header will switch to display the step number that is
+   * currently in progress. To change the max width, use 'extraSmall', 'medium', 'large',
+   * 'extraLarge', 'extraExtraLarge'
+   */
+  compactWidth: PropTypes.string,
 };
 
 StepperHeader.defaultProps = {
   className: null,
   PageCountComponent: PageCount,
+  compactWidth: 'small',
 };
 
 StepList.propTypes = {

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -36,7 +36,7 @@ function StepperHeader({ className, PageCountComponent, compactWidth }) {
   const { steps, activeKey } = useContext(StepperContext);
   const windowDimensions = useWindowSize();
   const size = Size[compactWidth] || 'small';
-  const breakpointWidth = breakpoints[size].maxWidth;
+  const breakpointWidth = breakpoints[size].maxWidth || Infinity;
   const isCompactView = windowDimensions.width < breakpointWidth;
 
   if (isCompactView) {

--- a/src/Stepper/tests/Stepper.test.jsx
+++ b/src/Stepper/tests/Stepper.test.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Stepper from '../Stepper';
+import StepperHeader from '../StepperHeader';
 import StepperHeaderStep from '../StepperHeaderStep';
 import { stepsReducer } from '../StepperContext';
 
@@ -16,7 +17,7 @@ function Example({
 }) {
   return (
     <Stepper activeKey={activeKey}>
-      <Stepper.Header />
+      <Stepper.Header compactWidth="sm" />
 
       <Stepper.Step
         eventKey="welcome"
@@ -101,6 +102,37 @@ describe('Stepper', () => {
       const step = screen.getAllByRole('button').find(button => button.textContent.includes('Welcome'));
       fireEvent.click(step);
       expect(onStepClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stepper header compact view', () => {
+    beforeEach(() => {
+      mockWindowSize.width = 200;
+      wrapper.update();
+    });
+
+    afterEach(() => {
+      mockWindowSize.width = 1000;
+      wrapper.update();
+    });
+
+    const step = '.flex-grow-1';
+
+    it('renders the compact view of stepper header', () => {
+      wrapper.setProps({ activeKey: 'cats' });
+      expect(wrapper.find(StepperHeader).exists(step)).toBe(true);
+    });
+
+    it('renders the standard view when the window is outside of the max width for compact view', () => {
+      mockWindowSize.width = 800;
+      wrapper.setProps({ activeKey: 'cats' });
+      expect(wrapper.find(StepperHeader).exists(step)).toBe(false);
+    });
+
+    it('renders the compact view when the desired max width is medium', () => {
+      wrapper.setProps({ compactWidth: 'md', activeKey: 'cats' });
+      mockWindowSize.width = 768;
+      expect(wrapper.find(StepperHeader).exists(step)).toBe(true);
     });
   });
 

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -29,4 +29,13 @@ const breakpoints = {
   },
 };
 
+export const Size = Object.freeze({
+  xs: 'extraSmall',
+  sm: 'small',
+  md: 'medium',
+  lg: 'large',
+  xl: 'extraLarge',
+  xxl: 'extraExtraLarge',
+});
+
 export default breakpoints;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,4 +7,13 @@ const Variant = Object.freeze({
   },
 });
 
+export const Size = Object.freeze({
+  xs: 'extraSmall',
+  sm: 'small',
+  md: 'medium',
+  lg: 'large',
+  xl: 'extraLarge',
+  xxl: 'extraExtraLarge',
+});
+
 export default Variant;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,13 +7,4 @@ const Variant = Object.freeze({
   },
 });
 
-export const Size = Object.freeze({
-  xs: 'extraSmall',
-  sm: 'small',
-  md: 'medium',
-  lg: 'large',
-  xl: 'extraLarge',
-  xxl: 'extraExtraLarge',
-});
-
 export default Variant;


### PR DESCRIPTION
## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).
<img width="695" alt="Screenshot 2023-06-01 at 3 15 54 PM" src="https://github.com/openedx/paragon/assets/62807795/305cccfd-c14b-4e4a-a137-bf060fb62aa9">
<img width="693" alt="Screenshot 2023-06-01 at 3 16 20 PM" src="https://github.com/openedx/paragon/assets/62807795/f458d974-9223-45e9-a8e4-02e3662f5f43">

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
