### PR TITLE
[BD-46] docs: add info about xs min-width

### DIFF
--- a/www/src/pages/foundations/responsive.jsx
+++ b/www/src/pages/foundations/responsive.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   DataTable, Container, breakpoints, OverlayTrigger, Tooltip, Icon,
 } from '~paragon-react';
-import { Question } from '~paragon-icons';
+import { QuestionMark } from '~paragon-icons';
 import SEO from '../../components/SEO';
 import Layout from '../../components/PageLayout';
 import CodeBlock from '../../components/CodeBlock';
@@ -25,11 +25,10 @@ function IdentifierCell({ row }) {
 function MinWidthCell({ row }) {
   if (row.values.identifier === 'xs') {
     return (
-      <div className="d-flex">
+      <div className="d-flex align-items-center">
         <code>-</code>
         <OverlayTrigger
           placement="top"
-          defaultShow
           overlay={(
             <Tooltip id={`tooltip-${row.values.identifier}`}>
               The min-width for the &quot;XS&quot; breakpoint is <strong>320px</strong>.
@@ -38,7 +37,7 @@ function MinWidthCell({ row }) {
             </Tooltip>
           )}
         >
-          <Icon src={Question} size="xs" />
+          <Icon src={QuestionMark} size="xs" />
         </OverlayTrigger>
       </div>
     );

--- a/www/src/pages/foundations/responsive.jsx
+++ b/www/src/pages/foundations/responsive.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, Container, breakpoints } from '~paragon-react';
+import {
+  DataTable, Container, breakpoints, OverlayTrigger, Tooltip, Icon,
+} from '~paragon-react';
+import { Question } from '~paragon-icons';
 import SEO from '../../components/SEO';
 import Layout from '../../components/PageLayout';
 import CodeBlock from '../../components/CodeBlock';
@@ -20,6 +23,26 @@ function IdentifierCell({ row }) {
   return <code>{row.values.identifier}</code>;
 }
 function MinWidthCell({ row }) {
+  if (row.values.identifier === 'xs') {
+    return (
+      <div className="d-flex">
+        <code>-</code>
+        <OverlayTrigger
+          placement="top"
+          defaultShow
+          overlay={(
+            <Tooltip id={`tooltip-${row.values.identifier}`}>
+              The min-width for the &quot;XS&quot; breakpoint is <strong>320px</strong>.
+              That pixel width is the smallest that designers support for mobile devices,
+              and also covers 16x magnification for accessibility.
+            </Tooltip>
+          )}
+        >
+          <Icon src={Question} size="xs" />
+        </OverlayTrigger>
+      </div>
+    );
+  }
   return <code>{row.values.minWidth ? `${row.values.minWidth}px` : '-'}</code>;
 }
 function MaxWidthCell({ row }) {


### PR DESCRIPTION
## Description

Add question mark icon and tooltip with text for the `xs` min-width breakpoint

### Deploy Preview

https://deploy-preview-2400--paragon-openedx.netlify.app/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
