### PR TITLE
[BD-46] fix: fixed duplicate calls in FormRadioSet and FormCheckboxSet

### DIFF
--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -62,7 +62,7 @@ const FormCheckbox = React.forwardRef(({
   floatLabelLeft,
   ...props
 }, ref) => {
-  const { getCheckboxControlProps, hasCheckboxSetProvider } = useCheckboxSetContext();
+  const { hasCheckboxSetProvider } = useCheckboxSetContext();
   const { hasFormGroupProvider, useSetIsControlGroupEffect, getControlProps } = useFormGroupContext();
   useSetIsControlGroupEffect(true);
   const shouldActAsGroup = hasFormGroupProvider && !hasCheckboxSetProvider;
@@ -70,14 +70,11 @@ const FormCheckbox = React.forwardRef(({
     ...getControlProps({}),
     role: 'group',
   } : {};
-  const checkboxInputProps = getCheckboxControlProps({
-    ...props,
-    className: controlClassName,
-  });
+
   const control = React.createElement(controlAs, { ...props, className: controlClassName, ref });
   return (
     <FormGroupContextProvider
-      controlId={checkboxInputProps.id}
+      controlId={props.id}
       isInvalid={isInvalid}
       isValid={isValid}
     >
@@ -85,7 +82,7 @@ const FormCheckbox = React.forwardRef(({
         className={classNames('pgn__form-checkbox', className, {
           'pgn__form-control-valid': isValid,
           'pgn__form-control-invalid': isInvalid,
-          'pgn__form-control-disabled': checkboxInputProps.disabled,
+          'pgn__form-control-disabled': props.disabled,
           'pgn__form-control-label-left': !!floatLabelLeft,
         })}
         {...groupProps}
@@ -107,6 +104,8 @@ const FormCheckbox = React.forwardRef(({
 });
 
 FormCheckbox.propTypes = {
+  /** Specifies id of the FormCheckbox component. */
+  id: PropTypes.string,
   /** Specifies contents of the component. */
   children: PropTypes.node.isRequired,
   /** Specifies class name to append to the base element. */
@@ -123,10 +122,14 @@ FormCheckbox.propTypes = {
   isValid: PropTypes.bool,
   /** Specifies control element. */
   controlAs: PropTypes.elementType,
+  /** Specifies whether the floating label should be aligned to the left. */
   floatLabelLeft: PropTypes.bool,
+  /** Specifies whether the `FormCheckbox` is disabled. */
+  disabled: PropTypes.bool,
 };
 
 FormCheckbox.defaultProps = {
+  id: undefined,
   className: undefined,
   controlClassName: undefined,
   labelClassName: undefined,
@@ -135,6 +138,7 @@ FormCheckbox.defaultProps = {
   isValid: false,
   controlAs: CheckboxControl,
   floatLabelLeft: false,
+  disabled: false,
 };
 
 export { CheckboxControl };

--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -74,7 +74,7 @@ const FormCheckbox = React.forwardRef(({
     ...props,
     className: controlClassName,
   });
-  const control = React.createElement(controlAs, { ...checkboxInputProps, ref });
+  const control = React.createElement(controlAs, { ...props, className: controlClassName, ref });
   return (
     <FormGroupContextProvider
       controlId={checkboxInputProps.id}

--- a/src/Form/FormRadio.jsx
+++ b/src/Form/FormRadio.jsx
@@ -59,7 +59,7 @@ const FormRadio = React.forwardRef(({
           'pgn__form-control-disabled': radioInputProps.disabled,
         })}
       >
-        <RadioControl {...radioInputProps} ref={ref} />
+        <RadioControl ref={ref} className={controlClassName} {...props} />
         <div>
           <FormLabel className={labelClassName}>
             {children}

--- a/src/Form/FormRadio.jsx
+++ b/src/Form/FormRadio.jsx
@@ -40,42 +40,37 @@ const FormRadio = React.forwardRef(({
   isInvalid,
   isValid,
   ...props
-}, ref) => {
-  const { getRadioControlProps } = useRadioSetContext();
-  const radioInputProps = getRadioControlProps({
-    ...props,
-    className: controlClassName,
-  });
-  return (
-    <FormGroupContextProvider
-      controlId={radioInputProps.id}
-      isInvalid={isInvalid}
-      isValid={isValid}
+}, ref) => (
+  <FormGroupContextProvider
+    controlId={props.id}
+    isInvalid={isInvalid}
+    isValid={isValid}
+  >
+    <div
+      className={classNames('pgn__form-radio', className, {
+        'pgn__form-control-valid': isValid,
+        'pgn__form-control-invalid': isInvalid,
+        'pgn__form-control-disabled': props.disabled,
+      })}
     >
-      <div
-        className={classNames('pgn__form-radio', className, {
-          'pgn__form-control-valid': isValid,
-          'pgn__form-control-invalid': isInvalid,
-          'pgn__form-control-disabled': radioInputProps.disabled,
-        })}
-      >
-        <RadioControl ref={ref} className={controlClassName} {...props} />
-        <div>
-          <FormLabel className={labelClassName}>
-            {children}
-          </FormLabel>
-          {description && (
-            <FormControlFeedback hasIcon={false}>
-              {description}
-            </FormControlFeedback>
-          )}
-        </div>
+      <RadioControl ref={ref} className={controlClassName} {...props} />
+      <div>
+        <FormLabel className={labelClassName}>
+          {children}
+        </FormLabel>
+        {description && (
+        <FormControlFeedback hasIcon={false}>
+          {description}
+        </FormControlFeedback>
+        )}
       </div>
-    </FormGroupContextProvider>
-  );
-});
+    </div>
+  </FormGroupContextProvider>
+));
 
 FormRadio.propTypes = {
+  /** Specifies id of the FormRadio component. */
+  id: PropTypes.string,
   /** Specifies contents of the component. */
   children: PropTypes.node.isRequired,
   /** Specifies class name to append to the base element. */
@@ -90,15 +85,19 @@ FormRadio.propTypes = {
   isInvalid: PropTypes.bool,
   /** Specifies whether to display component in valid state, this affects styling. */
   isValid: PropTypes.bool,
+  /** Specifies whether the `FormRadio` is disabled. */
+  disabled: PropTypes.bool,
 };
 
 FormRadio.defaultProps = {
+  id: undefined,
   className: undefined,
   controlClassName: undefined,
   labelClassName: undefined,
   description: undefined,
   isInvalid: false,
   isValid: false,
+  disabled: false,
 };
 
 export { RadioControl };

--- a/src/Form/tests/FormCheckboxSet.test.jsx
+++ b/src/Form/tests/FormCheckboxSet.test.jsx
@@ -165,4 +165,23 @@ describe('FormCheckboxSet', () => {
       expect(checkboxNode.defaultChecked).toBe(true);
     });
   });
+
+  it('checks if onClick is called once in FormCheckboxSet', () => {
+    const handleChange = jest.fn();
+    const { getByLabelText } = render(
+      <FormGroup controlId="my-field">
+        <FormLabel>Which color?</FormLabel>
+        <FormCheckboxSet
+          name="colors"
+          onChange={handleChange}
+        >
+          <FormCheckbox value="red">Red</FormCheckbox>
+          <FormCheckbox value="green">Green</FormCheckbox>
+        </FormCheckboxSet>
+      </FormGroup>,
+    );
+
+    userEvent.click(getByLabelText('Red'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/Form/tests/FormRadioSet.test.jsx
+++ b/src/Form/tests/FormRadioSet.test.jsx
@@ -108,4 +108,23 @@ describe('FormRadioSet', () => {
     expect(evergreenRadio).toHaveAttribute('name', 'trees');
     expect(deciduousRadio).toHaveAttribute('name', 'trees');
   });
+
+  it('checks if onClick is called once in FormRadioSet', () => {
+    const handleChange = jest.fn();
+    const { getByLabelText } = render(
+      <FormGroup>
+        <FormLabel>Which color?</FormLabel>
+        <FormRadioSet
+          name="colors"
+          onChange={handleChange}
+        >
+          <FormRadio value="red">Red</FormRadio>
+          <FormRadio value="green">Green</FormRadio>
+        </FormRadioSet>
+      </FormGroup>,
+    );
+
+    userEvent.click(getByLabelText('Red'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/Menu/__snapshots__/Menu.test.jsx.snap
+++ b/src/Menu/__snapshots__/Menu.test.jsx.snap
@@ -126,6 +126,7 @@ exports[`Menu Item renders correctly renders as expected with menu items 1`] = `
   >
     <input
       className="pgn__form-checkbox-input"
+      disabled={false}
       id="form-field1"
       type="checkbox"
     />


### PR DESCRIPTION
## Description

- fixed the problem of duplicate calls during `onChange` for the `Form.RadioSet` and `Form.CheckboxSet` components.

**Issue:** https://github.com/openedx/paragon/issues/2683

### Deploy Preview

[Playground demo](https://deploy-preview-2705--paragon-openedx.netlify.app/playground?code=N4Igxg9gJgpiBcJgApkEoAEBeAfB4AOgHYYaREDOALhgNoBuAhgDYCuMANBhTFQGot2AXWwZWPAMpVGVGMgDkAcwBOMGEXloA3MVLlqdAJYUAwgAsYYANYwoXHlXOWbUEVjGTps5ADMWPbV0yCEoaM0YiKGYYcwjFGFEE3HwgvRCKCGiAOmYIRQUAMQhlAFsAJUYoQwgMcMjo2KJ4gEJW%2BS4YLOlleKospjYYQJJSbl4BQeRO7t7%2BwSGdEYBfRbTQ2oiomItrACMIAA9G%2BMTsPEIRtYzs3Pz5ItKnPcON%2Bu24mFbm9oxpxh7eHNBsNRmNHDsXFMuv9ZmAIbY0EEVkFVFRWMoSMhUhgADw4bGg0g4h4lLIAcWUEFYAAd8ZdRsTiqSADKMXYwZg4ADqZkMcIwJkyxQA-DiAPQkrKs9mcgm4yUVKoQCS8OWkIiMEowLAEcBC5QUXVqjAhY7a4B1LZmpbGgbsLDAO0wG300h0wkMhWVaoYJ06kCqKC6nBlWzir1K90e%2BVMrKKn1%2B3UqNREYMUlPh2PxiBRj2M0px701RMgXaDYMAIUGmYL2dzhPzpOzvvm-rAAE8IrqMFUKGzolAcCZO0Qa02i-WiRKs0WVVR62PyZSaZOG5KKVTaXLG1K2Rzubz%2BYLcspRdOC9L99vJU8rPsDnPjRqtW39YaQMbTXV4g7LQ0Ife1q2q2wDGLetguh6q5EjeAEvCWgbBqGUCLre97QTGBZofBrZJqo6hpvho7nqS2EHBhO5kS2gz%2BmW7CVtWJFZGRFGwc497Ufauodl2IA9sY-a2EOI6oXB5HbkxZFzguTEbiu2LilGwxLGg6BLCASxAA)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
