### PR TITLE
chore: adding a read into memory example to the Dropzone component template

### DIFF
--- a/src/Dropzone/README.md
+++ b/src/Dropzone/README.md
@@ -277,3 +277,44 @@ This example validates that only `400x479` images can be uploaded.
   );
 }
 ```
+
+## Reading file contents into memory
+
+Accepts only .xml files up to a size of 20MB. You can read in the contents of the `File` object into memory. The ``onProcessUpload`` prop should retrieve the file Blob from the passed ``fileData`` param and pass it into a file reader.
+
+Note that `Dropzone` does not handle unexpected errors that might happen in your function, they should be handled by the ``handleProcessUpload`` method.
+
+```jsx live
+() => {
+  const [text, setText] = useState("");
+
+  async function handleProcessUpload({
+    fileData, requestConfig, handleError
+  }) {
+    const blob = fileData.get('file');
+    const reader = new FileReader();
+    reader.readAsDataURL(blob);
+    reader.onloadend = function() {
+      const base64data = reader.result.split(',')[1];                
+      console.log(atob(base64data));
+      setText(atob(base64data));
+    }
+  };
+
+  return (
+    <>
+      <Dropzone
+        onProcessUpload={handleProcessUpload}
+        onUploadProgress={(percent) => console.log(percent)}
+        onUploadCancel={() => console.log('UPLOAD CANCEL')}
+        progressVariant="bar"
+        maxSize={20 * 1048576}
+        accept={{
+          "application/xml": ['.xml']
+        }}
+      />
+      <p>{text}</p>
+    </>
+  )
+}
+```


### PR DESCRIPTION
## Description

![image](https://github.com/openedx/paragon/assets/67655836/a018a538-ab63-40e4-8b45-3de558b9accb)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
