### PR TITLE
[BD-46] feat: added arrow bg color for Popover component

### DIFF
--- a/src/Popover/_mixins.scss
+++ b/src/Popover/_mixins.scss
@@ -1,0 +1,31 @@
+@mixin get-popover-variant($bg, $icon-color) {
+  background: $bg;
+
+  .popover-header {
+    background: $bg;
+
+    &::before {
+      border-bottom-color: $bg;
+    }
+  }
+
+  .pgn__icon {
+    color: $icon-color;
+  }
+
+  &.bs-popover-bottom .arrow::after {
+    border-bottom-color: $bg;
+  }
+
+  &.bs-popover-top .arrow::after {
+    border-top-color: $bg;
+  }
+
+  &.bs-popover-right .arrow::after {
+    border-right-color: $bg;
+  }
+
+  &.bs-popover-left .arrow::after {
+    border-left-color: $bg;
+  }
+}

--- a/src/Popover/index.scss
+++ b/src/Popover/index.scss
@@ -1,4 +1,5 @@
 @import "variables";
+@import "mixins";
 @import "~bootstrap/scss/popover";
 
 .popover {
@@ -18,37 +19,13 @@
 }
 
 .popover-success {
-  background: $popover-success-bg;
-
-  .popover-header {
-    background: $popover-success-bg;
-  }
-
-  .pgn__icon {
-    color: $popover-success-icon-color;
-  }
+  @include get-popover-variant($popover-success-bg, $popover-success-icon-color);
 }
 
 .popover-warning {
-  background: $popover-warning-bg;
-
-  .popover-header {
-    background: $popover-warning-bg;
-  }
-
-  .pgn__icon {
-    color: $popover-warning-icon-color;
-  }
+  @include get-popover-variant($popover-warning-bg, $popover-warning-icon-color);
 }
 
 .popover-danger {
-  background: $popover-danger-bg;
-
-  .popover-header {
-    background: $popover-danger-bg;
-  }
-
-  .pgn__icon {
-    color: $popover-danger-icon-color;
-  }
+  @include get-popover-variant($popover-danger-bg, $popover-danger-icon-color);
 }


### PR DESCRIPTION
## Description

Issue: https://github.com/openedx/paragon/issues/2422

### Deploy Preview

[Popover component](https://deploy-preview-2477--paragon-openedx.netlify.app/components/popover/#state-variants)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
