### PR TITLE
[BD-46] docs: added link to Contrast Checker tool

### DIFF
--- a/www/src/components/Menu.tsx
+++ b/www/src/components/Menu.tsx
@@ -133,6 +133,10 @@ const handlePlaygroundClick = () => {
   global.analytics.track('openedx.paragon.docs.menu.playground.visit_playground.clicked');
 };
 
+const handleContrastCheckerClick = () => {
+  global.analytics.track('openedx.paragon.docs.menu.tools.visit_contrast_checker');
+};
+
 MenuComponentListCategory.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.string.isRequired,
@@ -227,6 +231,17 @@ function Menu() {
             </li>
             <li>
               <Link to="/tools/component-generator">Component Generator</Link>
+            </li>
+            <li>
+              <Hyperlink
+                destination="https://webaim.org/resources/contrastchecker"
+                target="_blank"
+                externalLinkAlternativeText="Contrast checker page"
+                externalLinkTitle="Contrast checker"
+                onClick={handleContrastCheckerClick}
+              >
+                Contrast Checker
+              </Hyperlink>
             </li>
           </ul>
         </Collapsible>

--- a/www/src/components/Menu.tsx
+++ b/www/src/components/Menu.tsx
@@ -134,7 +134,7 @@ const handlePlaygroundClick = () => {
 };
 
 const handleContrastCheckerClick = () => {
-  global.analytics.track('openedx.paragon.docs.menu.tools.visit_contrast_checker');
+  global.analytics.track('openedx.paragon.docs.menu.tools.visit_contrast_checker.clicked');
 };
 
 MenuComponentListCategory.propTypes = {


### PR DESCRIPTION
## Description

- added link to Contrast Checker tool;
- added segment event.

**Issue:** https://github.com/openedx/paragon/issues/2647

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
