### PR TITLE
[BD-46] fix: fixed border-radius of the card img

### DIFF
--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -41,7 +41,7 @@ $card-logo-bottom-offset-horizontal: .4375rem !default;
 $card-logo-width:                    7.25rem !default;
 $card-logo-height:                   4.125rem !default;
 
-$card-image-border-radius:           .3125rem !default;
+$card-image-border-radius:           $card-border-radius !default;
 $card-logo-border-radius:            .25rem !default;
 
 $card-footer-text-font-size:         $x-small-font-size;

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -88,7 +88,6 @@ a.pgn__card {
 
 .pgn__card {
   outline: none;
-  overflow: hidden;
 
   @include pgn-box-shadow(1, "down");
 
@@ -295,6 +294,8 @@ a.pgn__card {
     object-fit: cover;
     max-height: inherit;
     width: 100%;
+    border-top-left-radius: $card-image-border-radius;
+    border-top-right-radius: $card-image-border-radius;
     display: none;
 
     &.show {
@@ -313,6 +314,9 @@ a.pgn__card {
       .pgn__card-image-cap {
         height: 100%;
         max-width: inherit;
+        border-top-left-radius: $card-image-border-radius;
+        border-top-right-radius: 0;
+        border-bottom-left-radius: $card-image-border-radius;
         width: auto;
         object-fit: cover;
       }


### PR DESCRIPTION
## Description

Fixed border-radius of the Card img

Issue: https://github.com/openedx/paragon/issues/2498

### Deploy Preview

[Card component](https://deploy-preview-2511--paragon-openedx.netlify.app/components/card/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
