### PR TITLE
[BD-46] feat: added Edit this page CTA to non-component pages

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -18,3 +18,18 @@ exports.createPages = ({ graphql, actions, reporter }) => createPages(graphql, a
 exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
   createCssUtilityClassNodes({ actions, createNodeId, createContentDigest });
 };
+
+exports.onCreatePage = ({ page, actions }) => {
+  const { createPage, deletePage } = actions;
+  const githubEditPath = `https://github.com/openedx/paragon/edit/master/www/src${page.componentPath.split('src')[1]}`;
+  deletePage(page);
+  // console.log('=================== page ====================', page.component);
+  // You can access the variable "house" in your page queries now
+  createPage({
+    ...page,
+    context: {
+      ...page.context,
+      githubEditPath,
+    },
+  });
+};

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -8,6 +8,7 @@ const createPages = require('./utils/createPages');
 const onCreateNode = require('./utils/onCreateNode');
 const onCreateWebpackConfig = require('./utils/onCreateWebpackConfig');
 const createCssUtilityClassNodes = require('./utils/createCssUtilityClassNodes');
+const onCreatePage = require('./utils/onCreatePage');
 
 exports.onCreateWebpackConfig = ({ actions }) => onCreateWebpackConfig(actions);
 
@@ -19,15 +20,4 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
   createCssUtilityClassNodes({ actions, createNodeId, createContentDigest });
 };
 
-exports.onCreatePage = ({ page, actions }) => {
-  const { createPage } = actions;
-  const githubEditPath = `https://github.com/openedx/paragon/edit/master/www/src${page.componentPath.split('src')[1]}`;
-
-  createPage({
-    ...page,
-    context: {
-      ...page.context,
-      githubEditPath,
-    },
-  });
-};
+exports.onCreatePage = ({ page, actions }) => onCreatePage(page, actions);

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -20,11 +20,9 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
 };
 
 exports.onCreatePage = ({ page, actions }) => {
-  const { createPage, deletePage } = actions;
+  const { createPage } = actions;
   const githubEditPath = `https://github.com/openedx/paragon/edit/master/www/src${page.componentPath.split('src')[1]}`;
-  deletePage(page);
-  // console.log('=================== page ====================', page.component);
-  // You can access the variable "house" in your page queries now
+
   createPage({
     ...page,
     context: {

--- a/www/src/components/PageEditBtn/index.tsx
+++ b/www/src/components/PageEditBtn/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Hyperlink, Nav } from '~paragon-react';
 
 export interface PageEditBtnProps extends Partial<AnchorHTMLAttributes<HTMLAnchorElement>> {
-  githubEditPath: string,
+  githubEditPath?: string,
   isNavLink?: boolean;
 }
 

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -64,19 +64,8 @@ function Layout({
           title
         }
       }
-    allSitePage {
-      nodes {
-        component
-      }
-    }
     }
   `);
-
-  const currentURL = typeof window !== 'undefined' ? window.location.pathname.split('/')[2] : '';
-  const filteredData = data.allSitePage.nodes.filter(item => !item.component.includes('components'));
-  const elementWithLayout = filteredData.find(item => item.component.includes(currentURL))?.component;
-  const componentName = elementWithLayout?.split('src')[1];
-  const foundationLinkBase = `https://github.com/openedx/paragon/blob/master/www/src${componentName}`;
 
   return (
     <div className="d-flex flex-column">
@@ -104,7 +93,7 @@ function Layout({
               <Container size="md">
                 <hr />
                 <Stack direction="horizontal" gap={2}>
-                  <PageEditBtn className="mb-5" githubEditPath={githubEditPath || foundationLinkBase} />
+                  <PageEditBtn className="mb-5" githubEditPath={githubEditPath} />
                   <LeaveFeedback className="mb-5" />
                 </Stack>
               </Container>

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -149,14 +149,14 @@ function Layout({
           <Nav.Item>
             <LeaveFeedback className="muted-link" isNavLink />
           </Nav.Item>
-          {isMdx && (
-            <Nav.Item>
-              <PageEditBtn
-                className="muted-link"
-                githubEditPath={githubEditPath ?? ''}
-                isNavLink
-              />
-            </Nav.Item>
+          {!hideFooterComponentMenu && (
+          <Nav.Item>
+            <PageEditBtn
+              className="muted-link"
+              githubEditPath={githubEditPath ?? ''}
+              isNavLink
+            />
+          </Nav.Item>
           )}
           <div className="flex-grow-1" />
           <Nav.Link

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -64,8 +64,19 @@ function Layout({
           title
         }
       }
+    allSitePage {
+      nodes {
+        component
+      }
+    }
     }
   `);
+
+  const currentURL = typeof window !== 'undefined' ? window.location.pathname.split('/')[2] : '';
+  const filteredData = data.allSitePage.nodes.filter(item => !item.component.includes('components'));
+  const elementWithLayout = filteredData.find(item => item.component.includes(currentURL))?.component;
+  const componentName = elementWithLayout?.split('src')[1];
+  const foundationLinkBase = `https://github.com/openedx/paragon/blob/master/www/src${componentName}`;
 
   return (
     <div className="d-flex flex-column">
@@ -93,9 +104,7 @@ function Layout({
               <Container size="md">
                 <hr />
                 <Stack direction="horizontal" gap={2}>
-                  {isMdx && (
-                    <PageEditBtn className="mb-5" githubEditPath={githubEditPath ?? ''} />
-                  )}
+                  <PageEditBtn className="mb-5" githubEditPath={githubEditPath || foundationLinkBase} />
                   <LeaveFeedback className="mb-5" />
                 </Stack>
               </Container>

--- a/www/src/pages/404.tsx
+++ b/www/src/pages/404.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Layout from '../components/PageLayout';
 import SEO from '../components/SEO';
 
-function NotFoundPage() {
+function NotFoundPage({ pageContext }) {
   return (
-    <Layout>
+    <Layout githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="404: Not found" />
       <h1>404: Not Found</h1>
@@ -13,5 +14,11 @@ function NotFoundPage() {
     </Layout>
   );
 }
+
+NotFoundPage.propTypes = {
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
+};
 
 export default NotFoundPage;

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -124,12 +124,12 @@ export interface IColorsPage {
 }
 
 // eslint-disable-next-line react/prop-types
-export default function ColorsPage({ data }: IColorsPage) {
+export default function ColorsPage({ data, pageContext }: IColorsPage) {
   const { settings } = useContext(SettingsContext);
   parseColors(data.allCssUtilityClasses.nodes); // eslint-disable-line react/prop-types
-
+  // console.log('====================== pageContext ========================', pageContext);
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Colors" />
       <Container size={settings.containerWidth} className="py-5">

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -121,13 +121,16 @@ export interface IColorsPage {
       nodes: [],
     },
   },
+  pageContext: {
+    githubEditPath: string,
+  }
 }
 
 // eslint-disable-next-line react/prop-types
 export default function ColorsPage({ data, pageContext }: IColorsPage) {
   const { settings } = useContext(SettingsContext);
   parseColors(data.allCssUtilityClasses.nodes); // eslint-disable-line react/prop-types
-  // console.log('====================== pageContext ========================', pageContext);
+
   return (
     <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}

--- a/www/src/pages/foundations/elevation.jsx
+++ b/www/src/pages/foundations/elevation.jsx
@@ -268,7 +268,7 @@ function BoxShadowGenerator() {
   );
 }
 
-export default function ElevationPage() {
+export default function ElevationPage({ pageContext }) {
   const { settings } = useContext(SettingsContext);
 
   const levelTitle = boxShadowLevels.map(level => (
@@ -284,7 +284,7 @@ export default function ElevationPage() {
   ));
 
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Elevation" />
       <Container size={settings.containerWidth} className="py-5">

--- a/www/src/pages/foundations/elevation.jsx
+++ b/www/src/pages/foundations/elevation.jsx
@@ -399,3 +399,9 @@ export default function ElevationPage({ pageContext }) {
     </Layout>
   );
 }
+
+ElevationPage.propTypes = {
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
+};

--- a/www/src/pages/foundations/responsive.jsx
+++ b/www/src/pages/foundations/responsive.jsx
@@ -49,7 +49,7 @@ function MaxWidthCell({ row }) {
   return <code>{row.values.maxWidth ? `${row.values.maxWidth}px` : '-'}</code>;
 }
 
-function Responsive() {
+function Responsive({ pageContext }) {
   const { settings } = useContext(SettingsContext);
   const breakpointsData = Object.keys(breakpoints).map(breakpoint => {
     const { minWidth, maxWidth } = breakpoints[breakpoint];
@@ -60,7 +60,7 @@ function Responsive() {
   });
 
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Responsive" />
       <Container size={settings.containerWidth} className="py-5">

--- a/www/src/pages/foundations/responsive.jsx
+++ b/www/src/pages/foundations/responsive.jsx
@@ -79,6 +79,7 @@ function Responsive({ pageContext }) {
             { Header: 'Min width', accessor: 'minWidth', Cell: MinWidthCell },
             { Header: 'Max Width', accessor: 'maxWidth', Cell: MaxWidthCell },
           ]}
+          itemCount={0}
         >
           <DataTable.Table />
         </DataTable>
@@ -102,6 +103,12 @@ function Responsive({ pageContext }) {
     </Layout>
   );
 }
+
+Responsive.propTypes = {
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
+};
 
 const cellPropTypes = {
   row: PropTypes.shape({

--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -83,7 +83,7 @@ SpaceBlock.defaultProps = {
   utilityClass: '',
 };
 
-export default function SpacingPage() {
+export default function SpacingPage({ pageContext }) {
   const { settings } = useContext(SettingsContext);
   const [size, setSize] = useState<number>(3);
   const [direction, setDirection] = useState<string>('r');
@@ -96,7 +96,7 @@ export default function SpacingPage() {
   }));
 
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Spacing" />
       <Container size={settings.containerWidth} className="py-5">

--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -109,6 +109,7 @@ export default function SpacingPage({ pageContext }) {
             { Header: 'Spacer value', accessor: 'spacer' },
             { Header: 'Pixel value', accessor: 'pixelValue' },
           ]}
+          itemCount={0}
         >
           <DataTable.Table />
         </DataTable>
@@ -197,9 +198,9 @@ export default function SpacingPage({ pageContext }) {
             </tr>
             <tr>
               {directions.map(({ key }) => (
-                <td>
+                <td key={key}>
                   {sizes.map(_size => (
-                    <code className="d-block">
+                    <code key={_size} className="d-block">
                       .{getUtilityClassName('m', key, _size)}
                     </code>
                   ))}
@@ -211,9 +212,9 @@ export default function SpacingPage({ pageContext }) {
             </tr>
             <tr>
               {directions.map(({ key }) => (
-                <td>
+                <td key={key}>
                   {sizes.map(_size => (
-                    <code className="d-block">
+                    <code key={_size} className="d-block">
                       .{getUtilityClassName('p', key, _size)}
                     </code>
                   ))}
@@ -226,3 +227,9 @@ export default function SpacingPage({ pageContext }) {
     </Layout>
   );
 }
+
+SpacingPage.propTypes = {
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
+};

--- a/www/src/pages/foundations/typography.tsx
+++ b/www/src/pages/foundations/typography.tsx
@@ -42,11 +42,11 @@ const measuredTypeProps = {
   },
 };
 
-export default function TypographyPage() {
+export default function TypographyPage({ pageContext }) {
   const { settings } = useContext(SettingsContext);
 
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Typography" />
       <Container size={settings.containerWidth} className="py-5">

--- a/www/src/pages/foundations/typography.tsx
+++ b/www/src/pages/foundations/typography.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import { Container } from '~paragon-react';
 import SEO from '../../components/SEO';
 import MeasuredItem from '../../components/MeasuredItem';
@@ -64,7 +65,7 @@ export default function TypographyPage({ pageContext }) {
               <th>CSS Class</th>
             </tr>
             {[1, 2, 3, 4, 5, 6].map(headingSize => (
-              <tr>
+              <tr key={headingSize}>
                 <td>
                   <MeasuredItem {...measuredTypeProps}>
                     <p className={`m-0 h${headingSize}`}>
@@ -166,7 +167,7 @@ export default function TypographyPage({ pageContext }) {
               <th>CSS Class</th>
             </tr>
             {[1, 2, 3, 4].map(displaySize => (
-              <tr>
+              <tr key={displaySize}>
                 <td>
                   <MeasuredItem {...measuredTypeProps}>
                     <p className={`m-0 display-${displaySize}`}>
@@ -398,3 +399,9 @@ export default function TypographyPage({ pageContext }) {
     </Layout>
   );
 }
+
+TypographyPage.propTypes = {
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
+};

--- a/www/src/pages/insights.tsx
+++ b/www/src/pages/insights.tsx
@@ -27,14 +27,21 @@ const {
   lastModified: analysisLastUpdated,
 } = dependentProjectsAnalysis;
 
-interface TabsDataType {
+export interface TabsDataType {
   components: string[],
   hooks: string[],
   utils: string[],
   icons: string[],
 }
 
-export default function InsightsPage({ pageContext: { tab } }: { pageContext: { tab: string } }) {
+export interface InsightsPageTypes {
+  pageContext: {
+    tab: string,
+    githubEditPath: string
+  }
+}
+
+export default function InsightsPage({ pageContext: { tab, githubEditPath } }: InsightsPageTypes) {
   const { settings } = useContext(SettingsContext);
   const { paragonTypes = {}, isParagonIcon = () => false } = useContext(InsightsContext) as IInsightsContext;
   const {
@@ -61,7 +68,7 @@ export default function InsightsPage({ pageContext: { tab } }: { pageContext: { 
     }
   };
   return (
-    <Layout isAutoToc tab={tab}>
+    <Layout isAutoToc tab={tab} githubEditPath={githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Usage Insights" />
       <Container size={settings.containerWidth} className="py-5">
@@ -113,5 +120,6 @@ export default function InsightsPage({ pageContext: { tab } }: { pageContext: { 
 InsightsPage.propTypes = {
   pageContext: PropTypes.shape({
     tab: PropTypes.oneOf(Object.values(INSIGHTS_TABS)),
+    githubEditPath: PropTypes.string,
   }).isRequired,
 };

--- a/www/src/pages/playground.tsx
+++ b/www/src/pages/playground.tsx
@@ -127,4 +127,7 @@ Playground.propTypes = {
     search: PropTypes.string,
     href: PropTypes.string,
   }).isRequired,
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
 };

--- a/www/src/pages/playground.tsx
+++ b/www/src/pages/playground.tsx
@@ -20,7 +20,7 @@ const FEEDBACK_URL = 'https://github.com/openedx/paragon/issues/new?assignees=&l
 const playroomStorage = localforage.createInstance({ name: storageKey });
 const EMPTY_PLAYROOM_URL_QUERY = '?code=N4XyA';
 
-export default function Playground({ location }) {
+export default function Playground({ location, pageContext }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [initialSearchParams, setInitialSearchParams] = useState('');
   const searchValue = useRef(location.search || '');
@@ -84,6 +84,13 @@ export default function Playground({ location }) {
               copied: <Icon src={Check} />,
             }}
           />
+          <Hyperlink
+            destination={pageContext.githubEditPath}
+            target="_blank"
+            className="text-white"
+          >
+            Edit this page
+          </Hyperlink>
           <Hyperlink
             destination={FEEDBACK_URL}
             target="_blank"

--- a/www/src/pages/playground.tsx
+++ b/www/src/pages/playground.tsx
@@ -20,7 +20,7 @@ const FEEDBACK_URL = 'https://github.com/openedx/paragon/issues/new?assignees=&l
 const playroomStorage = localforage.createInstance({ name: storageKey });
 const EMPTY_PLAYROOM_URL_QUERY = '?code=N4XyA';
 
-export default function Playground({ location, pageContext }) {
+export default function Playground({ location }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [initialSearchParams, setInitialSearchParams] = useState('');
   const searchValue = useRef(location.search || '');
@@ -84,13 +84,6 @@ export default function Playground({ location, pageContext }) {
               copied: <Icon src={Check} />,
             }}
           />
-          <Hyperlink
-            destination={pageContext.githubEditPath}
-            target="_blank"
-            className="text-white"
-          >
-            Edit this page
-          </Hyperlink>
           <Hyperlink
             destination={FEEDBACK_URL}
             target="_blank"

--- a/www/src/pages/status.tsx
+++ b/www/src/pages/status.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
 import { Table, Container } from '~paragon-react';
 import { ComponentStatus } from '../components/doc-elements';
@@ -91,3 +92,9 @@ export default function StatusPage({ pageContext }) {
     </Layout>
   );
 }
+
+StatusPage.propTypes = {
+  pageContext: PropTypes.shape({
+    githubEditPath: PropTypes.string,
+  }).isRequired,
+};

--- a/www/src/pages/status.tsx
+++ b/www/src/pages/status.tsx
@@ -11,11 +11,11 @@ export interface IComponents {
   title?: string,
 }
 
-export default function StatusPage() {
+export default function StatusPage({ pageContext }) {
   const { settings } = useContext(SettingsContext);
 
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Status" />
       <Container size={settings.containerWidth} className="py-5">

--- a/www/src/templates/default-mdx-page-template.tsx
+++ b/www/src/templates/default-mdx-page-template.tsx
@@ -29,6 +29,7 @@ export interface IPageTemplateType {
     frontmatter: {
       title: string,
     },
+    githubEditPath: string,
   },
 }
 
@@ -36,7 +37,7 @@ export default function PageTemplate({ children, pageContext }: IPageTemplateTyp
   const { settings } = useContext(SettingsContext);
 
   return (
-    <Layout isAutoToc>
+    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title={pageContext?.frontmatter?.title} />
       <Container size={settings.containerWidth} className="py-5">
@@ -53,5 +54,6 @@ PageTemplate.propTypes = {
     frontmatter: PropTypes.shape({
       title: PropTypes.string,
     }),
+    githubEditPath: PropTypes.string,
   }).isRequired,
 };

--- a/www/utils/createPages.js
+++ b/www/utils/createPages.js
@@ -78,7 +78,7 @@ async function createPages(graphql, actions, reporter) {
     createPage({
       path: pagePath,
       component: require.resolve('../src/pages/insights.tsx'),
-      context: { tab, githubEditPath: 'https://github.com/openedx/paragon/blob/master/www/src/pages/insights.tsx' },
+      context: { tab, githubEditPath: 'https://github.com/openedx/paragon/edit/master/www/src/pages/insights.tsx' },
     });
   });
 

--- a/www/utils/createPages.js
+++ b/www/utils/createPages.js
@@ -78,7 +78,7 @@ async function createPages(graphql, actions, reporter) {
     createPage({
       path: pagePath,
       component: require.resolve('../src/pages/insights.tsx'),
-      context: { tab },
+      context: { tab, githubEditPath: 'https://github.com/openedx/paragon/blob/master/www/src/pages/insights.tsx' },
     });
   });
 

--- a/www/utils/createPages.js
+++ b/www/utils/createPages.js
@@ -75,10 +75,11 @@ async function createPages(graphql, actions, reporter) {
   }
 
   INSIGHTS_PAGES.forEach(({ path: pagePath, tab }) => {
+    const githubEditPath = 'https://github.com/openedx/paragon/edit/master/www/src/pages/insights.tsx';
     createPage({
       path: pagePath,
       component: require.resolve('../src/pages/insights.tsx'),
-      context: { tab, githubEditPath: 'https://github.com/openedx/paragon/edit/master/www/src/pages/insights.tsx' },
+      context: { tab, githubEditPath },
     });
   });
 

--- a/www/utils/onCreatePage.js
+++ b/www/utils/onCreatePage.js
@@ -1,0 +1,14 @@
+async function onCreatePage(page, actions) {
+  const { createPage } = actions;
+  const githubEditPath = `https://github.com/openedx/paragon/edit/master/www/src${page.componentPath.split('src')[1]}`;
+
+  createPage({
+    ...page,
+    context: {
+      ...page.context,
+      githubEditPath,
+    },
+  });
+}
+
+module.exports = onCreatePage;


### PR DESCRIPTION
## Description

- added Edit this page CTA to non-component pages;
- some refactoring.

Issue: https://github.com/openedx/paragon/issues/2625

### Deploy Preview

[Paragon site documentations](https://deploy-preview-2667--paragon-openedx.netlify.app/foundations/layout)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
