### PR TITLE
[BD-46] fix: fixed Tooltip zindex in FullscreenModal

### DIFF
--- a/www/src/scss/_variables.scss
+++ b/www/src/scss/_variables.scss
@@ -2,3 +2,4 @@ $zindex-header:                      2500;
 $zindex-sheet-backdrop:              2501;
 $zindex-sheet:                       2502;
 $zindex-modal:                       2503;
+$zindex-tooltip:                     2504;


### PR DESCRIPTION
## Description

- fixed [Tooltip](https://paragon-openedx.netlify.app/components/tooltip/) zindex in [FullscreenModal](https://paragon-openedx.netlify.app/components/modal/fullscreen-modal/).

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
