### PR TITLE
[BD-46] feat: help command for Paragon CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Usage on with `@edx/brand`:
 
 Note that including fonts will affect performance.  In some applications may choose not to load the custom font to keep it highly performant.
 
+## Paragon CLI
+
+The Paragon CLI (Command Line Interface) is a tool that provides various utility commands to automate actions within the Open edX environment.
+
+### Available Commands
+
+- `paragon install-theme [theme]`: Installs the specific @edx/brand package.
+
+Use `paragon help` to see more information.
+
 ## Getting Help
 
 Please reach out to the Paragon Working Group (PWG):

--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -1,10 +1,49 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 const chalk = require('chalk');
 const themeCommand = require('../lib/install-theme');
+const helpCommand = require('../lib/help');
 
-// command: executor function
 const COMMANDS = {
-  'install-theme': themeCommand,
+  // 'command-name': {
+  //   executor: executorFunc,
+  //
+  //   ********** Block for help command start **********
+  //   description: 'Command description',
+  //   parameters: [
+  //     {
+  //       name: 'paramName',
+  //       description: 'paramDescription',
+  //       defaultValue: 'paramDefaultValue',
+  //       required: true/false,
+  //     },
+  //     ...
+  //   ],
+  //   options: [
+  //     {
+  //       name: '--optionName',
+  //       description: 'optionDescription',
+  //     },
+  //     ...
+  //   ],
+  //   ********** Block for help command end **********
+  // },
+  'install-theme': {
+    executor: themeCommand,
+    description: 'Installs the specific @edx/brand package.',
+    parameters: [
+      {
+        name: 'theme',
+        description: 'The @edx/brand package to install.',
+        defaultValue: '@edx/brand-openedx@latest',
+        required: false,
+      },
+    ],
+  },
+  help: {
+    executor: helpCommand,
+    description: 'Displays help for available commands.',
+  },
 };
 
 (async () => {
@@ -12,15 +51,18 @@ const COMMANDS = {
   const executor = COMMANDS[command];
 
   if (!executor) {
-    // eslint-disable-next-line no-console
-    console.log(chalk.red.bold('Unknown command. Usage: paragon <command>'));
+    console.log(chalk.red.bold('Unknown command. Usage: paragon <command>.'));
+    return;
+  }
+
+  if (command === 'help') {
+    helpCommand(COMMANDS);
     return;
   }
 
   try {
-    await executor();
+    await executor.executor();
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error(chalk.red.bold('An error occurred:', error.message));
     process.exit(1);
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-console */
+const chalk = require('chalk');
+
+const DESCRIPTION_PAD = 20;
+
+/**
+ * Pads a description string to align with a specified offset string.
+ *
+ * @param {string} description - The description to pad.
+ * @param {string} offsetString - The offset string that the description should align with.
+ * @returns {string} - The padded description.
+ */
+function padLeft(description, offsetString) {
+  // Calculate the necessary padding based on the offsetString length
+  const padding = ' '.repeat(Math.max(0, DESCRIPTION_PAD - offsetString.length));
+  return `${padding}${description}`;
+}
+
+/**
+ * Displays a help message for available commands, including descriptions, parameters, and options.
+ *
+ * @param {Object} commands - An object containing information about available commands.
+ */
+function helpCommand(commands) {
+  console.log(chalk.yellow.bold('Paragon Help'));
+  console.log();
+  console.log('Available commands:');
+  console.log();
+
+  Object.keys(commands).forEach(command => {
+    console.log(`  ${chalk.green.bold(command)}`);
+    if (commands[command].description) {
+      console.log(`    ${commands[command].description}`);
+    }
+
+    if (commands[command].parameters && commands[command].parameters.length > 0) {
+      console.log(`    ${chalk.cyan('Parameters: ')}`);
+      commands[command].parameters.forEach(parameter => {
+        const requiredStatus = parameter.required ? 'Required' : 'Optional';
+        const formattedDescription = padLeft(parameter.description, parameter.name);
+        console.log(`      ${parameter.name}${formattedDescription} (${requiredStatus}, Default: ${parameter.defaultValue || 'None'})`);
+      });
+    }
+
+    if (commands[command].options && commands[command].options.length > 0) {
+      console.log(`    ${chalk.cyan('Options: ')}`);
+      commands[command].options.forEach(option => {
+        const formattedDescription = padLeft(option.description, option.name);
+        console.log(`      ${option.name}${formattedDescription}`);
+      });
+    }
+
+    console.log();
+  });
+}
+
+module.exports = helpCommand;

--- a/lib/install-theme.js
+++ b/lib/install-theme.js
@@ -1,6 +1,12 @@
+/* eslint-disable no-console */
 const inquirer = require('inquirer');
 const childProcess = require('child_process');
 
+/**
+ * Prompts the user to enter the @edx/brand package they want to install.
+ *
+ * @returns {Promise<Object>} - A Promise that resolves to an object containing the user's input.
+ */
 function promptUserForTheme() {
   return inquirer.prompt([
     {
@@ -12,6 +18,11 @@ function promptUserForTheme() {
   ]);
 }
 
+/**
+ * Installs a specified @edx/brand package.
+ *
+ * @param {string} theme - The @edx/brand package to install.
+ */
 function installTheme(theme) {
   const version = theme ? `npm:${theme}` : '';
 
@@ -20,9 +31,19 @@ function installTheme(theme) {
   childProcess.execSync(installCommand, { stdio: 'inherit' });
 }
 
+/**
+ * Command handler for installing an @edx/brand package.
+ */
 async function themeCommand() {
-  const answers = await promptUserForTheme();
-  installTheme(answers.theme);
+  // Check if the user passed a theme parameter as a command-line argument
+  console.log('process.argv', process.argv);
+  if (process.argv.length === 4) {
+    const providedTheme = process.argv[3];
+    installTheme(providedTheme);
+  } else {
+    const answers = await promptUserForTheme();
+    installTheme(answers.theme);
+  }
 }
 
 module.exports = themeCommand;


### PR DESCRIPTION
## Description

PR includes:
- new `help` command
- new structure for `COMMANDS` object with commented example
- documentation in the `README.md`
- new support for `paragon install-theme <theme>` that can receive `<theme>` parameter

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
