### PR TITLE
fix(deps): OEP65. updating to react-intl 6.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0",
         "react-dom": "^16.8.6 || ^17.0.0",
-        "react-intl": "^5.25.1"
+        "react-intl": "^5.25.1 || ^6.4"
       }
     },
     "component-generator": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.0",
     "react-dom": "^16.8.6 || ^17.0.0",
-    "react-intl": "^5.25.1 || ^6.4"
+    "react-intl": "^5.25.1 || ^6.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.0",
     "react-dom": "^16.8.6 || ^17.0.0",
-    "react-intl": "^5.25.1"
+    "react-intl": "^5.25.1 || ^6.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",


### PR DESCRIPTION
## Description

Allowing a peer dependency to react-intl@^6.4. The current version @^5.25.1 is incompatible with [Piral](https://piral.io/) which is being used as a the base framework for [OEP65 - currently still known as OEPXXXX](https://github.com/openedx/open-edx-proposals/blob/426f6e09ffe615e77aa9205281d77012385a08d4/oeps/architectural-decisions/oep-XXXX-modular-micro-frontend-domains.rst).

