### PR TITLE
[BD-46] feat: add reverse prop to the stack component

### DIFF
--- a/src/Stack/README.md
+++ b/src/Stack/README.md
@@ -36,3 +36,22 @@ Stacks are vertical by default and stacked items are full-width by default. Watc
   <div className="border p-2">third block</div>
 </Stack>
 ```
+
+## Reversed props
+
+- **Vertical** with `reversed` prop
+```jsx live
+<Stack gap={3} reversed>
+  <Button>first button</Button>
+  <Button>second button</Button>
+  <Button>third button</Button>
+</Stack>
+```
+- **Horizontal** with `reversed` prop
+```jsx live
+<Stack direction="horizontal" gap={3} reversed>
+  <div className="border p-2">first block</div>
+  <div className="border p-2">second block</div>
+  <div className="border p-2">third block</div>
+</Stack>
+```

--- a/src/Stack/Stack.test.jsx
+++ b/src/Stack/Stack.test.jsx
@@ -1,16 +1,27 @@
 import React from 'react';
+import { render } from '@testing-library/react';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 
 import Stack from './index';
 
+const stackList = ['First', 'Second'];
+
 describe('<Stack />', () => {
   describe('correct rendering', () => {
     it('renders without props', () => {
       const tree = renderer.create((
-        <Stack>content</Stack>
+        <Stack>{stackList.map((el) => <div>{el}</div>)}</Stack>
       )).toJSON();
       expect(tree).toMatchSnapshot();
+    });
+    it('renders with the reversed prop', () => {
+      const { container } = render(
+        <Stack reversed>
+          {stackList.reverse().map((el) => <div>{el}</div>)}
+        </Stack>,
+      );
+      expect(container).toMatchSnapshot();
     });
     it('renders with the vertical direction', () => {
       const wrapper = mount(<Stack>Content</Stack>);
@@ -26,14 +37,6 @@ describe('<Stack />', () => {
       const gap = 3;
       const wrapper = mount(<Stack gap={gap}>Content</Stack>);
       expect(wrapper.find('.pgn__vstack').hasClass(`pgn__stack-gap--${gap}`)).toEqual(true);
-    });
-    it('renders reversed children with the vertical direction', () => {
-      const wrapper = mount(<Stack reversed>Content</Stack>);
-      expect(wrapper.find('.pgn__vstack').hasClass('pgn__stack-reversed')).toEqual(true);
-    });
-    it('renders reversed children with the horizontal direction', () => {
-      const wrapper = mount(<Stack direction="horizontal" reversed>Content</Stack>);
-      expect(wrapper.find('.pgn__hstack').hasClass('pgn__stack-reversed')).toEqual(true);
     });
     it('renders with the className prop', () => {
       const className = 'className';

--- a/src/Stack/Stack.test.jsx
+++ b/src/Stack/Stack.test.jsx
@@ -27,6 +27,14 @@ describe('<Stack />', () => {
       const wrapper = mount(<Stack gap={gap}>Content</Stack>);
       expect(wrapper.find('.pgn__vstack').hasClass(`pgn__stack-gap--${gap}`)).toEqual(true);
     });
+    it('renders reversed children with the vertical direction', () => {
+      const wrapper = mount(<Stack reversed>Content</Stack>);
+      expect(wrapper.find('.pgn__vstack').hasClass('pgn__stack-reversed')).toEqual(true);
+    });
+    it('renders reversed children with the horizontal direction', () => {
+      const wrapper = mount(<Stack direction="horizontal" reversed>Content</Stack>);
+      expect(wrapper.find('.pgn__hstack').hasClass('pgn__stack-reversed')).toEqual(true);
+    });
     it('renders with the className prop', () => {
       const className = 'className';
       const wrapper = mount(<Stack className={className}>Content</Stack>);

--- a/src/Stack/__snapshots__/Stack.test.jsx.snap
+++ b/src/Stack/__snapshots__/Stack.test.jsx.snap
@@ -1,9 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Stack /> correct rendering renders with the reversed prop 1`] = `
+<div>
+  <div
+    class="pgn__vstack pgn__stack-reversed"
+  >
+    <div>
+      Second
+    </div>
+    <div>
+      First
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Stack /> correct rendering renders without props 1`] = `
 <div
   className="pgn__vstack"
 >
-  content
+  <div>
+    First
+  </div>
+  <div>
+    Second
+  </div>
 </div>
 `;

--- a/src/Stack/index.jsx
+++ b/src/Stack/index.jsx
@@ -10,22 +10,30 @@ const DIRECTION_VARIANTS = [
 const Stack = forwardRef(({
   direction,
   gap,
+  reverse,
   children,
   className,
   ...rest
-}, ref) => (
-  <div
-    ref={ref}
-    className={classNames(
-      direction === 'horizontal' ? 'pgn__hstack' : 'pgn__vstack',
-      gap ? `pgn__stack-gap--${gap}` : '',
-      className,
-    )}
-    {...rest}
-  >
-    {children}
-  </div>
-));
+}, ref) => {
+  const childrenArray = React.Children.toArray(children);
+
+  if (reverse) {
+    childrenArray.reverse();
+  }
+  return (
+    <div
+      ref={ref}
+      className={classNames(
+        direction === 'horizontal' ? 'pgn__hstack' : 'pgn__vstack',
+        gap ? `pgn__stack-gap--${gap}` : '',
+        className,
+      )}
+      {...rest}
+    >
+      {childrenArray}
+    </div>
+  );
+});
 
 Stack.propTypes = {
   /** Specifies the content of the `Stack`. */
@@ -39,6 +47,8 @@ Stack.propTypes = {
    * `0, 0.5, ... 6`.
    */
   gap: PropTypes.number,
+  /** Specifies the order of the children. */
+  reverse: PropTypes.bool,
   /** Specifies an additional `className` to add to the base element. */
   className: PropTypes.string,
 };
@@ -47,6 +57,7 @@ Stack.defaultProps = {
   direction: 'vertical',
   gap: 0,
   className: undefined,
+  reverse: false,
 };
 
 export default Stack;

--- a/src/Stack/index.jsx
+++ b/src/Stack/index.jsx
@@ -10,30 +10,24 @@ const DIRECTION_VARIANTS = [
 const Stack = forwardRef(({
   direction,
   gap,
-  reverse,
+  reversed,
   children,
   className,
   ...rest
-}, ref) => {
-  const childrenArray = React.Children.toArray(children);
-
-  if (reverse) {
-    childrenArray.reverse();
-  }
-  return (
-    <div
-      ref={ref}
-      className={classNames(
-        direction === 'horizontal' ? 'pgn__hstack' : 'pgn__vstack',
-        gap ? `pgn__stack-gap--${gap}` : '',
-        className,
-      )}
-      {...rest}
-    >
-      {childrenArray}
-    </div>
-  );
-});
+}, ref) => (
+  <div
+    ref={ref}
+    className={classNames(
+      direction === 'horizontal' ? 'pgn__hstack' : 'pgn__vstack',
+      gap ? `pgn__stack-gap--${gap}` : '',
+      reversed ? 'pgn__stack-reversed' : '',
+      className,
+    )}
+    {...rest}
+  >
+    {children}
+  </div>
+));
 
 Stack.propTypes = {
   /** Specifies the content of the `Stack`. */
@@ -48,7 +42,7 @@ Stack.propTypes = {
    */
   gap: PropTypes.number,
   /** Specifies the order of the children. */
-  reverse: PropTypes.bool,
+  reversed: PropTypes.bool,
   /** Specifies an additional `className` to add to the base element. */
   className: PropTypes.string,
 };
@@ -57,7 +51,7 @@ Stack.defaultProps = {
   direction: 'vertical',
   gap: 0,
   className: undefined,
-  reverse: false,
+  reversed: false,
 };
 
 export default Stack;

--- a/src/Stack/index.scss
+++ b/src/Stack/index.scss
@@ -16,9 +16,18 @@
 .pgn__vstack {
   flex: 1 1 auto;
   flex-direction: column;
+
+  &.pgn__stack-reversed {
+    flex-direction: column-reverse;
+  }
 }
 
 .pgn__hstack {
   flex-direction: row;
   align-items: center;
+
+  &.pgn__stack-reversed {
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+  }
 }


### PR DESCRIPTION
## Description
Add reverse prop to the Stack component
[Issue](https://github.com/openedx/paragon/issues/2627)

### Deploy Preview

[Deploy](https://deploy-preview-2678--paragon-openedx.netlify.app/components/stack/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
