### PR TITLE
feat: create themes flag to build tokens

### DIFF
--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -2,7 +2,7 @@
 const { program } = require('commander');
 const path = require('path');
 const { StyleDictionary, colorTransform, createCustomCSSVariables } = require('./style-dictionary');
-const { createIndexFile } = require('./utils');
+const { createIndexCssFile } = require('./utils');
 
 program
   .version('0.0.1')
@@ -10,14 +10,14 @@ program
   .option('--build-dir <char>', 'A path to directory where to put files with built tokens, must end with a /.', './build/')
   .option('--source <char>', 'A path where to look for additional tokens that will get merged with Paragon ones, must be a path to root directory of the token files that contains "root" and "themes" subdirectories.')
   .option('--source-tokens-only', 'If provided, only tokens from --source will be included in the output; Paragon tokens will be used for references but not included in the output.')
-  .option('--themes <themes...>', 'A list of all the themes do you want to build, by default Paragn build light theme.')
+  .option('--themes <themes...>', 'A list of theme variants to build. By default, Paragon currently only supports a light theme.')
   .parse();
 
 const {
   buildDir,
   source: tokensSource,
   sourceTokensOnly: hasSourceTokensOnly,
-  themes
+  themes,
 } = program.opts();
 
 const coreConfig = {
@@ -99,14 +99,12 @@ const getStyleDictionaryConfig = (themeVariant) => ({
 StyleDictionary.extend(coreConfig).buildAllPlatforms();
 
 // This line creates the index file for core folder, specially when buildDir is outside Paragon.
-createIndexFile(buildDir,false);
+createIndexCssFile({ buildDir, isTheme: false });
 
-const THEME_VARIANTS = themes ? themes : ['light'];
+const THEME_VARIANTS = themes || ['light'];
 
 THEME_VARIANTS.forEach((themeVariant) => {
   const config = getStyleDictionaryConfig(themeVariant);
   StyleDictionary.extend(config).buildAllPlatforms();
-  createIndexFile(buildDir,true, themeVariant);
-
+  createIndexCssFile({ buildDir, isTheme: true, themeVariant });
 });
-

--- a/tokens/build-tokens.js
+++ b/tokens/build-tokens.js
@@ -2,6 +2,7 @@
 const { program } = require('commander');
 const path = require('path');
 const { StyleDictionary, colorTransform, createCustomCSSVariables } = require('./style-dictionary');
+const { createIndexFile } = require('./utils');
 
 program
   .version('0.0.1')
@@ -9,12 +10,14 @@ program
   .option('--build-dir <char>', 'A path to directory where to put files with built tokens, must end with a /.', './build/')
   .option('--source <char>', 'A path where to look for additional tokens that will get merged with Paragon ones, must be a path to root directory of the token files that contains "root" and "themes" subdirectories.')
   .option('--source-tokens-only', 'If provided, only tokens from --source will be included in the output; Paragon tokens will be used for references but not included in the output.')
+  .option('--themes <themes...>', 'A list of all the themes do you want to build, by default Paragn build light theme.')
   .parse();
 
 const {
   buildDir,
   source: tokensSource,
   sourceTokensOnly: hasSourceTokensOnly,
+  themes
 } = program.opts();
 
 const coreConfig = {
@@ -95,9 +98,15 @@ const getStyleDictionaryConfig = (themeVariant) => ({
 
 StyleDictionary.extend(coreConfig).buildAllPlatforms();
 
-const THEME_VARIANTS = ['light'];
+// This line creates the index file for core folder, specially when buildDir is outside Paragon.
+createIndexFile(buildDir,false);
+
+const THEME_VARIANTS = themes ? themes : ['light'];
 
 THEME_VARIANTS.forEach((themeVariant) => {
   const config = getStyleDictionaryConfig(themeVariant);
   StyleDictionary.extend(config).buildAllPlatforms();
+  createIndexFile(buildDir,true, themeVariant);
+
 });
+

--- a/tokens/utils.js
+++ b/tokens/utils.js
@@ -162,7 +162,37 @@ async function transformInPath(location, variablesMap, transformType = 'definiti
   }
 }
 
+
+function createIndexFile(buildDir, isTheme, themeVariant){
+  const directoryPath = isTheme ? `${buildDir}/themes/${themeVariant}`:`${buildDir}/core`;
+  
+fs.readdir(directoryPath, (err, files) => {
+  if (err) {
+    console.error('Error reading directory:', err);
+    return;
+  }
+
+  const jsonFiles = files.filter(file => file !== 'index.css');
+  isTheme && jsonFiles.reverse();
+
+  const exportStatements = jsonFiles.map((file) => {
+    const fileName = path.basename(file, '.css');
+    return `@import "${fileName}";`;
+  });
+
+  const indexContent = exportStatements.join('\n');
+
+  fs.writeFile(path.join(directoryPath, 'index.css'), indexContent, (err) => {
+    if (err) {
+      console.error('Error creating index file:', err);
+      return;
+     }
+    });
+  });
+}
+
 module.exports = {
+  createIndexFile,
   getFilesWithExtension,
   getSCSStoCSSMap,
   transformInPath,

--- a/tokens/utils.js
+++ b/tokens/utils.js
@@ -162,37 +162,36 @@ async function transformInPath(location, variablesMap, transformType = 'definiti
   }
 }
 
+function createIndexCssFile({ buildDir = path.resolve(__dirname, '../styles/css'), isTheme, themeVariant }) {
+  const directoryPath = isTheme ? `${buildDir}/themes/${themeVariant}` : `${buildDir}/core`;
 
-function createIndexFile(buildDir, isTheme, themeVariant){
-  const directoryPath = isTheme ? `${buildDir}/themes/${themeVariant}`:`${buildDir}/core`;
-  
-fs.readdir(directoryPath, (err, files) => {
-  if (err) {
-    console.error('Error reading directory:', err);
-    return;
-  }
-
-  const jsonFiles = files.filter(file => file !== 'index.css');
-  isTheme && jsonFiles.reverse();
-
-  const exportStatements = jsonFiles.map((file) => {
-    const fileName = path.basename(file, '.css');
-    return `@import "${fileName}";`;
-  });
-
-  const indexContent = exportStatements.join('\n');
-
-  fs.writeFile(path.join(directoryPath, 'index.css'), indexContent, (err) => {
-    if (err) {
-      console.error('Error creating index file:', err);
+  fs.readdir(directoryPath, (errDir, files) => {
+    if (errDir) {
+      // eslint-disable-next-line no-console
+      console.error('Error reading directory:', errDir);
       return;
-     }
+    }
+
+    const outputCssFiles = files.filter(file => file !== 'index.css');
+    // When creating themes, there are typically two files: one for utility classes and one for variables.
+    // It's organized them to allow variables be reading first.
+    if (isTheme) { outputCssFiles.reverse(); }
+
+    const exportStatements = outputCssFiles.map((file) => `@import "${file}";`);
+
+    const indexContent = `${exportStatements.join('\n')}\n`;
+
+    fs.writeFile(path.join(directoryPath, 'index.css'), indexContent, (errFile) => {
+      if (errFile) {
+        // eslint-disable-next-line no-console
+        console.error('Error creating index file:', errFile);
+      }
     });
   });
 }
 
 module.exports = {
-  createIndexFile,
+  createIndexCssFile,
   getFilesWithExtension,
   getSCSStoCSSMap,
   transformInPath,


### PR DESCRIPTION
## Description

This PR is a proposal to be able to build tokens of any custom theme throughout CLI. Also, add a function to create the index file for the output, understanding that the build-scss command needs this file.

      themes/ 
        light/
        │  ├─ index.css
        │  ├─ other_css_files
        dark/
        │  ├─ index.css
        │  ├─ other_css_files
        some_other_custom_theme/
        │  ├─ index.css
        │  ├─ other_css_files

The user can run something like `build-design-tokens --build-dir  ./<folder_path> --source /<folder_path> --themes custom_theme_a custom_theme_b light`

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.


@adamstankiewicz  
