### PR TITLE
[BD-46] docs: replaced SCSS variables with CSS variables on the Colors page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7705,27 +7705,6 @@
         "@types/tern": "*"
       }
     },
-    "node_modules/@types/color": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/color-convert": "*"
-      }
-    },
-    "node_modules/@types/color-convert": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/color-name": "*"
-      }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/common-tags": {
       "version": "1.8.1",
       "license": "MIT"
@@ -39313,7 +39292,6 @@
         "analytics-node": "^6.0.0",
         "axios": "^0.27.2",
         "classnames": "^2.3.1",
-        "color": "^4.2.3",
         "gatsby": "^4.23.1",
         "gatsby-plugin-manifest": "^4.17.0",
         "gatsby-plugin-mdx": "^3.17.0",
@@ -39350,7 +39328,6 @@
         "@babel/preset-typescript": "^7.16.7",
         "@edx/eslint-config": "^3.1.0",
         "@svgr/webpack": "6.5.1",
-        "@types/color": "^3.0.3",
         "@types/mdx": "^2.0.3",
         "@types/mdx-js__react": "^1.5.5",
         "@types/react-helmet": "^6.1.6",

--- a/www/package.json
+++ b/www/package.json
@@ -10,7 +10,6 @@
     "analytics-node": "^6.0.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
-    "color": "^4.2.3",
     "gatsby": "^4.23.1",
     "gatsby-plugin-manifest": "^4.17.0",
     "gatsby-plugin-mdx": "^3.17.0",
@@ -36,8 +35,8 @@
     "rehype-slug": "^4.0.1",
     "sass": "^1.53.0",
     "sass-loader": "12.6.0",
-    "uuid": "^9.0.0",
-    "slugify": "^1.6.5"
+    "slugify": "^1.6.5",
+    "uuid": "^9.0.0"
   },
   "keywords": [
     "paragon",
@@ -68,7 +67,6 @@
     "@babel/preset-typescript": "^7.16.7",
     "@edx/eslint-config": "^3.1.0",
     "@svgr/webpack": "6.5.1",
-    "@types/color": "^3.0.3",
     "@types/mdx": "^2.0.3",
     "@types/mdx-js__react": "^1.5.5",
     "@types/react-helmet": "^6.1.6",

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -27,11 +27,6 @@ import { SettingsContext } from '../context/SettingsContext';
 import LeaveFeedback from './LeaveFeedback';
 import AutoToc from './AutoToc';
 
-if (process.env.NODE_ENV === 'development') {
-  /* eslint-disable-next-line global-require */
-  require('~paragon-style/scss/core/core.scss');
-}
-
 export interface ILayout {
   children: React.ReactNode,
   showMinimizedTitle: boolean,

--- a/www/src/components/_doc-elements.scss
+++ b/www/src/components/_doc-elements.scss
@@ -324,3 +324,9 @@
 .pgn-doc__box-shadow-toolkit--controls-box--remove-btn svg {
   color: var(--pgn-color-white);
 }
+
+.color-palette {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+  grid-row-gap: 2rem;
+}

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -55,10 +55,10 @@ export interface ISwatch {
   isUnused?: boolean,
 }
 
-const styles = getComputedStyle(document.body);
+const styles = typeof window !== 'undefined' ? getComputedStyle(document.body) : null;
 
 function Swatch({ name, colorClassName, isUnused }: ISwatch) {
-  const computedValue = styles.getPropertyValue(name);
+  const computedValue = styles?.getPropertyValue(name);
 
   return (
     <div className="d-flex align-items-center mb-2">
@@ -71,6 +71,7 @@ function Swatch({ name, colorClassName, isUnused }: ISwatch) {
         <code className="mb-0 d-block text-lowercase text-dark-700">
           {`var(${name})`}
         </code>
+
         <code style={{ fontSize: '65%' }} className="text-muted">
           {computedValue}
         </code>
@@ -128,16 +129,15 @@ export default function ColorsPage({ data }: IColorsPage) {
           {colors
             .slice(0, 3)
             .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
+          {colors
+            .slice(3)
+            .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
           <div>
             <p className="h5">accents</p>
 
             <Swatch name="--pgn-color-accent-a" colorClassName="bg-accent-a" />
             <Swatch name="--pgn-color-accent-b" colorClassName="bg-accent-b" />
           </div>
-
-          {colors
-            .slice(3)
-            .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
         </div>
 
         <h3>CSS Color Usage</h3>

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -49,15 +49,18 @@ function parseColors(cssSelectors: { selector: string; declarations: string; }[]
   });
 }
 
+export type CSSStyleDeclarationType = CSSStyleDeclaration | null;
+
 export interface ISwatch {
   name: string,
   colorClassName: string,
   isUnused?: boolean,
+  styles: CSSStyleDeclarationType,
 }
 
-const styles = typeof window !== 'undefined' ? getComputedStyle(document.body) : null;
-
-function Swatch({ name, colorClassName, isUnused }: ISwatch) {
+function Swatch({
+  name, colorClassName, isUnused, styles,
+}: ISwatch) {
   const computedValue = styles?.getPropertyValue(name);
 
   return (
@@ -90,7 +93,7 @@ Swatch.defaultProps = {
   isUnused: false,
 };
 
-const renderColorRamp = (themeName: string, unusedLevels: number[]) => (
+const renderColorRamp = (themeName: string, unusedLevels: number[], styles: CSSStyleDeclarationType) => (
   <div
     key={`${themeName}`}
   >
@@ -101,6 +104,7 @@ const renderColorRamp = (themeName: string, unusedLevels: number[]) => (
         name={`--pgn-color-${themeName}-${level}`}
         colorClassName={utilityClasses.bg(themeName, level)}
         isUnused={unusedLevels.includes(level)}
+        styles={styles}
       />
     ))}
   </div>
@@ -117,6 +121,8 @@ export interface IColorsPage {
 // eslint-disable-next-line react/prop-types
 export default function ColorsPage({ data }: IColorsPage) {
   const { settings } = useContext(SettingsContext);
+  const styles = typeof window !== 'undefined' ? getComputedStyle(document.body) : null;
+
   parseColors(data.allCssUtilityClasses.nodes); // eslint-disable-line react/prop-types
 
   return (
@@ -128,15 +134,15 @@ export default function ColorsPage({ data }: IColorsPage) {
         <div className="color-palette mb-3">
           {colors
             .slice(0, 3)
-            .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
+            .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels, styles))}
           {colors
             .slice(3)
-            .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
+            .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels, styles))}
           <div>
             <p className="h5">accents</p>
 
-            <Swatch name="--pgn-color-accent-a" colorClassName="bg-accent-a" />
-            <Swatch name="--pgn-color-accent-b" colorClassName="bg-accent-b" />
+            <Swatch name="--pgn-color-accent-a" colorClassName="bg-accent-a" styles={styles} />
+            <Swatch name="--pgn-color-accent-b" colorClassName="bg-accent-b" styles={styles} />
           </div>
         </div>
 

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -2,10 +2,8 @@ import React, { useContext } from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Color from 'color';
 import { Container, DataTable } from '~paragon-react';
 import SEO from '../../components/SEO';
-import MeasuredItem from '../../components/MeasuredItem';
 import Layout from '../../components/PageLayout';
 import { SettingsContext } from '../../context/SettingsContext';
 import { CodeCell } from '../../components/TableCells';
@@ -57,30 +55,26 @@ export interface ISwatch {
   isUnused?: boolean,
 }
 
+const styles = getComputedStyle(document.body);
+
 function Swatch({ name, colorClassName, isUnused }: ISwatch) {
+  const computedValue = styles.getPropertyValue(name);
+
   return (
     <div className="d-flex align-items-center mb-2">
-      <MeasuredItem
-        properties={['background-color']}
-        renderAfter={(measurements: { [x: string]: JSX.Element; }) => (
-          <div style={{ lineHeight: 1 }} className="small">
-            <code className="mb-0 d-block text-lowercase text-dark-700">
-              {name}
-            </code>
-            {measurements['background-color'] && (
-            <code style={{ fontSize: '65%' }} className="text-muted">
-              {Color(measurements['background-color']).hex()}
-            </code>
-            )}
-          </div>
-        )}
-      >
-        <div
-          className={classNames('p-3 mr-2 rounded', colorClassName, {
-            'unused-level': isUnused,
-          })}
-        />
-      </MeasuredItem>
+      <div
+        className={classNames('p-3 mr-2 rounded', colorClassName, {
+          'unused-level': isUnused,
+        })}
+      />
+      <div style={{ lineHeight: 1 }} className="small">
+        <code className="mb-0 d-block text-lowercase text-dark-700">
+          {`var(${name})`}
+        </code>
+        <code style={{ fontSize: '65%' }} className="text-muted">
+          {computedValue}
+        </code>
+      </div>
     </div>
   );
 }
@@ -103,7 +97,7 @@ const renderColorRamp = (themeName: string, unusedLevels: number[]) => (
     {levels.map(level => (
       <Swatch
         key={`${themeName}-${level}`}
-        name={`var(--pgn-color-${themeName}-${level})`}
+        name={`--pgn-color-${themeName}-${level}`}
         colorClassName={utilityClasses.bg(themeName, level)}
         isUnused={unusedLevels.includes(level)}
       />
@@ -137,8 +131,8 @@ export default function ColorsPage({ data }: IColorsPage) {
           <div>
             <p className="h5">accents</p>
 
-            <Swatch name="var(--pgn-color-accent-a)" colorClassName="bg-accent-a" />
-            <Swatch name="var(--pgn-color-accent-b)" colorClassName="bg-accent-b" />
+            <Swatch name="--pgn-color-accent-a" colorClassName="bg-accent-a" />
+            <Swatch name="--pgn-color-accent-b" colorClassName="bg-accent-b" />
           </div>
 
           {colors

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -98,13 +98,12 @@ Swatch.defaultProps = {
 const renderColorRamp = (themeName: string, unusedLevels: number[]) => (
   <div
     key={`${themeName}`}
-    style={{ flexBasis: '24%', marginRight: '1%', marginBottom: '2rem' }}
   >
     <p className="h5">{themeName}</p>
     {levels.map(level => (
       <Swatch
-        key={`$${themeName}-${level}`}
-        name={`$${themeName}-${level}`}
+        key={`${themeName}-${level}`}
+        name={`var(--pgn-color-${themeName}-${level})`}
         colorClassName={utilityClasses.bg(themeName, level)}
         isUnused={unusedLevels.includes(level)}
       />
@@ -131,21 +130,15 @@ export default function ColorsPage({ data }: IColorsPage) {
       <SEO title="Colors" />
       <Container size={settings.containerWidth} className="py-5">
         <h1>Colors</h1>
-        <div className="d-flex flex-wrap">
+        <div className="color-palette mb-3">
           {colors
             .slice(0, 3)
             .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
-          <div
-            style={{
-              flexBasis: '19%',
-              marginRight: '1%',
-              marginBottom: '2rem',
-            }}
-          >
+          <div>
             <p className="h5">accents</p>
 
-            <Swatch name="$accent-a" colorClassName="bg-accent-a" />
-            <Swatch name="$accent-b" colorClassName="bg-accent-b" />
+            <Swatch name="var(--pgn-color-accent-a)" colorClassName="bg-accent-a" />
+            <Swatch name="var(--pgn-color-accent-b)" colorClassName="bg-accent-b" />
           </div>
 
           {colors
@@ -153,101 +146,30 @@ export default function ColorsPage({ data }: IColorsPage) {
             .map(({ themeName, unusedLevels }) => renderColorRamp(themeName, unusedLevels))}
         </div>
 
-        <h3>SCSS Color Usage</h3>
-        <p>Include these colors in scss files in one of two ways:</p>
+        <h3>CSS Color Usage</h3>
 
         <h4>Variable name</h4>
         <code className="d-block mb-4 lead bg-gray-100 p-3">
-          {'// $color_name-level '}
+          {'// var(--pgn-color-name-level) '}
           <br />
-          $primary-100
+          var(--pgn-color-primary-100)
           <br />
-          $primary-200
+          var(--pgn-color-primary-200)
           <br />
-          $brand-100
+          var(--pgn-color-brand-100)
           <br />
-          $brand-200
+          var(--pgn-color-brand-200)
         </code>
 
-        <h4>Mixin (deprecated)</h4>
-        <code className="d-block mb-4 lead bg-gray-100 p-3">
-          theme-color($color-name, $variant)
-        </code>
-
+        <h4>With default value</h4>
         <p>
-          Using the variable name instead of the theme-color mixin will make
-          later upgrade paths easier. Paragon may begin to adopt CSS variables
-          for theming and attempt to eliminate mixins from the public api.
+          Using a default value in CSS variables allows you to set a default value for a variable,
+          which will be used if the primary value of the variable is not defined or not available.
         </p>
-
-        <table className="pgn-doc__table mb-2">
-          <tbody>
-            <tr>
-              <td className="p-3">
-                <strong>Color Name</strong>
-                <br />A theme color
-              </td>
-              <td className="p-3 align-baseline">
-                {colors.map(({ themeName }) => (
-                  <code key={themeName} className="mr-2">
-                    {themeName}
-                  </code>
-                ))}
-              </td>
-            </tr>
-            <tr>
-              <td className="p-3 align-baseline">
-                <strong>Variant</strong>
-                <br />
-                <p>A number level or element type</p>
-              </td>
-              <td className="p-3">
-                <strong className="d-block">Levels </strong>
-                {levels.map((level) => (
-                  <code key={level} className="mr-2">
-                    {level}
-                  </code>
-                ))}
-                <br />
-                <strong className="d-block">Element types </strong>
-                {[
-                  'background',
-                  'disabled-border',
-                  'border',
-                  'icon',
-                  'active-border',
-                  'focus',
-                  'graphic',
-                  'default',
-                  'light-text',
-                  'hover',
-                  'text',
-                  'active',
-                  'dark-text',
-                ].map((element) => (
-                  <code key={element} className="mr-2">
-                    {element}
-                  </code>
-                ))}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h4>Example</h4>
-        <code className="d-block mb-2 bg-gray-100 p-3">
-          border: solid 1px <strong>$gray-300</strong>;
-        </code>
-
-        <code className="d-block mb-2 bg-gray-100 p-3">
-          border: solid 1px{' '}
-          <strong>theme-color(&ldquo;gray&rdquo;, &ldquo;border&rdquo;)</strong>
-          ;
-        </code>
-
-        <code className="d-block mb-4 bg-gray-100 p-3">
-          border: solid 1px{' '}
-          <strong>theme-color(&ldquo;gray&rdquo;, 300)</strong>;
+        <code className="d-block mb-4 lead bg-gray-100 p-3">
+          {'// var(--pgn-color-name-level), default variable '}
+          <br />
+          var(--pgn-color-brand-100, var(--pgn-color-primary-200))
         </code>
 
         <h3>CSS Class Utilities</h3>

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -163,7 +163,7 @@ export default function ColorsPage({ data }: IColorsPage) {
 
         <h4>With default value</h4>
         <p>
-          Using a default value in CSS variables allows you to set a default value for a variable,
+          Using a default value in CSS variables allows to set a default value for a variable,
           which will be used if the primary value of the variable is not defined or not available.
         </p>
         <code className="d-block mb-4 lead bg-gray-100 p-3">


### PR DESCRIPTION
## Description
- refactored Color page;
- added CSS variables.

[Github issue](https://github.com/openedx/paragon/issues/2345)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
