### PR TITLE
feat: autosuggest error handling

### DIFF
--- a/src/Form/form-autosuggest.mdx
+++ b/src/Form/form-autosuggest.mdx
@@ -19,7 +19,15 @@ Form auto-suggest enables users to manually select or type to find matching opti
 
 ```jsx live
 () => {
-    const [selected, setSelected] = useState('');
+    const [selectedDisplay, setSelectedDisplay] = useState('');
+    const [selectedData, setSelectedData] = useState('');
+    const handleSelected = (selectedObject) => {
+        setSelectedDisplay(selectedObject.displayValue)
+        setSelectedData(selectedObject.dataValue)
+    }
+
+    console.log("SELECTEDDISPLAY:", selectedDisplay)
+    console.log("SELECTEDDATA:", selectedData)
 
     return (
         <Form.Autosuggest
@@ -27,15 +35,15 @@ Form auto-suggest enables users to manually select or type to find matching opti
             aria-label="form autosuggest"
             helpMessage="Select language"
             errorMessageText="Error, no selected value"
-            value={selected}
-            onSelected={(value) => setSelected(value)}
+            errorNoMatchingText="Error, no matching value"
+            value={selectedData}
+            freeformValue={selectedDisplay}
+            onSelected={(value) => handleSelected(value)}
+            allowFreeFormInput={true}
         >
-            <Form.AutosuggestOption>JavaScript</Form.AutosuggestOption>
-            <Form.AutosuggestOption>Python</Form.AutosuggestOption>
-            <Form.AutosuggestOption>Rube</Form.AutosuggestOption>
-            <Form.AutosuggestOption onClick={(e) => alert(e.currentTarget.getAttribute('data-value'))}>
-                Option with custom onClick
-            </Form.AutosuggestOption>
+            <Form.AutosuggestOption value="js">JavaScript</Form.AutosuggestOption>
+            <Form.AutosuggestOption value="py">Python</Form.AutosuggestOption>
+            <Form.AutosuggestOption value="rb">Ruby</Form.AutosuggestOption>
         </Form.Autosuggest>
     );
 }


### PR DESCRIPTION
## Description

Added logic to set error handling when clicking or tabing outside of the component. Created logic to allow consumer to use freeform functionality. Created option values and seperate display versus data value logic.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
