### PR TITLE
[BD-46] fix: fixed replacing CSS variables on the Colors page

### DIFF
--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -121,7 +121,16 @@ export interface IColorsPage {
 // eslint-disable-next-line react/prop-types
 export default function ColorsPage({ data }: IColorsPage) {
   const { settings } = useContext(SettingsContext);
-  const styles = typeof window !== 'undefined' ? getComputedStyle(document.body) : null;
+  const [styles, setStyles] = useState<CSSStyleDeclarationType>(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (typeof window !== 'undefined') {
+        const newStyles = getComputedStyle(document.body);
+        setStyles(newStyles);
+      }
+    }, 500);
+  }, [settings.theme]);
 
   parseColors(data.allCssUtilityClasses.nodes); // eslint-disable-line react/prop-types
 


### PR DESCRIPTION
## Description

- fixed replacing CSS variables on the Colors page.

**Issue:** https://github.com/openedx/paragon/issues/2629

### Deploy Preview

[Colors page](https://deploy-preview-2628--paragon-openedx.netlify.app/foundations/colors)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
