### PR TITLE
chore: Update openedx brand dependency.

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -38,7 +38,7 @@ const COMMANDS = {
       {
         name: 'theme',
         description: 'The @edx/brand package to install.',
-        defaultValue: '@edx/brand-openedx@latest',
+        defaultValue: '@openedx/brand-openedx@latest',
         required: false,
       },
     ],

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-platform": "^4.2.0",
     "@faker-js/faker": "^7.6.0",
     "core-js": "^3.22.2",

--- a/lib/install-theme.js
+++ b/lib/install-theme.js
@@ -12,7 +12,7 @@ function promptUserForTheme() {
       type: 'input',
       name: 'theme',
       message: 'What @edx/brand package do you want to install?',
-      default: '@edx/brand-openedx@latest',
+      default: '@openedx/brand-openedx@latest',
     },
   ]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-platform": "^4.2.0",
         "@faker-js/faker": "^7.6.0",
         "core-js": "^3.22.2",
@@ -153,6 +153,12 @@
       "devDependencies": {
         "@edx/frontend-build": "^12.8.10"
       }
+    },
+    "example/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.2.tgz",
+      "integrity": "sha512-mBvxR7aB9290j9+h3d/9G8VkG1b8ecLSmlxc0vskfm7DL/fKUzFmHAj3PI7Z4kkwCQOL4QT5mJHJKC0ZFf7qvQ=="
     },
     "icons": {
       "version": "1.0.0",
@@ -2304,19 +2310,9 @@
         }
       }
     },
-    "node_modules/@edx/brand": {
-      "name": "@edx/brand-openedx",
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.2.0.tgz",
-      "integrity": "sha512-r4PDN3rCgDsLovW44ayxoNNHgG5I4Rvss6MG5CrQEX4oW8YhQVEod+jJtwR5vi0mFLN2GIaMlDpd7iIy03VqXg=="
-    },
     "node_modules/@edx/brand-edx.org": {
       "version": "2.1.2",
       "license": "UNLICENSED"
-    },
-    "node_modules/@edx/brand-openedx": {
-      "version": "1.2.0",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.2.0",
@@ -5913,6 +5909,11 @@
       "dependencies": {
         "@octokit/openapi-types": "^16.0.0"
       }
+    },
+    "node_modules/@openedx/brand-openedx": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.2.tgz",
+      "integrity": "sha512-mBvxR7aB9290j9+h3d/9G8VkG1b8ecLSmlxc0vskfm7DL/fKUzFmHAj3PI7Z4kkwCQOL4QT5mJHJKC0ZFf7qvQ=="
     },
     "node_modules/@parcel/bundler-default": {
       "version": "2.6.2",
@@ -12807,42 +12808,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/child_process": {
@@ -38904,10 +38869,10 @@
       "dependencies": {
         "@docsearch/react": "^3.1.0",
         "@edx/brand-edx.org": "^2.1.2",
-        "@edx/brand-openedx": "^1.1.0",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
+        "@openedx/brand-openedx": "^1.2.2",
         "analytics-node": "^6.0.0",
         "axios": "^0.27.2",
         "classnames": "^2.3.1",

--- a/www/package.json
+++ b/www/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@docsearch/react": "^3.1.0",
     "@edx/brand-edx.org": "^2.1.2",
-    "@edx/brand-openedx": "^1.1.0",
+    "@openedx/brand-openedx": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",

--- a/www/src/scss/openedx-theme.scss
+++ b/www/src/scss/openedx-theme.scss
@@ -1,6 +1,6 @@
-@import "~@edx/brand-openedx/paragon/fonts";
+@import "~@openedx/brand-openedx/paragon/fonts";
 @import "variables";
-@import "~@edx/brand-openedx/paragon/variables";
+@import "~@openedx/brand-openedx/paragon/variables";
 @import "~paragon-style/core/core";
-@import "~@edx/brand-openedx/paragon/overrides";
+@import "~@openedx/brand-openedx/paragon/overrides";
 @import "base";


### PR DESCRIPTION
We've moved the dependency to the `openedx` scope so update the
dependency and re-build package-lock.json where applicable.
