### PR TITLE
[BD-46] fix: fixed Input is not defined in TransitionReplace component

### DIFF
--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -25,10 +25,10 @@ TransitionReplace expects only one child at any time. Swap content inside the co
     <div>
       <TransitionReplace className="mb-3">
         {isEditing ? (
-          <form key="the-form">
-            <label htmlFor="name">First Name</label>
-            <Input type="text" value="some name" />
-          </form>
+          <Form.Group>
+            <Form.Label>First Name</Form.Label>
+            <Form.Control value="some name" />
+          </Form.Group>
         ) : (
           <div key="other">
             <h4 className="mt-0">First Name</h4>


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2367

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
