### PR TITLE
[BD-46] feat: added FormControl input mask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
+        "react-imask": "^7.1.3",
         "react-loading-skeleton": "^3.1.0",
         "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
@@ -2117,6 +2118,23 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.15.tgz",
+      "integrity": "sha512-SAj8oKi8UogVi6eXQXKNPu8qZ78Yzy7zawrlTr0M+IuW/g8Qe9gVDhGcF9h1S69OyACpYoLxEzpjs1M15sI5wQ==",
+      "dependencies": {
+        "core-js-pure": "^3.30.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/standalone": {
       "version": "7.21.8",
@@ -13854,9 +13872,10 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.30.1",
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.32.2.tgz",
+      "integrity": "sha512-Y2rxThOuNywTjnX/PgA5vWM6CZ9QB9sz9oGeCixV8MqXZO70z/5SHzf9EeBrEBK0PN36DnEBBu9O/aGWzKuMZQ==",
       "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -21033,6 +21052,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/imask": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-7.1.3.tgz",
+      "integrity": "sha512-jZCqTI5Jgukhl2ff+znBQd8BiHOTlnFYCIgggzHYDdoJsHmSSWr1BaejcYBxsjy4ZIs8Rm0HhbOxQcobcdESRQ==",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.22.6"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
       }
     },
     "node_modules/immediate": {
@@ -31618,6 +31648,21 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-imask": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.1.3.tgz",
+      "integrity": "sha512-anCnzdkqpDzNwe7ot76kQSvmnz4Sw7AW/QFjjLh3B87HVNv9e2oHC+1m9hQKSIui2Tqm7w68ooMgDFsCQlDMyg==",
+      "dependencies": {
+        "imask": "^7.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/react-intl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7441,15 +7441,15 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.0.1",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
+      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "^5.0.0",
+        "aria-query": "5.1.3",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
@@ -7587,28 +7587,11 @@
         }
       }
     },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "8.20.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@testing-library/user-event": {
       "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-colorful": "^5.6.1",
     "react-dropzone": "^14.2.1",
     "react-focus-on": "^3.5.4",
+    "react-imask": "^7.1.3",
     "react-loading-skeleton": "^3.1.0",
     "react-popper": "^2.2.5",
     "react-proptype-conditional-require": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -191,5 +191,8 @@
     "www",
     "icons",
     "dependent-usage-analyzer"
-  ]
+  ],
+  "overrides": {
+    "@testing-library/dom": "9.3.3"
+  }
 }

--- a/src/DataTable/tests/TableActions.test.jsx
+++ b/src/DataTable/tests/TableActions.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import classNames from 'classnames';
 import TableActions from '../TableActions';
@@ -216,9 +216,10 @@ describe('<TableActions />', () => {
       expect(overflowToggle).toBeInTheDocument();
 
       userEvent.click(overflowToggle);
-
-      const buttons = screen.getAllByRole('button');
-      expect(buttons.length).toBeGreaterThan(1);
+      waitFor(() => {
+        const buttons = screen.getAllByRole('button');
+        expect(buttons.length).toBeGreaterThan(1);
+      });
     });
 
     it('renders the correct alt text for the dropdown', () => {

--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import RBFormControl from 'react-bootstrap/FormControl';
+import { IMaskInput } from 'react-imask';
 import { useFormGroupContext } from './FormGroupContext';
 import FormControlFeedback from './FormControlFeedback';
 import FormControlDecoratorGroup from './FormControlDecoratorGroup';
@@ -17,6 +18,7 @@ const FormControl = React.forwardRef(({
   floatingLabel,
   autoResize,
   onChange,
+  withMask,
   ...props
 }, ref) => {
   const {
@@ -71,7 +73,7 @@ const FormControl = React.forwardRef(({
       className={className}
     >
       <RBFormControl
-        as={as}
+        as={withMask ? IMaskInput : as}
         ref={resolvedRef}
         size={size}
         isInvalid={isInvalid}

--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -9,8 +9,6 @@ import FormControlDecoratorGroup from './FormControlDecoratorGroup';
 
 import { callAllHandlers, useHasValue } from './fieldUtils';
 
-const DEFAULT_MASK_VALUE = '00-00-000';
-
 const FormControl = React.forwardRef(({
   as,
   className,
@@ -21,7 +19,6 @@ const FormControl = React.forwardRef(({
   autoResize,
   onChange,
   hasInputMask,
-  mask,
   ...props
 }, ref) => {
   const {
@@ -76,7 +73,7 @@ const FormControl = React.forwardRef(({
       className={className}
     >
       <RBFormControl
-        as={hasInputMask ? IMaskInput : as}
+        as={hasInputMask?.length ? IMaskInput : as}
         ref={resolvedRef}
         size={size}
         isInvalid={isInvalid}
@@ -85,7 +82,7 @@ const FormControl = React.forwardRef(({
           'has-value': hasValue,
         })}
         onChange={handleOnChange}
-        mask={mask}
+        mask={hasInputMask}
         {...controlProps}
       />
     </FormControlDecoratorGroup>
@@ -128,10 +125,8 @@ FormControl.propTypes = {
   isInvalid: PropTypes.bool,
   /** Only for `as="textarea"`. Specifies whether the input can be resized according to the height of content. */
   autoResize: PropTypes.bool,
-  /** Specifies whether to use an input mask for the input. */
-  hasInputMask: PropTypes.bool,
-  /** Specifies the input mask to be used if `hasInputMask` is set to `true`. */
-  mask: PropTypes.string,
+  /** Specifies what format to use for the input mask. */
+  hasInputMask: PropTypes.string,
 };
 
 FormControl.defaultProps = {
@@ -150,8 +145,7 @@ FormControl.defaultProps = {
   isValid: undefined,
   isInvalid: undefined,
   autoResize: false,
-  hasInputMask: false,
-  mask: DEFAULT_MASK_VALUE,
+  hasInputMask: undefined,
 };
 
 export default FormControl;

--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -18,7 +18,7 @@ const FormControl = React.forwardRef(({
   floatingLabel,
   autoResize,
   onChange,
-  hasInputMask,
+  inputMask,
   ...props
 }, ref) => {
   const {
@@ -73,7 +73,7 @@ const FormControl = React.forwardRef(({
       className={className}
     >
       <RBFormControl
-        as={hasInputMask?.length ? IMaskInput : as}
+        as={inputMask ? IMaskInput : as}
         ref={resolvedRef}
         size={size}
         isInvalid={isInvalid}
@@ -82,7 +82,7 @@ const FormControl = React.forwardRef(({
           'has-value': hasValue,
         })}
         onChange={handleOnChange}
-        mask={hasInputMask}
+        mask={inputMask}
         {...controlProps}
       />
     </FormControlDecoratorGroup>
@@ -126,7 +126,7 @@ FormControl.propTypes = {
   /** Only for `as="textarea"`. Specifies whether the input can be resized according to the height of content. */
   autoResize: PropTypes.bool,
   /** Specifies what format to use for the input mask. */
-  hasInputMask: PropTypes.string,
+  inputMask: PropTypes.string,
 };
 
 FormControl.defaultProps = {
@@ -145,7 +145,7 @@ FormControl.defaultProps = {
   isValid: undefined,
   isInvalid: undefined,
   autoResize: false,
-  hasInputMask: undefined,
+  inputMask: undefined,
 };
 
 export default FormControl;

--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -9,6 +9,8 @@ import FormControlDecoratorGroup from './FormControlDecoratorGroup';
 
 import { callAllHandlers, useHasValue } from './fieldUtils';
 
+const DEFAULT_MASK_VALUE = '00-00-000';
+
 const FormControl = React.forwardRef(({
   as,
   className,
@@ -18,7 +20,8 @@ const FormControl = React.forwardRef(({
   floatingLabel,
   autoResize,
   onChange,
-  withMask,
+  hasInputMask,
+  mask,
   ...props
 }, ref) => {
   const {
@@ -73,7 +76,7 @@ const FormControl = React.forwardRef(({
       className={className}
     >
       <RBFormControl
-        as={withMask ? IMaskInput : as}
+        as={hasInputMask ? IMaskInput : as}
         ref={resolvedRef}
         size={size}
         isInvalid={isInvalid}
@@ -82,6 +85,7 @@ const FormControl = React.forwardRef(({
           'has-value': hasValue,
         })}
         onChange={handleOnChange}
+        mask={mask}
         {...controlProps}
       />
     </FormControlDecoratorGroup>
@@ -124,6 +128,10 @@ FormControl.propTypes = {
   isInvalid: PropTypes.bool,
   /** Only for `as="textarea"`. Specifies whether the input can be resized according to the height of content. */
   autoResize: PropTypes.bool,
+  /** Specifies whether to use an input mask for the input. */
+  hasInputMask: PropTypes.bool,
+  /** Specifies the input mask to be used if `hasInputMask` is set to `true`. */
+  mask: PropTypes.string,
 };
 
 FormControl.defaultProps = {
@@ -142,6 +150,8 @@ FormControl.defaultProps = {
   isValid: undefined,
   isInvalid: undefined,
   autoResize: false,
+  hasInputMask: false,
+  mask: DEFAULT_MASK_VALUE,
 };
 
 export default FormControl;

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -43,90 +43,6 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 }
 ```
 
-## Input phone mask
-
-```jsx live
-() => {
-  const [value, setValue] = useState('');
-
-  return (
-    <Form.Group>
-      <Form.Control withMask mask="+{7}(000)000-00-00"
-        leadingElement={<Icon src={FavoriteBorder} />}
-        trailingElement={<Icon src={Verified} />}
-        floatingLabel="What kind of cats?"
-        value={value}
-        onAccept={
-          (value, unmaskedValue, mask) => console.log(unmaskedValue)
-        }
-        onChange={(e) => setValue(e.target.value)}
-      />
-    </Form.Group>
-  );
-}
-```
-
-## Input card number mask
-
-```jsx live
-() => {
-  const [value, setValue] = useState('');
-  console.log('============ value ===========', value);
-  return (
-    <Form.Group>
-      <Form.Control withMask mask="0000 0000 0000 0000"
-        leadingElement={<Icon src={FavoriteBorder} />}
-        trailingElement={<Icon src={Verified} />}
-        floatingLabel="What kind of cats?"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-    </Form.Group>
-  );
-}
-```
-
-## Input date mask
-
-```jsx live
-() => {
-  const [value, setValue] = useState('');
-  console.log('============ value ===========', value);
-  return (
-    <Form.Group>
-      <Form.Control withMask mask={Date} min={new Date(1990, 0, 1)} max={new Date(2020, 0, 1)}
-        leadingElement={<Icon src={FavoriteBorder} />}
-        trailingElement={<Icon src={Verified} />}
-        floatingLabel="What kind of cats?"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-    </Form.Group>
-  );
-}
-```
-
-## Input Google-style OTP mask
-
-```jsx live
-() => {
-  const [value, setValue] = useState('');
-  console.log('============ value ===========', value);
-  return (
-    <Form.Group>
-      <Form.Control withMask mask="G-000000000000"
-        leadingElement={<Icon src={FavoriteBorder} />}
-        trailingElement={<Icon src={Verified} />}
-        floatingLabel="What kind of cats?"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-    </Form.Group>
-  );
-}
-```
-
-
 ## Input types
 
 ```jsx live
@@ -242,6 +158,163 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
       
       {inputs[type]}
     </>
+  );
+}
+```
+
+## Input masks
+Paragon uses the [react-imask](https://www.npmjs.com/package/react-imask) library, which allows you to add masks of different types for inputs.
+To create your own mask, you need to pass the required mask pattern (`+{1}(000)000-00-00`) to the `mask` property. <br />
+See [react-imask](https://imask.js.org) for documentation on available props.
+
+```jsx live
+() => {
+  {/* start example state */}
+  const [maskType, setMaskType] = useState('phone');
+  {/* end example state */}
+
+  const inputsWithMask = {
+    phone: (
+      <>
+        <h3>Phone</h3>
+        <Form.Group>
+          <Form.Control
+            hasInputMask
+            mask="+{1}(000)000-00-00"
+            value={value}
+            onChange={handleChange}
+            leadingElement={<Icon src={FavoriteBorder} />}
+            floatingLabel="What is your phone number?"
+          />
+        </Form.Group>
+      </>
+    ),
+    creditCard: (<>
+      <h3>Credit card</h3>
+      <Form.Group>
+        <Form.Control
+          hasInputMask
+          mask="0000 0000 0000 0000"
+          value={value}
+          onChange={handleChange}
+          leadingElement={<Icon src={FavoriteBorder} />}
+          floatingLabel="What is your credit card number?"
+        />
+      </Form.Group>
+    </>),
+    date: (<>
+      <h3>Date</h3>
+      <Form.Group>
+        <Form.Control
+          hasInputMask
+          mask={Date}
+          value={value}
+          onChange={handleChange}
+          leadingElement={<Icon src={FavoriteBorder} />}
+          floatingLabel="What is your date of birth?"
+        />
+      </Form.Group>
+    </>),
+    securePassword: (<>
+      <h3>Secure password</h3>
+      <Form.Group>
+        <Form.Control
+          hasInputMask
+          mask="XXX-XX-0000"
+          value={value}
+          definitions={{
+            X: {
+              mask: '0',
+              displayChar: 'X',
+              placeholderChar: '#',
+            },
+          }}
+          onChange={handleChange}
+          leadingElement={<Icon src={FavoriteBorder} />}
+          floatingLabel="What is your password?"
+        />
+      </Form.Group>
+    </>),
+    OTPpassword: (<>
+      <h3>OTP password</h3>
+      <Form.Group>
+        <Form.Control
+          hasInputMask
+          mask="G-00000"
+          value={value}
+          onChange={handleChange}
+          leadingElement={<Icon src={FavoriteBorder} />}
+          floatingLabel="What is your OPT password?"
+        />
+      </Form.Group>
+    </>),
+    price: (
+        <>
+          <h3>Course prise</h3>
+          <Form.Group>
+            <Form.Control
+              hasInputMask
+              mask="$num"
+              blocks={{
+                num: {
+                  // nested masks are available!
+                  mask: Number,
+                  thousandsSeparator: ' '
+                }
+              }}
+              value={value}
+              onChange={handleChange}
+              leadingElement={<Icon src={FavoriteBorder} />}
+              floatingLabel="What is the price of this course?"
+            />
+          </Form.Group>
+        </>
+    ),
+  };
+
+  const [value, setValue] = useState('');
+
+  const handleChange = (e) => setValue(e.target.value);
+
+  return (
+    <>
+      {/* start example form block */}
+      <ExamplePropsForm
+        inputs={[
+          { value: maskType, setValue: setMaskType, options: Object.keys(inputsWithMask), name: 'Mask variants' },
+        ]}
+      />
+      {/* end example form block */}
+
+      {inputsWithMask[maskType]}
+    </>
+  );
+}
+```
+
+## Input masks with clear value
+`unmask` prop allows get and set value and unmasked value easily
+
+```jsx live
+() => {
+  const [value, setValue] = useState('');
+
+  return (
+    <Form.Group>
+      <Form.Control
+        hasInputMask
+        mask="+{1}(000)000-00-00"
+        leadingElement={<Icon src={FavoriteBorder} />}
+        trailingElement={<Icon src={Verified} />}
+        floatingLabel="What kind of cats?"
+        value={value}
+        unmask
+        onChange={(e) => setValue(e.target.value)}
+          onAccept={
+            (value) => console.log(value)
+          }
+      />
+    </Form.Group>
   );
 }
 ```

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -43,6 +43,89 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 }
 ```
 
+## Input phone mask
+
+```jsx live
+() => {
+  const [value, setValue] = useState('');
+
+  return (
+    <Form.Group>
+      <Form.Control withMask mask="+{7}(000)000-00-00"
+        leadingElement={<Icon src={FavoriteBorder} />}
+        trailingElement={<Icon src={Verified} />}
+        floatingLabel="What kind of cats?"
+        value={value}
+        onAccept={
+          (value, unmaskedValue, mask) => console.log(unmaskedValue)
+        }
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </Form.Group>
+  );
+}
+```
+
+## Input card number mask
+
+```jsx live
+() => {
+  const [value, setValue] = useState('');
+  console.log('============ value ===========', value);
+  return (
+    <Form.Group>
+      <Form.Control withMask mask="0000 0000 0000 0000"
+        leadingElement={<Icon src={FavoriteBorder} />}
+        trailingElement={<Icon src={Verified} />}
+        floatingLabel="What kind of cats?"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </Form.Group>
+  );
+}
+```
+
+## Input date mask
+
+```jsx live
+() => {
+  const [value, setValue] = useState('');
+  console.log('============ value ===========', value);
+  return (
+    <Form.Group>
+      <Form.Control withMask mask={Date} min={new Date(1990, 0, 1)} max={new Date(2020, 0, 1)}
+        leadingElement={<Icon src={FavoriteBorder} />}
+        trailingElement={<Icon src={Verified} />}
+        floatingLabel="What kind of cats?"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </Form.Group>
+  );
+}
+```
+
+## Input Google-style OTP mask
+
+```jsx live
+() => {
+  const [value, setValue] = useState('');
+  console.log('============ value ===========', value);
+  return (
+    <Form.Group>
+      <Form.Control withMask mask="G-000000000000"
+        leadingElement={<Icon src={FavoriteBorder} />}
+        trailingElement={<Icon src={Verified} />}
+        floatingLabel="What kind of cats?"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </Form.Group>
+  );
+}
+```
+
 
 ## Input types
 

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -165,7 +165,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 ## Input masks
 Paragon uses the [react-imask](https://www.npmjs.com/package/react-imask) library,
 which allows you to add masks of different types for inputs.
-To create your own mask, you need to pass the required mask pattern (`+{1}(000)000-00-00`) to the `inputMask` property. <br />
+To create your own mask, you need to pass the required mask pattern (`+{1} (000) 000-0000`) to the `inputMask` property. <br />
 See [react-imask](https://imask.js.org) for documentation on available props.
 
 ```jsx live
@@ -180,7 +180,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
         <h3>Phone</h3>
         <Form.Group>
           <Form.Control
-            inputMask="+{1}(000)000-00-00"
+            inputMask="+{1} (000) 000-0000"
             value={value}
             onChange={handleChange}
             leadingElement={<Icon src={FavoriteBorder} />}
@@ -198,18 +198,6 @@ See [react-imask](https://imask.js.org) for documentation on available props.
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
           floatingLabel="What is your credit card number?"
-        />
-      </Form.Group>
-    </>),
-    date: (<>
-      <h3>Date</h3>
-      <Form.Group>
-        <Form.Control
-          inputMask={Date}
-          value={value}
-          onChange={handleChange}
-          leadingElement={<Icon src={FavoriteBorder} />}
-          floatingLabel="What is your date of birth?"
         />
       </Form.Group>
     </>),
@@ -246,7 +234,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
     </>),
     price: (
         <>
-          <h3>Course prise</h3>
+          <h3>Course priсe</h3>
           <Form.Group>
             <Form.Control
               inputMask="$num"
@@ -298,7 +286,7 @@ To get a value without a mask, you need to use `onChange` instead of `onAccept` 
       <>
         <Form.Group>
           <Form.Control
-            inputMask="+{1}(000)000-00-00"
+            inputMask="+{1} (000) 000-0000"
             leadingElement={<Icon src={FavoriteBorder} />}
             trailingElement={<Icon src={Verified} />}
             floatingLabel="What is your phone number?"

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -165,7 +165,7 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 ## Input masks
 Paragon uses the [react-imask](https://www.npmjs.com/package/react-imask) library,
 which allows you to add masks of different types for inputs.
-To create your own mask, you need to pass the required mask pattern (`+{1}(000)000-00-00`) to the `hasInputMask` property. <br />
+To create your own mask, you need to pass the required mask pattern (`+{1}(000)000-00-00`) to the `inputMask` property. <br />
 See [react-imask](https://imask.js.org) for documentation on available props.
 
 ```jsx live
@@ -180,7 +180,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
         <h3>Phone</h3>
         <Form.Group>
           <Form.Control
-            hasInputMask="+{1}(000)000-00-00"
+            inputMask="+{1}(000)000-00-00"
             value={value}
             onChange={handleChange}
             leadingElement={<Icon src={FavoriteBorder} />}
@@ -193,7 +193,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>Credit card</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask="0000 0000 0000 0000"
+          inputMask="0000 0000 0000 0000"
           value={value}
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
@@ -205,7 +205,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>Date</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask={Date}
+          inputMask={Date}
           value={value}
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
@@ -217,7 +217,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>Secure password</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask="XXX-XX-0000"
+          inputMask="XXX-XX-0000"
           value={value}
           definitions={{
             X: {
@@ -236,7 +236,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>OTP password</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask="G-00000"
+          inputMask="G-00000"
           value={value}
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
@@ -249,7 +249,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
           <h3>Course prise</h3>
           <Form.Group>
             <Form.Control
-              hasInputMask="$num"
+              inputMask="$num"
               blocks={{
                 num: {
                   // nested masks are available!
@@ -298,7 +298,7 @@ To get a value without a mask, you need to use `onChange` instead of `onAccept` 
       <>
         <Form.Group>
           <Form.Control
-            hasInputMask="+{1}(000)000-00-00"
+            inputMask="+{1}(000)000-00-00"
             leadingElement={<Icon src={FavoriteBorder} />}
             trailingElement={<Icon src={Verified} />}
             floatingLabel="What is your phone number?"

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -163,8 +163,9 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 ```
 
 ## Input masks
-Paragon uses the [react-imask](https://www.npmjs.com/package/react-imask) library, which allows you to add masks of different types for inputs.
-To create your own mask, you need to pass the required mask pattern (`+{1}(000)000-00-00`) to the `mask` property. <br />
+Paragon uses the [react-imask](https://www.npmjs.com/package/react-imask) library,
+which allows you to add masks of different types for inputs.
+To create your own mask, you need to pass the required mask pattern (`+{1}(000)000-00-00`) to the `hasInputMask` property. <br />
 See [react-imask](https://imask.js.org) for documentation on available props.
 
 ```jsx live
@@ -179,8 +180,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
         <h3>Phone</h3>
         <Form.Group>
           <Form.Control
-            hasInputMask
-            mask="+{1}(000)000-00-00"
+            hasInputMask="+{1}(000)000-00-00"
             value={value}
             onChange={handleChange}
             leadingElement={<Icon src={FavoriteBorder} />}
@@ -193,8 +193,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>Credit card</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask
-          mask="0000 0000 0000 0000"
+          hasInputMask="0000 0000 0000 0000"
           value={value}
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
@@ -206,8 +205,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>Date</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask
-          mask={Date}
+          hasInputMask={Date}
           value={value}
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
@@ -219,8 +217,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>Secure password</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask
-          mask="XXX-XX-0000"
+          hasInputMask="XXX-XX-0000"
           value={value}
           definitions={{
             X: {
@@ -239,8 +236,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
       <h3>OTP password</h3>
       <Form.Group>
         <Form.Control
-          hasInputMask
-          mask="G-00000"
+          hasInputMask="G-00000"
           value={value}
           onChange={handleChange}
           leadingElement={<Icon src={FavoriteBorder} />}
@@ -253,8 +249,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
           <h3>Course prise</h3>
           <Form.Group>
             <Form.Control
-              hasInputMask
-              mask="$num"
+              hasInputMask="$num"
               blocks={{
                 num: {
                   // nested masks are available!
@@ -293,25 +288,30 @@ See [react-imask](https://imask.js.org) for documentation on available props.
 ```
 
 ## Input masks with clear value
-`unmask` prop allows get and set value and unmasked value easily
+To get a value without a mask, you need to use `onChange` instead of `onAccept` to handle changes.
 
 ```jsx live
 () => {
   const [value, setValue] = useState('');
-  console.log(value);
 
   return (
-    <Form.Group>
-      <Form.Control
-        hasInputMask
-        mask="+{1}(000)000-00-00"
-        leadingElement={<Icon src={FavoriteBorder} />}
-        trailingElement={<Icon src={Verified} />}
-        floatingLabel="What is your phone number?"
-        value={value}
-        onAccept={(_, mask) => setValue(mask._unmaskedValue)}
-      />
-    </Form.Group>
+      <>
+        <Form.Group>
+          <Form.Control
+            hasInputMask="+{1}(000)000-00-00"
+            leadingElement={<Icon src={FavoriteBorder} />}
+            trailingElement={<Icon src={Verified} />}
+            floatingLabel="What is your phone number?"
+            value={value}
+            // depending on prop above first argument is
+            // `value` if `unmask=false`,
+            // `unmaskedValue` if `unmask=true`,
+            // `typedValue` if `unmask='typed'`
+            onAccept={(_, mask) => setValue(mask._unmaskedValue)}
+          />
+        </Form.Group>
+        Unmasked value: {JSON.stringify(value)}
+      </>
   );
 }
 ```

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -298,6 +298,7 @@ See [react-imask](https://imask.js.org) for documentation on available props.
 ```jsx live
 () => {
   const [value, setValue] = useState('');
+  console.log(value);
 
   return (
     <Form.Group>
@@ -306,13 +307,9 @@ See [react-imask](https://imask.js.org) for documentation on available props.
         mask="+{1}(000)000-00-00"
         leadingElement={<Icon src={FavoriteBorder} />}
         trailingElement={<Icon src={Verified} />}
-        floatingLabel="What kind of cats?"
+        floatingLabel="What is your phone number?"
         value={value}
-        unmask
-        onChange={(e) => setValue(e.target.value)}
-          onAccept={
-            (value) => console.log(value)
-          }
+        onAccept={(_, mask) => setValue(mask._unmaskedValue)}
       />
     </Form.Group>
   );

--- a/src/Form/tests/FormControl.test.jsx
+++ b/src/Form/tests/FormControl.test.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-   render, screen, act,
+  render, screen, act, fireEvent,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Form/tests/FormControl.test.jsx
+++ b/src/Form/tests/FormControl.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -7,6 +7,23 @@ import FormControl from '../FormControl';
 const ref = {
   current: null,
 };
+
+// eslint-disable-next-line react/prop-types
+function Component({ isClearValue }) {
+  const onChangeFunc = jest.fn();
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <FormControl
+      hasInputMask
+      mask="+{1}(000)000-00-00"
+      value={inputValue}
+      onChange={isClearValue ? onChangeFunc : (e) => setInputValue(e.target.value)}
+      onAccept={isClearValue ? onChangeFunc : (value) => setInputValue(value)}
+      data-testid="form-control-with-mask"
+    />
+  );
+}
 
 describe('FormControl', () => {
   it('textarea changes its height with autoResize prop', async () => {
@@ -30,5 +47,20 @@ describe('FormControl', () => {
 
     expect(onChangeFunc).toHaveBeenCalledTimes(inputText.length);
     expect(ref.current.style.height).toEqual(`${ref.current.scrollHeight + ref.current.offsetHeight}px`);
+  });
+
+  it('should apply and accept input mask for phone numbers', () => {
+    render(<Component />);
+
+    const input = screen.getByTestId('form-control-with-mask');
+    fireEvent.change(input, { target: { value: '1234567890' } });
+    expect(input.value).toBe('+1(234)567-89-0');
+  });
+  it('should be cleared from the mask elements value', () => {
+    render(<Component isClearValue />);
+
+    const input = screen.getByTestId('form-control-with-mask');
+    fireEvent.change(input, { target: { value: '1234567890' } });
+    expect(input.value).toBe('1234567890');
   });
 });

--- a/src/Form/tests/FormControl.test.jsx
+++ b/src/Form/tests/FormControl.test.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import {
+   render, screen, act,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import FormControl from '../FormControl';
@@ -15,8 +17,7 @@ function Component({ isClearValue }) {
 
   return (
     <FormControl
-      hasInputMask
-      mask="+{1}(000)000-00-00"
+      hasInputMask="+{1}(000)000-00-00"
       value={inputValue}
       onChange={isClearValue ? onChangeFunc : (e) => setInputValue(e.target.value)}
       onAccept={isClearValue ? onChangeFunc : (value) => setInputValue(value)}
@@ -52,9 +53,11 @@ describe('FormControl', () => {
   it('should apply and accept input mask for phone numbers', () => {
     render(<Component />);
 
-    const input = screen.getByTestId('form-control-with-mask');
-    fireEvent.change(input, { target: { value: '1234567890' } });
-    expect(input.value).toBe('+1(234)567-89-0');
+    act(() => {
+      const input = screen.getByTestId('form-control-with-mask');
+      userEvent.type(input, '1234567890');
+      expect(input.value).toBe('+1(234)567-89-0');
+    });
   });
   it('should be cleared from the mask elements value', () => {
     render(<Component isClearValue />);

--- a/src/Form/tests/FormControl.test.jsx
+++ b/src/Form/tests/FormControl.test.jsx
@@ -17,7 +17,7 @@ function Component({ isClearValue }) {
 
   return (
     <FormControl
-      hasInputMask="+{1}(000)000-00-00"
+      inputMask="+{1}(000)000-00-00"
       value={inputValue}
       onChange={isClearValue ? onChangeFunc : (e) => setInputValue(e.target.value)}
       onAccept={isClearValue ? onChangeFunc : (value) => setInputValue(value)}


### PR DESCRIPTION
## Description

- added FormControl input mask.

**Issue:** https://github.com/openedx/paragon/issues/2458

### Deploy Preview

[Form.Control component](https://deploy-preview-2626--paragon-openedx.netlify.app/components/form/form-control/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
