### PR TITLE
fix: run leave control logic when tabbing out

### DIFF
--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -112,6 +112,7 @@ function FormAutosuggest({
     <IconButton
       className="pgn__form-autosuggest__icon-button"
       data-testid="autosuggest-iconbutton"
+      tabindex="-1"
       src={isMenuClosed ? KeyboardArrowDown : KeyboardArrowUp}
       iconAs={Icon}
       size="sm"
@@ -123,17 +124,21 @@ function FormAutosuggest({
     />
   );
 
+  const leaveControl = () => {
+    setIsActive(false);
+
+    setState(prevState => ({
+      ...prevState,
+      dropDownItems: [],
+      errorMessage: !state.displayValue ? errorMessageText : '',
+    }));
+
+    setIsMenuClosed(true);
+  };
+
   const handleDocumentClick = (e) => {
     if (parentRef.current && !parentRef.current.contains(e.target) && isActive) {
-      setIsActive(false);
-
-      setState(prevState => ({
-        ...prevState,
-        dropDownItems: [],
-        errorMessage: !state.displayValue ? errorMessageText : '',
-      }));
-
-      setIsMenuClosed(true);
+      leaveControl();
     }
   };
 
@@ -147,6 +152,9 @@ function FormAutosuggest({
       }));
 
       setIsMenuClosed(true);
+    }
+    if (e.key === 'Tab' && isActive) {
+      leaveControl();
     }
   };
 

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -240,4 +240,21 @@ describe('controlled behavior', () => {
 
     expect(getByText('2 options found')).toBeInTheDocument();
   });
+
+  it('closes options list when tabbed out and the input is no longer active', () => {
+    const { getByTestId, queryAllByTestId } = render(<FormAutosuggestTestComponent />);
+    const input = getByTestId('autosuggest-textbox-input');
+
+    userEvent.click(input);
+    expect(document.activeElement).toBe(getByTestId('autosuggest-textbox-input'));
+
+    const list = queryAllByTestId('autosuggest-optionitem');
+    expect(list.length).toBe(3);
+
+    userEvent.tab();
+    expect(document.activeElement).not.toBe(getByTestId('autosuggest-textbox-input'));
+
+    const updatedList = queryAllByTestId('autosuggest-optionitem');
+    expect(updatedList.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Description

Resolves: https://github.com/openedx/paragon/issues/2437

Before:
- When user tabbed the focus would jump to the drop down icon arrow
- Tabbing out doesn't hide the dropdown

After:
- When hitting tab, the focus jumps to the next control of the DOM 
- Dropdown is then closed

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
