### PR TITLE
chore: adding file name to in-memory Dropzone upload example

### DIFF
--- a/src/Dropzone/README.md
+++ b/src/Dropzone/README.md
@@ -280,25 +280,21 @@ This example validates that only `400x479` images can be uploaded.
 
 ## Reading file contents into memory
 
-Accepts only .xml files up to a size of 20MB. You can read in the contents of the `File` object into memory. The ``onProcessUpload`` prop should retrieve the file Blob from the passed ``fileData`` param and pass it into a file reader.
+Accepts only .xml files up to a size of 20MB. You can read in the contents of the `File` object into memory. The ``onProcessUpload`` prop can retrieve the file Blob from the passed ``fileData`` param and either pass it into a file reader or use text() promise.
 
 Note that `Dropzone` does not handle unexpected errors that might happen in your function, they should be handled by the ``handleProcessUpload`` method.
 
 ```jsx live
 () => {
   const [text, setText] = useState("");
+  const [fileName, setFileName] = useState("");
 
-  async function handleProcessUpload({
-    fileData, requestConfig, handleError
-  }) {
+  const handleProcessUpload = ({ fileData }) => {
     const blob = fileData.get('file');
-    const reader = new FileReader();
-    reader.readAsDataURL(blob);
-    reader.onloadend = function() {
-      const base64data = reader.result.split(',')[1];                
-      console.log(atob(base64data));
-      setText(atob(base64data));
-    }
+    blob.text().then(xmlText => {
+      setText(xmlText);
+      setFileName(blob.name);
+    });
   };
 
   return (
@@ -313,6 +309,12 @@ Note that `Dropzone` does not handle unexpected errors that might happen in your
           "application/xml": ['.xml']
         }}
       />
+      {fileName && (
+        <Form.Control.Feedback type="valid">
+          Uploaded{' '}
+          {fileName}
+        </Form.Control.Feedback>
+      )}
       <p>{text}</p>
     </>
   )


### PR DESCRIPTION
## Description

Adding filename display to https://paragon-openedx.netlify.app/components/dropzone/#reading-file-contents-into-memory

![image](https://github.com/openedx/paragon/assets/322346/54ef868e-5603-49aa-985a-1c13945e2242)
[Deployed Preview](https://deploy-preview-2682--paragon-openedx.netlify.app/components/dropzone/#reading-file-contents-into-memory)
## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
