### PR TITLE
feat: POC for isHidden prop on ModalDialog

### DIFF
--- a/src/Modal/ModalContext.jsx
+++ b/src/Modal/ModalContext.jsx
@@ -6,11 +6,11 @@ const ModalContext = React.createContext({
 });
 
 function ModalContextProvider({
-  onClose, isOpen, isBlocking, children,
+  onClose, isOpen, isHidden, isBlocking, children,
 }) {
   const modalContextValue = useMemo(
-    () => ({ onClose, isOpen, isBlocking }),
-    [onClose, isOpen, isBlocking],
+    () => ({ onClose, isOpen, isHidden, isBlocking }),
+    [onClose, isOpen, isHidden, isBlocking],
   );
 
   return (

--- a/src/Modal/ModalDialog.jsx
+++ b/src/Modal/ModalDialog.jsx
@@ -20,6 +20,7 @@ function ModalDialog({
   children,
   title,
   isOpen,
+  isHidden,
   onClose,
   size,
   variant,
@@ -34,7 +35,7 @@ function ModalDialog({
   const isMobile = useMediaQuery({ query: '(max-width: 767.98px)' });
   const showFullScreen = (isFullscreenOnMobile && isMobile);
   return (
-    <ModalLayer isOpen={isOpen} onClose={onClose} isBlocking={isBlocking} zIndex={zIndex}>
+    <ModalLayer isOpen={isOpen} isHidden={isHidden} onClose={onClose} isBlocking={isBlocking} zIndex={zIndex}>
       <div
         role="dialog"
         aria-label={title}

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -39,7 +39,7 @@ ModalContentContainer.defaultProps = {
  * component is that if a modal object is visible then it is "enabled"
  */
 function ModalLayer({
-  children, onClose, isOpen, isBlocking, zIndex,
+  children, onClose, isOpen, isHidden, isBlocking, zIndex,
 }) {
   useEffect(() => {
     if (isOpen) {
@@ -52,29 +52,31 @@ function ModalLayer({
     };
   }, [isOpen]);
 
-  if (!isOpen) {
+  if (!isOpen && !isHidden) {
     return null;
   }
 
   const onClickOutside = !isBlocking ? onClose : null;
 
   return (
-    <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>
+    <ModalContextProvider onClose={onClose} isOpen={isOpen} isHidden={isHidden} isBlocking={isBlocking}>
       <Portal>
         <FocusOn
           allowPinchZoom
           scrollLock
-          enabled={isOpen}
+          enabled={isOpen && !isHidden}
           onEscapeKey={onClose}
           onClickOutside={onClickOutside}
-          className={classNames(
-            'pgn__modal-layer',
-            zIndex ? `zindex-${zIndex}` : '',
-          )}
+          className={classNames({
+            'pgn__modal-layer': isOpen && !isHidden,
+            [`zindex-${zIndex}`]: !!zIndex,
+          })}
         >
           <ModalContentContainer>
-            <ModalBackdrop onClick={onClickOutside} />
-            {children}
+            {!isHidden && <ModalBackdrop onClick={onClickOutside} />}
+            <div className={classNames({ 'd-none': isHidden })}>
+              {children}
+            </div>
           </ModalContentContainer>
         </FocusOn>
       </Portal>

--- a/src/Modal/modal-dialog.mdx
+++ b/src/Modal/modal-dialog.mdx
@@ -163,3 +163,53 @@ label for the dialog element.
   )
 }
 ```
+
+## With hidden modal contents
+
+By default, ``ModalDialog`` only render its modal contents to the DOM when the modal is explicitly marked as open via the `isOpen` prop. However, in some cases, needing to re-render the contents of the modal body each and every time the modal closes and re-opens can be expensive and/or a poor user experience (UX), e.g. if the modal contents are dynamic and loaded from an external source like some iframed content or a slow loading API request.
+
+To mitigate these performance concerns, ``ModalDialog`` supports an optional ``isHidden`` prop that when used in conjunction with ``isOpen``, would result in the modal contents and the backdrop still being kept in the React Portal DOM, but visually hidden in the UI.
+
+```jsx live
+() => {
+  const [isHidden, hideModal, showModal] = useToggle(true);
+  return (
+    <>
+      <div className="d-flex">
+        <Button variant="outline-primary" onClick={showModal}>Open standard modal dialog</Button>
+      </div>
+      <ModalDialog
+        title="My dialog"
+        isOpen /* always "open" */
+        isHidden={isHidden}
+        onClose={hideModal}
+        hasCloseButton
+        isFullscreenOnMobile
+      >
+        <ModalDialog.Header>
+          <ModalDialog.Title>
+            I'm a dialog box
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+
+        <ModalDialog.Body>
+          <p>
+            I'm baby palo santo ugh celiac fashion axe. La croix lo-fi venmo whatever. Beard man braid migas single-origin coffee forage ramps. Tumeric messenger bag bicycle rights wayfarers, try-hard cronut blue bottle health goth. Sriracha tumblr cardigan, cloud bread succulents tumeric copper mug marfa semiotics woke next level organic roof party +1 try-hard.
+          </p>
+        </ModalDialog.Body>
+
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton variant="tertiary">
+              Cancel
+            </ModalDialog.CloseButton>
+            <Button variant="primary">
+              Continue
+            </Button>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
+    </>
+  )
+}
+```


### PR DESCRIPTION
## Description

Demos a proof-of-concept of updating the `ModalDialog` component to introduce an `isHidden` prop for the following types of use cases:

> By default, ``ModalDialog`` only renders its modal contents to the DOM when the modal is explicitly marked as open via the `isOpen` prop. However, in some cases, needing to re-render the contents of the modal body each and every time the modal closes and re-opens can be expensive and/or a poor user experience (UX), e.g. if the modal contents are dynamic and loaded from an external source like some iframed content or a slow loading API request.
>
> To mitigate these performance concerns, ``ModalDialog`` supports an optional ``isHidden`` prop that when used in conjunction with ``isOpen``, would result in the modal contents and the backdrop still being kept in the React Portal DOM, but visually hidden in the UI.

### Deploy Preview

TBD

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
