### PR TITLE
fix: use kebab-case-ids in autosuggest esc test

### DIFF
--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -260,8 +260,8 @@ describe('controlled behavior', () => {
 
   it('check focus on input after esc', () => {
     const { getByTestId } = render(<FormAutosuggestTestComponent />);
-    const input = getByTestId('autosuggest_textbox_input');
-    const dropdownBtn = getByTestId('autosuggest_iconbutton');
+    const input = getByTestId('autosuggest-textbox-input');
+    const dropdownBtn = getByTestId('autosuggest-iconbutton');
     userEvent.click(dropdownBtn);
 
     userEvent.keyboard('{esc}');


### PR DESCRIPTION
## Description

https://github.com/openedx/paragon/pull/2556 didn't have conflicts and all tests had passed when I merged it, but the test was using old test ids (snake_case instead of kebab-case).

This fixes the test by updating the ids used to kebab-case.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
