### PR TITLE
[BD-46] docs: fixed links leading to React Bootstrap

### DIFF
--- a/docs/decisions/0009-usage-of-react-bootstrap.rst
+++ b/docs/decisions/0009-usage-of-react-bootstrap.rst
@@ -93,4 +93,4 @@ Following this decision there will be a pull request containing 18 components th
 References
 ----------
 
-* https://react-bootstrap.github.io/
+* https://react-bootstrap-v4.netlify.app/

--- a/src/Alert/README.md
+++ b/src/Alert/README.md
@@ -21,7 +21,7 @@ Alerts offer four severity levels that set a distinctive icon and color:
 - **Success**: used for success messages
 - **Danger**: used to communicate problems that have to be resolved immediately
 
-This component utilizes and extends the `Alert` component from react-bootstrap.<br/> <a href="https://react-bootstrap.github.io/components/alerts/" target="_blank" rel="noopener noreferrer"> See React-Bootstrap for additional documentation.</a>
+This component utilizes and extends the `Alert` component from react-bootstrap.<br/> <a href="https://react-bootstrap-v4.netlify.app/components/alerts/" target="_blank" rel="noopener noreferrer"> See React-Bootstrap for additional documentation.</a>
 
 ## Basic Usage
 

--- a/src/Badge/README.md
+++ b/src/Badge/README.md
@@ -19,7 +19,7 @@ Badges are composed of text and an accompanying indicator color, and are typical
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/badge/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/badge/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for additional documentation.
   </a>
 </p>

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -12,7 +12,7 @@ notes: |
   TODO: Remove subcomponent of deprecated implementation soon
 ---
 
-This component utilizes `Button` from React-Bootstrap and extends it with an ability to add icons before and after button label, see [below](#with-icons-before-or-after) for usage example.<br/> <a href="https://react-bootstrap.github.io/components/buttons/" target="_blank" rel="noopener noreferrer"> See React-Bootstrap for additional documentation. </a>
+This component utilizes `Button` from React-Bootstrap and extends it with an ability to add icons before and after button label, see [below](#with-icons-before-or-after) for usage example.<br/> <a href="https://react-bootstrap-v4.netlify.app/components/buttons/" target="_blank" rel="noopener noreferrer"> See React-Bootstrap for additional documentation. </a>
 
 ## Core Buttons
 

--- a/src/Button/button-group.mdx
+++ b/src/Button/button-group.mdx
@@ -15,7 +15,7 @@ notes: |
 
 <p className="lead">
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/button-group/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/button-group/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -26,7 +26,7 @@ notes: |
 
 `Card` supports `vertical` and `horizontal` orientation which is controlled by `CardContext`, see examples below.
 
-This component uses a `Card` from react-bootstrap as a base component and extends it with additional subcomponents. <br/> <a href="https://react-bootstrap.github.io/components/cards/" target="_blank" rel="noopener noreferrer">See React-Bootstrap for additional documentation.</a>
+This component uses a `Card` from react-bootstrap as a base component and extends it with additional subcomponents. <br/> <a href="https://react-bootstrap-v4.netlify.app/components/cards/" target="_blank" rel="noopener noreferrer">See React-Bootstrap for additional documentation.</a>
 
 ## Basic Usage
 

--- a/src/Carousel/README.md
+++ b/src/Carousel/README.md
@@ -16,7 +16,7 @@ notes: |
 
 <p className="lead">
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/carousel/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/carousel/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Container/README.md
+++ b/src/Container/README.md
@@ -12,7 +12,7 @@ notes: |
 
 ---
 
-The base container to contain, pad, and center content in the viewport. This component extends the React-Bootstrap `Container`.<br/> <a href="https://react-bootstrap.github.io/layout/grid/" target="_blank" rel="noopener noreferrer">See React-Bootstrap for more documentation.</a>
+The base container to contain, pad, and center content in the viewport. This component extends the React-Bootstrap `Container`.<br/> <a href="https://react-bootstrap-v4.netlify.app/layout/grid/" target="_blank" rel="noopener noreferrer">See React-Bootstrap for more documentation.</a>
 
 ## Basic Usage
 

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -20,7 +20,7 @@ notes: |
 
 <p className="lead">
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/dropdowns/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/dropdowns/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Figure/README.md
+++ b/src/Figure/README.md
@@ -14,7 +14,7 @@ notes: |
 
 <p className="lead">
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/docs/components/figures" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/figures/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Form/input-group.mdx
+++ b/src/Form/input-group.mdx
@@ -14,7 +14,7 @@ notes: |
 
 <p className="lead">
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/input-group/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/input-group/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Hyperlink/README.md
+++ b/src/Hyperlink/README.md
@@ -58,6 +58,7 @@ notes: |
 <Hyperlink destination="https://www.edx.org">
   <Icon
     id="SampleIcon"
+    src={Add}
     className="fa fa-book"
     screenReaderText="Visit edX Home"
   />

--- a/src/Image/README.md
+++ b/src/Image/README.md
@@ -15,7 +15,7 @@ notes: |
 
 <p className="lead">
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/images/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/images/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Nav/README.md
+++ b/src/Nav/README.md
@@ -19,7 +19,7 @@ Navigation bits in Bootstrap all share a general ``Nav`` component and styles. S
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/navs/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/navs/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for additional documentation.
   </a>
 </p>

--- a/src/Navbar/README.md
+++ b/src/Navbar/README.md
@@ -18,7 +18,7 @@ A powerful, responsive navigation header, the navbar. Includes support for brand
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/navbar/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/navbar/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Overlay/README.md
+++ b/src/Overlay/README.md
@@ -19,7 +19,7 @@ This component is used to power Tooltips and Popovers.
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/overlays/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/overlays/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for additional documentation.
   </a>
 </p>

--- a/src/ProgressBar/README.md
+++ b/src/ProgressBar/README.md
@@ -17,7 +17,7 @@ A bar to indicate the completed progress of a task.
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/progress" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/progress/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Spinner/README.md
+++ b/src/Spinner/README.md
@@ -17,7 +17,7 @@ A spinning animation that indicates loading.
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/spinners" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/spinners/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -15,7 +15,7 @@ notes: |
 
 <p>
   This is a pass through component from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/cards/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/components/tabs/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>

--- a/www/src/pages/foundations/layout.mdx
+++ b/www/src/pages/foundations/layout.mdx
@@ -18,7 +18,7 @@ Paragon's layout is controlled by the Bootstrap grid system. Documentation can b
 
 <p>
   These components are pass throughs from React-Bootstrap.<br/>
-  <a href="https://react-bootstrap.github.io/components/layout/" target="_blank" rel="noopener noreferrer">
+  <a href="https://react-bootstrap-v4.netlify.app/layout/grid/" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
   </a>
 </p>


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2365

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
