### PR TITLE
[BD-46] Fix incorrect number of items in DataTable component

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -53,97 +53,98 @@ or a filter component can be defined on the column. See <a href="https://react-t
 for more information.
 
 ```jsx live
-  <DataTable
-    isPaginated
-    isSelectable
-    initialState={{
-      pageSize: 2,
-    }}
-    isFilterable
-    isSortable
-    defaultColumnValues={{ Filter: TextFilter }}
-    itemCount={7}
-    data={[
-      {
-        name: 'Lil Bub',
-        color: 'brown tabby',
-        famous_for: 'weird tongue',
-      },
-      {
-        name: 'Grumpy Cat',
-        color: 'siamese',
-        famous_for: 'serving moods',
-      },
-      {
-        name: 'Smoothie',
-        color: 'orange tabby',
-        famous_for: 'modeling',
-      },
-      {
-        name: 'Maru',
-        color: 'brown tabby',
-        famous_for: 'being a lovable oaf',
-      },
-      {
-        name: 'Keyboard Cat',
-        color: 'orange tabby',
-        famous_for: 'piano virtuoso',
-      },
-      {
-        name: 'Long Cat',
-        color: 'russian white',
-        famous_for:
-          'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
-      },
-      {
-        name: 'Zeno',
-        color: 'brown tabby',
-        famous_for: 'getting halfway there'
-      },
-    ]}
-    columns={[
-      {
-        Header: 'Name',
-        accessor: 'name',
+() => {
+  const data = useMemo(() => [
+    {
+      name: 'Lil Bub',
+      color: 'brown tabby',
+      famous_for: 'weird tongue',
+    },
+    {
+      name: 'Grumpy Cat',
+      color: 'siamese',
+      famous_for: 'serving moods',
+    },
+    {
+      name: 'Smoothie',
+      color: 'orange tabby',
+      famous_for: 'modeling',
+    },
+    {
+      name: 'Maru',
+      color: 'brown tabby',
+      famous_for: 'being a lovable oaf',
+    },
+    {
+      name: 'Keyboard Cat',
+      color: 'orange tabby',
+      famous_for: 'piano virtuoso',
+    },
+    {
+      name: 'Long Cat',
+      color: 'russian white',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+    },
+    {
+      name: 'Zeno',
+      color: 'brown tabby',
+      famous_for: 'getting halfway there'
+    },
+  ], [])
 
-      },
-      {
-        Header: 'Famous For',
-        accessor: 'famous_for',
-      },
-      {
-        Header: 'Coat Color',
-        accessor: 'color',
-        Filter: CheckboxFilter,
-        filter: 'includesValue',
-        filterChoices: [{
-          name: 'russian white',
-          number: 1,
-          value: 'russian white',
+  const reducedChoices = data.reduce((acc, currentObject) => {
+    const { color } = currentObject;
+    if (color in acc) {
+      acc[color].number += 1;
+    } else {
+      acc[color] = {
+        name: color,
+        number: 1,
+        value: color,
+      };
+    }
+    return acc;
+  }, {});
+
+   return (
+    <DataTable
+      isPaginated
+      isSelectable
+      initialState={{
+        pageSize: 2,
+      }}
+      isFilterable
+      isSortable
+      defaultColumnValues={{ Filter: TextFilter }}
+      itemCount={data.length}
+      data={data}
+      columns={[
+        {
+          Header: 'Name',
+          accessor: 'name',
+
         },
         {
-          name: 'orange tabby',
-          number: 2,
-          value: 'orange tabby',
+          Header: 'Famous For',
+          accessor: 'famous_for',
         },
         {
-          name: 'brown tabby',
-          number: 3,
-          value: 'brown tabby',
+          Header: 'Coat Color',
+          accessor: 'color',
+          Filter: CheckboxFilter,
+          filter: 'includesValue',
+          filterChoices: Object.values(reducedChoices),
         },
-        {
-          name: 'siamese',
-          number: 1,
-          value: 'siamese',
-        }]
-      },
-    ]}
-  >
-    <DataTable.TableControlBar />
-    <DataTable.Table />
-    <DataTable.EmptyTable content="No results found" />
-    <DataTable.TableFooter />
-  </DataTable>
+      ]}
+    >
+      <DataTable.TableControlBar />
+      <DataTable.Table />
+      <DataTable.EmptyTable content="No results found" />
+      <DataTable.TableFooter />
+    </DataTable>
+   );
+}
 ```
 
 ## Backend filtering and sorting
@@ -360,19 +361,6 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
       famous_for: 'modeling',
     },
   ], [])
-  const reducedChoices = data.reduce((acc, currentObject) => {
-  const { color } = currentObject;
-   if (color in acc) {
-    color.number += 1;
-   } else {
-    acc[color] = {
-      name: color,
-      number: 1,
-      value: color,
-    };
-  }
-  return acc;
-}, {});
 
   return (
     <DataTable
@@ -401,7 +389,21 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
           accessor: 'color',
           Filter: CheckboxFilter,
           filter: 'includesValue',
-          filterChoices: Object.values(reducedChoices),
+          filterChoices: [{
+            name: 'orange tabby',
+            number: 1,
+            value: 'orange tabby',
+          },
+          {
+            name: 'brown tabby',
+            number: 1,
+            value: 'brown tabby',
+          },
+          {
+            name: 'siamese',
+            number: 1,
+            value: 'siamese',
+          }],
         },
       ]}
     >
@@ -468,18 +470,13 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
           Filter: CheckboxFilter,
           filter: 'includesValue',
           filterChoices: [{
-            name: 'russian white',
-            number: 1,
-            value: 'russian white',
-          },
-          {
             name: 'orange tabby',
-            number: 2,
+            number: 1,
             value: 'orange tabby',
           },
           {
             name: 'brown tabby',
-            number: 3,
+            number: 1,
             value: 'brown tabby',
           },
           {
@@ -1275,18 +1272,13 @@ For a more desktop friendly view, you can move filters into a sidebar by providi
         Filter: CheckboxFilter,
         filter: 'includesValue',
         filterChoices: [{
-          name: 'russian white',
-          number: 1,
-          value: 'russian white',
-        },
-        {
           name: 'orange tabby',
           number: 2,
           value: 'orange tabby',
         },
         {
           name: 'brown tabby',
-          number: 3,
+          number: 2,
           value: 'brown tabby',
         },
         {
@@ -1663,3 +1655,4 @@ After selecting the maximum possible number of rows, you can display an error me
     </DataTable>
   );
 }
+```

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -360,6 +360,20 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
       famous_for: 'modeling',
     },
   ], [])
+  const reducedChoices = data.reduce((acc, currentObject) => {
+  const { color } = currentObject;
+   if (color in acc) {
+    color.number += 1;
+   } else {
+    acc[color] = {
+      name: color,
+      number: 1,
+      value: color,
+    };
+  }
+  return acc;
+}, {});
+
   return (
     <DataTable
       isFilterable
@@ -371,7 +385,7 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
       }}
       isSortable
       defaultColumnValues={{ Filter: TextFilter }}
-      itemCount={3}
+      itemCount={data.length}
       data={data}
       columns={[
         {
@@ -387,26 +401,7 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
           accessor: 'color',
           Filter: CheckboxFilter,
           filter: 'includesValue',
-          filterChoices: [{
-            name: 'russian white',
-            number: 1,
-            value: 'russian white',
-          },
-          {
-            name: 'orange tabby',
-            number: 2,
-            value: 'orange tabby',
-          },
-          {
-            name: 'brown tabby',
-            number: 3,
-            value: 'brown tabby',
-          },
-          {
-            name: 'siamese',
-            number: 1,
-            value: 'siamese',
-          }]
+          filterChoices: Object.values(reducedChoices),
         },
       ]}
     >


### PR DESCRIPTION
## Description

Fix  display of number in DataTable
[Issue](https://github.com/openedx/paragon/issues/2548)

### Deploy Preview

[View Switching](https://deploy-preview-2598--paragon-openedx.netlify.app/components/datatable/#view-switching)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
