### PR TITLE
fix: use .css extension on react-loading-skeleton import

### DIFF
--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -5,7 +5,12 @@
 @import "~bootstrap/scss/reboot";
 @import "typography";
 @import "grid";
-@import "~react-loading-skeleton/dist/skeleton";
+// The react-loading-skeleton package.json defines an 'exports' field which specifies a '.css'
+// extension on this export.  Without the '.css' on the end of this line, webpack can't find the file
+// and the build fails.
+// See https://webpack.js.org/guides/package-exports/ for more information on how webpack uses
+// the 'exports' field.
+@import "~react-loading-skeleton/dist/skeleton.css";
 @import "~bootstrap/scss/transitions";
 @import "utilities";
 @import "~bootstrap/scss/media";


### PR DESCRIPTION
Folks are seeing errors like this in MFEs:

```
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Can't find stylesheet to import.
  ╷
8 │ @import "~react-loading-skeleton/dist/skeleton";
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  node_modules/@edx/paragon/scss/core/core.scss 8:9  @import
  src/index.scss 3:9                                 root stylesheet
```

react-loading-skeleton defines an exports field in its package.json which looks like this:

```
"exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "require": "./dist/index.cjs",
      "import": "./dist/index.js"
    },
    "./dist/skeleton.css": "./dist/skeleton.css"
  },
```

The webpack documentation states that if an exports field is defined in package.json, it replaces the default module loading behavior and any other request for a module will result in a ModuleNotFound error.

Our call to load react-loading-skeleton in Paragon looks like this:

```
@import "~react-loading-skeleton/dist/skeleton";
```

That isn’t in the list of possible exports.  This is though:

```
@import "~react-loading-skeleton/dist/skeleton.css";
```

This commit updates our import to the latter, which fixes downstream issues in MFEs that can’t figure out how to import react-loading-skeleton

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
