### PR TITLE
fix: avoid infinite while loop with `colorYiq`

### DIFF
--- a/styles/css/core/custom-media-breakpoints.css
+++ b/styles/css/core/custom-media-breakpoints.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Thu, 01 Jun 2023 14:00:29 GMT
+ * Generated on Sat, 03 Jun 2023 13:27:55 GMT
  */
 
 @custom-media --min-pgn-size-breakpoint-xs (min-width: 0);

--- a/styles/css/core/variables.css
+++ b/styles/css/core/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Thu, 01 Jun 2023 14:00:29 GMT
+ * Generated on Sat, 03 Jun 2023 13:27:55 GMT
  */
 
 :root {

--- a/styles/css/themes/light/utility-classes.css
+++ b/styles/css/themes/light/utility-classes.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Thu, 01 Jun 2023 14:00:29 GMT
+ * Generated on Sat, 03 Jun 2023 13:27:55 GMT
  */
 
 .bg-accent-a {

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Thu, 01 Jun 2023 14:00:29 GMT
+ * Generated on Sat, 03 Jun 2023 13:27:55 GMT
  */
 
 :root {

--- a/tokens/sass-helpers.js
+++ b/tokens/sass-helpers.js
@@ -6,14 +6,24 @@ const chroma = require('chroma-js');
  * Javascript version of bootstrap's color-yiq function. Decides whether to return light color variant or dark one
  * based on contrast value of the input color
  *
- * @param color - chroma-js color instance
- * @param {String} [themeVariant] - theme variant name that will be used to find default contrast colors
- * @param {String} [light] - light color variant from ./src/themes/{themeVariant}/global/other.json
- * @param {String} [dark] - dark color variant from ./src/themes/{themeVariant}/global/other.json
- * @param {Number} [threshold] - contrast threshold from ./src/core/global/other.json
+ * @param {Object} args
+ * @param {Object} args.tokenName - Name of design token, used to log warnings
+ * @param {Object} args.color - chroma-js color instance
+ * @param {String} args.light - light color variant from ./src/themes/{themeVariant}/global/other.json
+ * @param {String} args.dark - dark color variant from ./src/themes/{themeVariant}/global/other.json
+ * @param {Number} args.threshold - contrast threshold from ./src/core/global/other.json
+ * @param {String} [args.themeVariant] - theme variant name that will be used to find default contrast colors
+ *
  * @return chroma-js color instance (one of dark or light variants)
  */
-function colorYiq(color, light, dark, threshold, themeVariant = 'light') {
+function colorYiq({
+  tokenName,
+  originalColor,
+  light,
+  dark,
+  threshold,
+  themeVariant = 'light',
+}) {
   const defaultThresholdFile = fs.readFileSync(path.resolve(__dirname, 'src/core/global', 'other.json'), 'utf8');
   const defaultThreshold = JSON.parse(defaultThresholdFile)['yiq-contrasted-threshold'];
 
@@ -27,24 +37,37 @@ function colorYiq(color, light, dark, threshold, themeVariant = 'light') {
   const lightColor = light || defaultLight;
   const darkColor = dark || defaultDark;
 
-  const [r, g, b] = color.rgb();
+  const [r, g, b] = originalColor.rgb();
   const yiq = ((r * 299) + (g * 587) + (b * 114)) * 0.001;
 
   let result = yiq >= contrastThreshold ? chroma(darkColor) : chroma(lightColor);
 
+  const maxAttempts = 10; // maximum number of attempts to darken/brighten color to pass contrast ratio
   if (yiq >= contrastThreshold) {
     // check whether the resulting combination of colors passes a11y contrast ratio of 4:5:1
-    // if not - darken resulting color until it does
-    while (chroma.contrast(color, result) < 4.5) {
+    // if not - darken resulting color until it does until maxAttempts is reached.
+    let numDarkenAttempts = 1;
+    while (chroma.contrast(originalColor, result) < 4.5 && numDarkenAttempts <= maxAttempts) {
       result = result.darken(0.1);
+      numDarkenAttempts += 1;
+      if (numDarkenAttempts === maxAttempts) {
+        // eslint-disable-next-line no-console
+        console.warn(`WARNING: Failed to darken ${tokenName} to pass contrast ratio of 4.5:1 (Original: ${originalColor.hex()}; Attempted: ${result.hex()}).`);
+      }
     }
     return result;
   }
 
   // check whether the resulting combination of colors passes a11y contrast ratio of 4:5:1
-  // if not - brighten resulting color until it does
-  while (chroma.contrast(color, result) < 4.5) {
+  // if not - brighten resulting color until it does until maxAttempts is reached.
+  let numBrightenAttempts = 1;
+  while (chroma.contrast(originalColor, result) < 4.5 && numBrightenAttempts <= maxAttempts) {
     result = result.brighten(0.1);
+    numBrightenAttempts += 1;
+    if (numBrightenAttempts === maxAttempts) {
+      // eslint-disable-next-line no-console
+      console.warn(`WARNING: Failed to brighten ${tokenName} () to pass contrast ratio of 4.5:1 (Original: ${originalColor.hex()}; Attempted: ${result.hex()}).`);
+    }
   }
   return result;
 }

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -9,7 +9,12 @@ const cssUtilities = require('./css-utilities');
 const { fileHeader, sortByReference } = StyleDictionary.formatHelpers;
 
 const colorTransform = (token, theme) => {
-  const { value, modify = [], original } = token;
+  const {
+    name: tokenName,
+    value,
+    original,
+    modify = [],
+  } = token;
   const reservedColorValues = ['inherit', 'initial', 'revert', 'unset', 'currentColor'];
 
   if (reservedColorValues.includes(original.value)) {
@@ -27,7 +32,14 @@ const colorTransform = (token, theme) => {
           break;
         case 'color-yiq': {
           const { light, dark, threshold } = modifier;
-          color = colorYiq(color, light, dark, threshold, theme);
+          color = colorYiq({
+            tokenName,
+            originalColor: color,
+            light,
+            dark,
+            threshold,
+            theme,
+          });
           break;
         }
         case 'darken':

--- a/www/src/components/Menu.scss
+++ b/www/src/components/Menu.scss
@@ -37,7 +37,7 @@
   }
 
   &-items {
-    margin-bottom: $spacer;
+    margin-bottom: var(--pgn-spacing-spacer-base);
 
     .pgn_collapsible {
       font-size: var(--pgn-typography-font-size-xs);


### PR DESCRIPTION
## Description

Running the updated `colorYiq` function that tries to automatically darken/brighten color tokens if they do not pass background/foreground color contrast ratio of 4.5:1 for a11y hits an infinite loop if the colors can never meet a 4.5:1 contrast ratio.

This PR ensures we only try to brighten/darken tokens a max of 10 times to avoid an infinite loop. Consoles a warning with the design token name when it couldn't brighten/darken tokens sufficiently to pass a 4.5:1 contrast ratio.

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
