### PR TITLE
Revert "fix: [BD-46] skeleton.css for both dev and prod (#2531)"

### DIFF
--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -1,5 +1,3 @@
-@use "~react-loading-skeleton/dist/skeleton";
-
 @import "functions";
 @import "variables";
 @import "~bootstrap/scss/mixins";
@@ -7,6 +5,12 @@
 @import "~bootstrap/scss/reboot";
 @import "typography";
 @import "grid";
+// The react-loading-skeleton package.json defines an 'exports' field which specifies a '.css'
+// extension on this export.  Without the '.css' on the end of this line, webpack can't find the file
+// and the build fails.
+// See https://webpack.js.org/guides/package-exports/ for more information on how webpack uses
+// the 'exports' field.
+@import "~react-loading-skeleton/dist/skeleton.css";
 @import "~bootstrap/scss/transitions";
 @import "utilities";
 @import "~bootstrap/scss/media";


### PR DESCRIPTION
This reverts commit 7e96a0a6bba91f3a00a85d3fd40a7c3afb26b4d1.

## Description

Reverts #2531 as it still seems to be causing issues for consuming MFEs (e.g., frontend-template-application). That is, an MFE was unable to start/build with the changes in this prior commit even though testing the same MFE through module.config.js worked without issue.

### Deploy Preview

n/a

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
