### PR TITLE
feat: add defaults to theme-urls.json output on build

### DIFF
--- a/build-scss.js
+++ b/build-scss.js
@@ -174,8 +174,8 @@ program
     new Option(
       '--defaultThemeVariants <defaultThemeVariants...>',
       `Specifies default theme variants. Defaults to a single 'light' theme variant.
-      You can provide multiple default theme variants by passing multiple \`--defaultThemeVariants\`
-      flags. For example: \`--defaultThemeVariants light dark\`
+      You can provide multiple default theme variants by passing multiple values, for
+      example: \`--defaultThemeVariants light dark\`
       `,
     ),
   );

--- a/build-scss.js
+++ b/build-scss.js
@@ -174,7 +174,7 @@ program
     new Option(
       '--defaultThemeVariants <defaultThemeVariants...>',
       `Specifies default theme variants. Defaults to a single 'light' theme variant.
-      You can provide multiple default theme variants by passing multiple \`--defaultThemeVariant\`
+      You can provide multiple default theme variants by passing multiple \`--defaultThemeVariants\`
       flags. For example: \`--defaultThemeVariants light dark\`
       `,
     ),


### PR DESCRIPTION
## Description

Extends `build-scss.js` Node.js script to include optional `--defaultThemeVariants` option to customize the default theme variants to include in the `theme-urls.json` output.

```bash
node build-scss.js --defaultThemeVariants light
node build-scss.js --defaultThemeVariants light dark
```

Ensures the `theme-urls.json` output looks like the following, with the additional of the `defaults` object property in favor of the previous `default` and `dark` properties:

```json
{
  "themeUrls": {
    "core": {
      "paths": {
        "default": "./core.css",
        "minified": "./core.min.css"
      }
    },
    "defaults": {
      "light": "light"
    },
    "variants": {
      "light": {
        "paths": {
          "default": "./light.css",
          "minified": "./light.min.css"
        }
      }
    }
  }
}
```

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
