### PR TITLE
[BD-46] fix: fixed Card border-radius and color

### DIFF
--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -5,7 +5,7 @@ $card-spacer-x:                      1.25rem !default;
 $card-border-width:                  $border-width !default;
 $card-border-radius:                 $border-radius !default;
 $card-border-color:                  rgba($black, .125) !default;
-$card-border-focus-color:            rgba($black, .5) !default;
+$card-border-focus-color:            $primary-500 !default;
 $card-border-focus-color-dark:       theme-color("primary", "focus") !default;
 $card-inner-border-radius:           subtract($card-border-radius, $card-border-width) !default;
 $card-cap-bg:                        rgba($black, .03) !default;
@@ -53,4 +53,4 @@ $loading-skeleton-spacer:            .313rem !default;
 
 $card-focus-border-offset:           5px !default;
 $card-focus-border-width:            2px !default;
-$card-focus-border-radius:           5px !default;
+$card-focus-border-radius:           .625rem !default;

--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -53,4 +53,4 @@ $loading-skeleton-spacer:            .313rem !default;
 
 $card-focus-border-offset:           5px !default;
 $card-focus-border-width:            2px !default;
-$card-focus-border-radius:           .625rem !default;
+$card-focus-border-radius:           calc($card-focus-border-offset + $card-border-radius) !default;


### PR DESCRIPTION
## Description

- fixed Card border-radius and color.

**Issue:** https://github.com/openedx/paragon/issues/2549

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
