### PR TITLE
[BD-46] fix: hover for danger button

### DIFF
--- a/src/SearchField/index.scss
+++ b/src/SearchField/index.scss
@@ -91,22 +91,6 @@
   &.pgn__searchfield--external {
     border: none;
 
-    .btn-primary {
-      background: map-get($search-btn-variants, "light");
-
-      &:hover {
-        background: darken(map-get($search-btn-variants, "light"), 7.5%);
-      }
-    }
-
-    .btn-brand {
-      background: map-get($search-btn-variants, "dark");
-
-      &:hover {
-        background: darken(map-get($search-btn-variants, "dark"), 7.5%);
-      }
-    }
-
     &.has-focus {
       box-shadow: none;
 

--- a/src/SearchField/index.scss
+++ b/src/SearchField/index.scss
@@ -122,6 +122,12 @@
         background: map-get($search-btn-variants, "dark");
       }
     }
+
+    &:hover {
+      .btn-brand {
+        background: map-get($search-btn-variants, "dark");
+      }
+    }
   }
 
   .pgn__searchfield_wrapper {

--- a/src/SearchField/index.scss
+++ b/src/SearchField/index.scss
@@ -93,10 +93,18 @@
 
     .btn-primary {
       background: map-get($search-btn-variants, "light");
+
+      &:hover {
+        background: darken(map-get($search-btn-variants, "light"), 7.5%);
+      }
     }
 
     .btn-brand {
       background: map-get($search-btn-variants, "dark");
+
+      &:hover {
+        background: darken(map-get($search-btn-variants, "dark"), 7.5%);
+      }
     }
 
     &.has-focus {
@@ -112,20 +120,6 @@
           width: 100%;
           height: 100%;
         }
-      }
-
-      .btn-primary {
-        background: map-get($search-btn-variants, "light");
-      }
-
-      .btn-brand {
-        background: map-get($search-btn-variants, "dark");
-      }
-    }
-
-    &:hover {
-      .btn-brand {
-        background: map-get($search-btn-variants, "dark");
       }
     }
   }


### PR DESCRIPTION
## Description
add hover styles for dark button
[Issue](https://github.com/openedx/paragon/issues/2650)

### Deploy Preview

[Deploy Preview](https://deploy-preview-2675--paragon-openedx.netlify.app/components/searchfield/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
