### PR TITLE
[BD-46] docs: update spacings table using dataTable

### DIFF
--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -95,6 +95,17 @@ export default function SpacingPage() {
     pixelValue: <PixelCell spacer={value} />,
   }));
 
+  const allUtilityClassesTabel= (prefix) => sizes.map(size => {
+    const rowData = {};
+    
+    directions.forEach(({ key, name }) => {
+      rowData[name] = getUtilityClassName(prefix, key, size);
+    });
+  
+    return rowData;
+  });
+
+
   return (
     <Layout isAutoToc>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
@@ -186,49 +197,39 @@ export default function SpacingPage() {
         </p>
 
         <h3>All Spacing Utility Classes</h3>
-        <table className="table">
-          <thead>
-            <tr>
-              <th>All directions</th>
-              <th>Top</th>
-              <th>Right</th>
-              <th>Bottom</th>
-              <th>Left</th>
-              <th>X Direction</th>
-              <th>Y Direction</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th colSpan={7}>Margin</th>
-            </tr>
-            <tr>
-              {directions.map(({ key }) => (
-                <td>
-                  {sizes.map(_size => (
-                    <code className="d-block">
-                      .{getUtilityClassName('m', key, _size)}
-                    </code>
-                  ))}
-                </td>
-              ))}
-            </tr>
-            <tr>
-              <th colSpan={7}>Padding</th>
-            </tr>
-            <tr>
-              {directions.map(({ key }) => (
-                <td>
-                  {sizes.map(_size => (
-                    <code className="d-block">
-                      .{getUtilityClassName('p', key, _size)}
-                    </code>
-                  ))}
-                </td>
-              ))}
-            </tr>
-          </tbody>
-        </table>
+
+        <h4>Margin</h4>
+        <DataTable
+          className="pgn-doc__spacing-table"
+          data={allUtilityClassesTabel('m')}
+          columns={[
+            { Header: 'All directions', accessor: "all" },
+            { Header: 'Top', accessor: "top" },
+            { Header: 'Right', accessor: 'right' },
+            { Header: 'Bottom', accessor: "bottom" },
+            { Header: 'Left', accessor: 'left' },
+            { Header: 'X Direction', accessor: "x direction" },
+            { Header: 'Y Direction', accessor: 'y direction' },
+          ]}
+        >
+          <DataTable.Table />
+        </DataTable>
+        <h4>Padding</h4>
+        <DataTable
+          className="pgn-doc__spacing-table"
+          data={allUtilityClassesTabel('p')}
+          columns={[
+            { Header: 'All directions', accessor: "all" },
+            { Header: 'Top', accessor: "top" },
+            { Header: 'Right', accessor: 'right' },
+            { Header: 'Bottom', accessor: "bottom" },
+            { Header: 'Left', accessor: 'left' },
+            { Header: 'X Direction', accessor: "x direction" },
+            { Header: 'Y Direction', accessor: 'y direction' },
+          ]}
+        >
+          <DataTable.Table />
+        </DataTable>
       </Container>
     </Layout>
   );

--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -95,16 +95,15 @@ export default function SpacingPage() {
     pixelValue: <PixelCell spacer={value} />,
   }));
 
-  const allUtilityClassesTabel= (prefix) => sizes.map(size => {
+  const createUtilityClassesTabel = (prefix) => sizes.map(el => {
     const rowData = {};
-    
+
     directions.forEach(({ key, name }) => {
-      rowData[name] = getUtilityClassName(prefix, key, size);
+      rowData[name] = <code>.{getUtilityClassName(prefix, key, el)}</code>;
     });
-  
+
     return rowData;
   });
-
 
   return (
     <Layout isAutoToc>
@@ -196,35 +195,35 @@ export default function SpacingPage() {
           <code>{'.p{direction}-{level}'}</code>.
         </p>
 
-        <h3>All Spacing Utility Classes</h3>
+        <h3 className="mt-4">All Spacing Utility Classes</h3>
 
-        <h4>Margin</h4>
+        <h4 className="mt-3">Margin</h4>
         <DataTable
           className="pgn-doc__spacing-table"
-          data={allUtilityClassesTabel('m')}
+          data={createUtilityClassesTabel('m')}
           columns={[
-            { Header: 'All directions', accessor: "all" },
-            { Header: 'Top', accessor: "top" },
+            { Header: 'All directions', accessor: 'all' },
+            { Header: 'Top', accessor: 'top' },
             { Header: 'Right', accessor: 'right' },
-            { Header: 'Bottom', accessor: "bottom" },
+            { Header: 'Bottom', accessor: 'bottom' },
             { Header: 'Left', accessor: 'left' },
-            { Header: 'X Direction', accessor: "x direction" },
+            { Header: 'X Direction', accessor: 'x direction' },
             { Header: 'Y Direction', accessor: 'y direction' },
           ]}
         >
           <DataTable.Table />
         </DataTable>
-        <h4>Padding</h4>
+        <h4 className="mt-3">Padding</h4>
         <DataTable
           className="pgn-doc__spacing-table"
-          data={allUtilityClassesTabel('p')}
+          data={createUtilityClassesTabel('p')}
           columns={[
-            { Header: 'All directions', accessor: "all" },
-            { Header: 'Top', accessor: "top" },
+            { Header: 'All directions', accessor: 'all' },
+            { Header: 'Top', accessor: 'top' },
             { Header: 'Right', accessor: 'right' },
-            { Header: 'Bottom', accessor: "bottom" },
+            { Header: 'Bottom', accessor: 'bottom' },
             { Header: 'Left', accessor: 'left' },
-            { Header: 'X Direction', accessor: "x direction" },
+            { Header: 'X Direction', accessor: 'x direction' },
             { Header: 'Y Direction', accessor: 'y direction' },
           ]}
         >


### PR DESCRIPTION
## Description
Update All Spacing Utility Classes table using DataTable component
[Issue](https://github.com/openedx/paragon/issues/2539)

### Deploy Preview

[Deploy](https://deploy-preview-2677--paragon-openedx.netlify.app/foundations/spacing)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
