### PR TITLE
[BD-46] fix: initial autoResize functionality

### DIFF
--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import RBFormControl from 'react-bootstrap/FormControl';
@@ -34,13 +34,7 @@ const FormControl = React.forwardRef(({
     value: props.value,
   });
 
-  const controlProps = getControlProps({
-    ...props,
-    // eslint-disable-next-line react/prop-types
-    onBlur: callAllHandlers(checkInputEventValue, props.onBlur),
-  });
-
-  const handleOnChange = (e) => {
+  const handleResize = useCallback(() => {
     if (as === 'textarea' && autoResize) {
       if (!resolvedRef.current.initialHeight && !resolvedRef.current.offsets) {
         resolvedRef.current.initialHeight = resolvedRef.current.offsetHeight;
@@ -49,6 +43,20 @@ const FormControl = React.forwardRef(({
       resolvedRef.current.style.height = `${resolvedRef.current.initialHeight}px`;
       resolvedRef.current.style.height = `${resolvedRef.current.scrollHeight + resolvedRef.current.offsets}px`;
     }
+  }, [as, autoResize, resolvedRef]);
+
+  useEffect(() => {
+    handleResize();
+  }, [handleResize]);
+
+  const controlProps = getControlProps({
+    ...props,
+    // eslint-disable-next-line react/prop-types
+    onBlur: callAllHandlers(checkInputEventValue, props.onBlur),
+  });
+
+  const handleOnChange = (e) => {
+    handleResize();
     if (onChange) {
       onChange(e);
     }

--- a/src/Form/tests/FormControl.test.jsx
+++ b/src/Form/tests/FormControl.test.jsx
@@ -18,7 +18,7 @@ describe('FormControl', () => {
     ref.offsetHeight = 90;
     ref.clientHeight = 88;
     expect(useReferenceSpy).toHaveBeenCalledTimes(1);
-    expect(ref.current.style.height).toBeFalsy();
+    expect(ref.current.style.height).toBe('0px');
     wrapper.find('textarea').simulate('change');
     expect(onChangeFunc).toHaveBeenCalledTimes(1);
     expect(ref.current.style.height).toEqual(`${ref.current.scrollHeight + ref.current.offsets}px`);


### PR DESCRIPTION
## Description

Add initial autoResize to support e.g. `defaultValue` or `value`

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
