### PR TITLE
[BD-46] fix: fixed link to bootstrap for the DataTable

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -1062,7 +1062,7 @@ a responsive grid of cards.
 ### Customizing number of Cards shown per row
 Use `columnSizes` prop of `CardView` component to define how many `Cards` are shown per row at each breakpoint.
 
-`columnSizes` is an object containing the desired column size at each breakpoint. The example below shows 1 `Card` per row at `xs` breakpoint, 2 `Cards` at `sm` and `md`, and 4 `Cards` at `lg` and higher. You can read more about the API at [React-Bootstrap grid documentation](https://react-bootstrap-v4.netlify.app/layout/grid/).
+`columnSizes` is an object containing the desired column size at each breakpoint. The example below shows 1 `Card` per row at `xs` breakpoint, 2 `Cards` at `sm` and `md`, and 4 `Cards` at `lg` and higher. You can read more about the API at [React-Bootstrap's grid documentation](https://react-bootstrap-v4.netlify.app/layout/grid/).
 
 ```jsx live
 () => {

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -1062,7 +1062,7 @@ a responsive grid of cards.
 ### Customizing number of Cards shown per row
 Use `columnSizes` prop of `CardView` component to define how many `Cards` are shown per row at each breakpoint.
 
-`columnSizes` is an object containing the desired column size at each breakpoint. The example below shows 1 `Card` per row at `xs` breakpoint, 2 `Cards` at `sm` and `md`, and 4 `Cards` at `lg` and higher. You can read more about the API at https://react-bootstrap.netlify.app/layout/grid/.
+`columnSizes` is an object containing the desired column size at each breakpoint. The example below shows 1 `Card` per row at `xs` breakpoint, 2 `Cards` at `sm` and `md`, and 4 `Cards` at `lg` and higher. You can read more about the API at [React-Bootstrap additional documentation](https://react-bootstrap-v4.netlify.app/layout/grid/).
 
 ```jsx live
 () => {

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -1062,7 +1062,7 @@ a responsive grid of cards.
 ### Customizing number of Cards shown per row
 Use `columnSizes` prop of `CardView` component to define how many `Cards` are shown per row at each breakpoint.
 
-`columnSizes` is an object containing the desired column size at each breakpoint. The example below shows 1 `Card` per row at `xs` breakpoint, 2 `Cards` at `sm` and `md`, and 4 `Cards` at `lg` and higher. You can read more about the API at [React-Bootstrap additional documentation](https://react-bootstrap-v4.netlify.app/layout/grid/).
+`columnSizes` is an object containing the desired column size at each breakpoint. The example below shows 1 `Card` per row at `xs` breakpoint, 2 `Cards` at `sm` and `md`, and 4 `Cards` at `lg` and higher. You can read more about the API at [React-Bootstrap grid documentation](https://react-bootstrap-v4.netlify.app/layout/grid/).
 
 ```jsx live
 () => {


### PR DESCRIPTION
## Description

- Replaced the link to the bootstrap documentation for the DataTable component.

[Issue](https://github.com/openedx/paragon/issues/2552)

### Deploy Preview

[DataTable component](https://deploy-preview-2606--paragon-openedx.netlify.app/components/datatable/#customizing-number-of-cards-shown-per-row)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
