### PR TITLE
[BD-46] fix: align DataTable checkboxes

### DIFF
--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -112,6 +112,12 @@
       display: flex;
       justify-content: flex-end;
     }
+
+    .pgn__data-table-side-filters-item {
+      .pgn__form-checkbox {
+        align-items: center;
+      }
+    }
   }
 
   .pgn__data-table-layout-main {

--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -175,6 +175,10 @@
 .pgn__data-table-filters-dropdown-item {
   padding: $data-table-padding-small 14px;
   min-width: 15em;
+
+  .pgn__form-checkbox {
+    align-items: center;
+  }
 }
 
 .pgn__data-table-status {

--- a/src/Form/_index.scss
+++ b/src/Form/_index.scss
@@ -465,6 +465,7 @@ select.form-control {
 .pgn__form-switch,
 .pgn__form-radio {
   display: inline-flex;
+  align-items: center;
 
   .pgn__form-label {
     display: flex;

--- a/src/Form/_index.scss
+++ b/src/Form/_index.scss
@@ -465,7 +465,6 @@ select.form-control {
 .pgn__form-switch,
 .pgn__form-radio {
   display: inline-flex;
-  align-items: center;
 
   .pgn__form-label {
     display: flex;


### PR DESCRIPTION
## Description
Aligned DataTable checkboxes

[Issue](https://github.com/openedx/paragon/issues/2589)

### Deploy Preview

[Deploy preview 2610](https://deploy-preview-2610--paragon-openedx.netlify.app/components/datatable/#frontend-filtering-and-sorting)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
