### PR TITLE
[BD-46] fix: default color for not valid value

### DIFF
--- a/src/ColorPicker/index.jsx
+++ b/src/ColorPicker/index.jsx
@@ -10,6 +10,8 @@ import { OverlayTrigger } from '../Overlay';
 import Tooltip from '../Tooltip';
 import useToggle from '../hooks/useToggle';
 
+const DEFAULT_COLOR = '#fefefe';
+
 function ColorPicker({
   color, setColor, className, size,
 }) {
@@ -65,7 +67,7 @@ function ColorPicker({
           className="pgn__color-modal rounded shadow"
           style={{ textAlign: 'start' }}
         >
-          <HexColorPicker color={color || ''} onChange={setColor} />
+          <HexColorPicker color={hexValid ? color : DEFAULT_COLOR} onChange={setColor} />
           <Form.Group className="pgn__hex-form" size="sm">
             <div>
               <Form.Label className="pgn__hex-label">Hex</Form.Label>


### PR DESCRIPTION
## Description

Add default value for invalid color proposed in [PR comments](https://github.com/openedx/paragon/pull/2646)
[Issue](https://github.com/openedx/paragon/issues/2524)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
