### PR TITLE
fix: disable browser autocomplete and edit dropdown items elements

### DIFF
--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -39,7 +39,7 @@ function FormAutosuggest({
   });
 
   const handleItemClick = (e, onClick) => {
-    const clickedValue = e.currentTarget.value;
+    const clickedValue = e.currentTarget.getAttribute('data-value');
 
     if (onSelected && clickedValue !== value) {
       onSelected(clickedValue);
@@ -66,7 +66,7 @@ function FormAutosuggest({
       return React.cloneElement(child, {
         ...rest,
         children,
-        value: children,
+        'data-value': children,
         onClick: (e) => handleItemClick(e, onClick),
       });
     });
@@ -219,6 +219,9 @@ function FormAutosuggest({
         <FormControl
           aria-expanded={(state.dropDownItems.length > 0).toString()}
           aria-owns="pgn__form-autosuggest__dropdown-box"
+          role="combobox"
+          aria-autocomplete="list"
+          autoComplete="off"
           value={state.displayValue}
           aria-invalid={state.errorMessage}
           onChange={handleOnChange}
@@ -240,25 +243,25 @@ function FormAutosuggest({
         )}
       </FormGroup>
 
-      <div
+      <ul
         id="pgn__form-autosuggest__dropdown-box"
         className="pgn__form-autosuggest__dropdown"
+        role="listbox"
       >
         {isLoading ? (
           <div className="pgn__form-autosuggest__dropdown-loading">
             <Spinner animation="border" variant="dark" screenReaderText={screenReaderText} />
           </div>
         ) : state.dropDownItems.length > 0 && state.dropDownItems}
-      </div>
+      </ul>
     </div>
   );
 }
 
 FormAutosuggest.defaultProps = {
-  arrowKeyNavigationSelector: 'a:not(:disabled),button:not(:disabled, .btn-icon),input:not(:disabled)',
+  arrowKeyNavigationSelector: 'a:not(:disabled),li:not(:disabled, .btn-icon),input:not(:disabled)',
   ignoredArrowKeysNames: ['ArrowRight', 'ArrowLeft'],
   isLoading: false,
-  role: 'list',
   className: null,
   floatingLabel: null,
   onChange: null,
@@ -283,8 +286,6 @@ FormAutosuggest.propTypes = {
   ignoredArrowKeysNames: PropTypes.arrayOf(PropTypes.string),
   /** Specifies loading state. */
   isLoading: PropTypes.bool,
-  /** An ARIA role describing the form autosuggest. */
-  role: PropTypes.string,
   /** Specifies class name to append to the base element. */
   className: PropTypes.string,
   /** Specifies floating label to display for the input component. */

--- a/src/Form/FormAutosuggestOption.jsx
+++ b/src/Form/FormAutosuggestOption.jsx
@@ -11,6 +11,9 @@ function FormAutosuggestOption({
 }) {
   return (
     <MenuItem
+      as="li"
+      role="option"
+      tabindex="-1"
       onClick={onClick}
       className={classNames(className, 'dropdown-item')}
       {...props}

--- a/src/Form/_index.scss
+++ b/src/Form/_index.scss
@@ -586,6 +586,7 @@ select.form-control {
     width: calc(100% - .5rem);
     z-index: $zindex-dropdown;
     top: 3.125rem;
+    padding: 0;
 
     .dropdown-item {
       display: block;

--- a/src/Form/form-autosuggest.mdx
+++ b/src/Form/form-autosuggest.mdx
@@ -33,7 +33,7 @@ Form auto-suggest enables users to manually select or type to find matching opti
             <Form.AutosuggestOption>JavaScript</Form.AutosuggestOption>
             <Form.AutosuggestOption>Python</Form.AutosuggestOption>
             <Form.AutosuggestOption>Rube</Form.AutosuggestOption>
-            <Form.AutosuggestOption onClick={(e) => alert(e.currentTarget.value)}>
+            <Form.AutosuggestOption onClick={(e) => alert(e.currentTarget.getAttribute('data-value'))}>
                 Option with custom onClick
             </Form.AutosuggestOption>
         </Form.Autosuggest>

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -73,7 +73,7 @@ describe('FormAutosuggest', () => {
 
     it('renders component with options', () => {
       container.find('input').simulate('click');
-      const optionsList = container.find('.pgn__form-autosuggest__dropdown').find('button');
+      const optionsList = container.find('.pgn__form-autosuggest__dropdown').find('li');
 
       expect(optionsList.length).toEqual(3);
     });
@@ -94,7 +94,7 @@ describe('FormAutosuggest', () => {
   describe('controlled behavior', () => {
     it('selects option', () => {
       container.find('input').simulate('click');
-      container.find('.pgn__form-autosuggest__dropdown').find('button')
+      container.find('.pgn__form-autosuggest__dropdown').find('li')
         .at(0).simulate('click');
 
       expect(container.find('input').instance().value).toEqual('Option 1');
@@ -104,7 +104,7 @@ describe('FormAutosuggest', () => {
 
     it('when a function is passed to onClick, it is called', () => {
       container.find('input').simulate('change', { target: { value: 'Option 2' } });
-      container.find('.pgn__form-autosuggest__dropdown').find('button')
+      container.find('.pgn__form-autosuggest__dropdown').find('li')
         .at(0).simulate('click');
 
       expect(onClick).toHaveBeenCalledTimes(1);
@@ -112,7 +112,7 @@ describe('FormAutosuggest', () => {
 
     it('when a function is not passed to onClick, it is not called', () => {
       container.find('input').simulate('change', { target: { value: 'Option 1' } });
-      container.find('.pgn__form-autosuggest__dropdown').find('button')
+      container.find('.pgn__form-autosuggest__dropdown').find('li')
         .at(0).simulate('click');
 
       expect(onClick).toHaveBeenCalledTimes(0);
@@ -127,26 +127,26 @@ describe('FormAutosuggest', () => {
     it('options list depends on filled field value', () => {
       container.find('input').simulate('change', { target: { value: 'option 1' } });
 
-      expect(container.find('.pgn__form-autosuggest__dropdown').find('button').length).toEqual(1);
+      expect(container.find('.pgn__form-autosuggest__dropdown').find('li').length).toEqual(1);
       expect(onSelected).toHaveBeenCalledTimes(0);
     });
 
     it('toggles options list', () => {
       const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
-      expect(container.find(dropdownContainer).find('button').length).toEqual(1);
+      expect(container.find(dropdownContainer).find('li').length).toEqual(1);
 
       container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-      expect(container.find(dropdownContainer).find('button').length).toEqual(0);
+      expect(container.find(dropdownContainer).find('li').length).toEqual(0);
 
       container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-      expect(container.find(dropdownContainer).find('button').length).toEqual(1);
+      expect(container.find(dropdownContainer).find('li').length).toEqual(1);
     });
 
     it('shows options list depends on field value', () => {
       container.find('input').simulate('change', { target: { value: '1' } });
 
-      expect(container.find('.pgn__form-autosuggest__dropdown').find('button').length).toEqual(2);
+      expect(container.find('.pgn__form-autosuggest__dropdown').find('li').length).toEqual(2);
     });
 
     it('closes options list on click outside', () => {
@@ -154,12 +154,12 @@ describe('FormAutosuggest', () => {
       const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
       container.find('input').simulate('click');
-      expect(container.find(dropdownContainer).find('button').length).toEqual(2);
+      expect(container.find(dropdownContainer).find('li').length).toEqual(2);
 
       act(() => { fireEvent.click(document.body); });
       container.update();
 
-      expect(container.find(dropdownContainer).find('button').length).toEqual(0);
+      expect(container.find(dropdownContainer).find('li').length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
Add attributes to `input` element to disable browser autocomplete on autosuggest component and change the div that houses the dropdown items to be a `ul`, change the button elements that render the list to be `li`. add new `role` to each element

## Description

Resolves [#2435](https://github.com/openedx/paragon/issues/2435) and resolves #2557.

We had to make more changes than anticipated here given that we previously relied on the `button` value attribute. After changing button elements to `li`, we realized that `li`'s value attribute is an integer value, which posed some problems.

Note that this doesn't fix the issue where if you try to tab out while in the dropdown, the menu is still displayed. (#2437)

### Deploy Preview

https://deploy-preview-2513--paragon-openedx.netlify.app/components/form/form-autosuggest/

## Merge Checklist

* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
