### PR TITLE
[BD-46] fix: truncating a whole text

### DIFF
--- a/src/Truncate/utils.js
+++ b/src/Truncate/utils.js
@@ -11,8 +11,7 @@ const createCopyElement = (element) => {
   const newElement = document.createElement(element.tagName);
   newElement.setAttribute(
     'style',
-    `line-height: ${LINE_HEIGHT_VALUE}px; display: inline-block;`,
-    'word-break: break-word',
+    `line-height: ${LINE_HEIGHT_VALUE}px; display: inline-block; word-break: break-word;`,
   );
   return newElement;
 };

--- a/src/Truncate/utils.js
+++ b/src/Truncate/utils.js
@@ -12,6 +12,7 @@ const createCopyElement = (element) => {
   newElement.setAttribute(
     'style',
     `line-height: ${LINE_HEIGHT_VALUE}px; display: inline-block;`,
+    'word-break: break-word',
   );
   return newElement;
 };


### PR DESCRIPTION
## Description

- Fixed issue with truncating a whole string without spaces by adding 'word-break: break-word' style.
_This style is added to the newElement which is a copy of element on which all calculations are made._

[Issue](https://github.com/openedx/paragon/issues/2475)

### Deploy Preview

[Truncate](https://deploy-preview-2584--paragon-openedx.netlify.app/components/truncate/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
