### PR TITLE
fix: make icons package tree-shakeable

### DIFF
--- a/icons/package.json
+++ b/icons/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "node copy-mui-icons.js && node copy-brand-icons.js && svgr svg --out-dir jsx && babel jsx -d es5",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Description

Currently, all of the Paragon icons are included into the bundle if at least one icon is used in the project. This PR adds tree-shaking support to include only used icons into the bundle.

Previously, using `SearchField` component (that uses couple of icons internally) would result in following Paragon bundle, which included all of the icons
![image](https://github.com/openedx/paragon/assets/52399399/39c686b7-c53d-485e-b393-6fb5dc658ddc)

this PR reduced the bundle to this
<img width="621" alt="Screenshot 2023-07-14 at 11 19 10" src="https://github.com/openedx/paragon/assets/52399399/1b9730f1-8723-4e14-b659-d0802a0f0d56">

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
