### PR TITLE
fix: filtered dropdown items by display value instead of event target

### DIFF
--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -79,7 +79,7 @@ function FormAutosuggest({
     return childrenOpt;
   }
 
-  const handleExpand = (e) => {
+  const handleExpand = () => {
     setIsMenuClosed(!isMenuClosed);
 
     const newState = {
@@ -87,7 +87,7 @@ function FormAutosuggest({
     };
 
     if (isMenuClosed) {
-      newState.dropDownItems = getItems(e.target.value);
+      newState.dropDownItems = getItems(state.displayValue);
       newState.errorMessage = '';
     }
 

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -140,7 +140,7 @@ describe('FormAutosuggest', () => {
       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
       container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-      expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+      expect(container.find(dropdownContainer).find('button').length).toEqual(1);
     });
 
     it('shows options list depends on field value', () => {


### PR DESCRIPTION
## Description

Fixes #2535 

### Deploy Preview

https://deploy-preview-2547--paragon-openedx.netlify.app/components/form/form-autosuggest/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
