### PR TITLE
fix: hyperlink button bug fix

### DIFF
--- a/src/Button/Button.test.jsx
+++ b/src/Button/Button.test.jsx
@@ -4,6 +4,7 @@ import renderer from 'react-test-renderer';
 
 import { Close } from '../../icons';
 import Button from './index';
+import Hyperlink from '../Hyperlink';
 
 describe('<Button />', () => {
   describe('correct rendering', () => {
@@ -81,6 +82,12 @@ describe('<Button />', () => {
         ));
         emptyHref.simulate('click');
         expect(onClick).toHaveBeenCalled();
+      });
+      test('test button as hyperlink', () => {
+        const wrapper = mount((
+          <Button as={Hyperlink} destination="https://www.poop.com/💩">Button</Button>
+        ));
+        expect(wrapper.find('a').prop('href')).toEqual('https://www.poop.com/💩');
       });
     });
   });

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -36,8 +36,6 @@ Button.propTypes = {
   /** A function that would specify what the button should do when the `onClick` event is triggered.
    * For example, the button could launch a `Modal`. The default is an empty function. */
   onClick: PropTypes.func,
-  /** Providing a `href` will render an `<a>` element, styled as a button. */
-  href: PropTypes.string,
   /** A function that would specify what the button should do when the `onKeyDown` event is triggered.
    * For example, this could handle using the `Escape` key to trigger the button's action.
    * The default is an empty function. */
@@ -66,7 +64,6 @@ Button.defaultProps = {
   className: undefined,
   iconBefore: undefined,
   iconAfter: undefined,
-  href: undefined,
   disabled: false,
 };
 


### PR DESCRIPTION
## Description

Quick fix that allows buttons formatted as hyperlinks to be clickable. 

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
