### PR TITLE
[BD-46] docs: fix Paragon's version generation in dependent-usage.json

### DIFF
--- a/dependent-usage-analyzer/index.js
+++ b/dependent-usage-analyzer/index.js
@@ -40,7 +40,7 @@ function getDependencyVersion(dir, options = {}) {
   const { projectsDir } = options;
   if (dir === projectsDir) {
     // At the top-level directory containing all projects; Paragon version not found.
-    return {};
+    return "";
   }
   const parentDir = dir.split('/').slice(0, -1).join('/');
   if (!fs.existsSync(`${dir}/${packageFilename}`)) {

--- a/dependent-usage.json
+++ b/dependent-usage.json
@@ -38991,7 +38991,7 @@
       }
     },
     {
-      "version": {},
+      "version": "",
       "name": "@edx/gatsby-react-app",
       "repository": {
         "type": "git",


### PR DESCRIPTION
## Description

Fixes Paragon's version value in dependent-usage.json to be `""` when it was not found in the cloned repo. Previously we defaulted to `{}` in such cases which breaks docs site build.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
