### PR TITLE
[BD-46] fix: skeleton.css for both dev and prod

### DIFF
--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -1,4 +1,5 @@
 @use "~react-loading-skeleton/dist/skeleton";
+
 @import "functions";
 @import "variables";
 @import "~bootstrap/scss/mixins";

--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -1,3 +1,4 @@
+@use "~react-loading-skeleton/dist/skeleton";
 @import "functions";
 @import "variables";
 @import "~bootstrap/scss/mixins";
@@ -5,12 +6,6 @@
 @import "~bootstrap/scss/reboot";
 @import "typography";
 @import "grid";
-// The react-loading-skeleton package.json defines an 'exports' field which specifies a '.css'
-// extension on this export.  Without the '.css' on the end of this line, webpack can't find the file
-// and the build fails.
-// See https://webpack.js.org/guides/package-exports/ for more information on how webpack uses
-// the 'exports' field.
-@import "~react-loading-skeleton/dist/skeleton.css";
 @import "~bootstrap/scss/transitions";
 @import "utilities";
 @import "~bootstrap/scss/media";


### PR DESCRIPTION
## Description

The issue was that in the prod environment Skeleton didn't show up. The fix is to use `@use` instead of `@import`.
https://github.com/openedx/paragon/issues/2420

### Deploy Preview

https://deploy-preview-2531--paragon-openedx.netlify.app/components/skeleton/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
