### PR TITLE
[BD-46] docs: make internationalized components available in playroom

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -55,6 +55,17 @@ exports.THEMES = [
 
     and your theme will automatically get picked up during the build.
 
+## Running playground locally
+
+Playground is a separate application (provided by [playroom](https://github.com/seek-oss/playroom) package) that in production gets bundled together with docs site and is served by gatsby by rendering this application in an iframe on the `/playground` route.
+Currently, there is no way to reproduce this behaviour id development mode. To work with playground locally you have to start `playroom`'s dev server and work with it separately from the docs site, to do that run
+
+```sh
+npm playroom start
+```
+
+which will make playroom available at http://localhost:9000/ with hot-reloading support.
+
 ## Feature Flags
 In some scenarios, it is helpful to put your changes to the Paragon documentation site behind a feature flag so that you have more control over how a particular feature or change is rolled out more broadly.
 

--- a/www/playroom/FrameComponent.jsx
+++ b/www/playroom/FrameComponent.jsx
@@ -1,24 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
+import { IntlProvider } from 'react-intl';
 
 export default function FrameComponent({ theme, children }) {
   return (
-    <main style={{ padding: '16px' }}>
-      <Helmet>
-        <link
-          href="/static/openedx-theme.css"
-          rel={`stylesheet${theme === 'openedx' ? '' : ' alternate'}`}
-          type="text/css"
-        />
-        <link
-          href="/static/edxorg-theme.css"
-          rel={`stylesheet${theme === 'edX.org' ? '' : ' alternate'}`}
-          type="text/css"
-        />
-      </Helmet>
-      {children}
-    </main>
+    <IntlProvider locale="en">
+      <main style={{ padding: '16px' }}>
+        <Helmet>
+          <link
+            href="/static/openedx-theme.css"
+            rel={`stylesheet${theme === 'openedx' ? '' : ' alternate'}`}
+            type="text/css"
+          />
+          <link
+            href="/static/edxorg-theme.css"
+            rel={`stylesheet${theme === 'edX.org' ? '' : ' alternate'}`}
+            type="text/css"
+          />
+        </Helmet>
+        {children}
+      </main>
+    </IntlProvider>
   );
 }
 


### PR DESCRIPTION
## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
