### PR TITLE
fix: properly test untyped selectable box sets

### DIFF
--- a/src/SelectableBox/tests/SelectableBoxSet.test.jsx
+++ b/src/SelectableBox/tests/SelectableBoxSet.test.jsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 import SelectableBox from '..';
 
+const boxText = (text) => `SelectableBox${text}`;
+
 const checkboxType = 'checkbox';
 const checkboxText = (text) => `SelectableCheckbox${text}`;
 
@@ -11,6 +13,16 @@ const radioType = 'radio';
 const radioText = (text) => `SelectableRadio${text}`;
 
 const ariaLabel = 'test-default-label';
+
+function SelectableBoxSet(props) {
+  return (
+    <SelectableBox.Set name="box" ariaLabel={ariaLabel} {...props}>
+      <SelectableBox value={1}>{boxText(1)}</SelectableBox>
+      <SelectableBox value={2}>{boxText(2)}</SelectableBox>
+      <SelectableBox value={3}>{boxText(3)}</SelectableBox>
+    </SelectableBox.Set>
+  );
+}
 
 function SelectableCheckboxSet(props) {
   return (
@@ -68,11 +80,8 @@ describe('<SelectableBox.Set />', () => {
       expect(screen.getByTestId('checkbox-set')).toBeInTheDocument();
     });
     it('renders with radio type if neither checkbox nor radio is passed', () => {
-      const originalError = console.error;
-      console.error = jest.fn();
-      render(<SelectableCheckboxSet type="text" data-testid="radio-set" />);
+      render(<SelectableBoxSet data-testid="radio-set" />);
       expect(screen.getByTestId('radio-set')).toBeInTheDocument();
-      console.error = originalError;
     });
     it('renders with radio type', () => {
       render(<SelectableRadioSet type={radioType} data-testid="radio-set" />);


### PR DESCRIPTION
## Description

Every PR post https://github.com/openedx/paragon/pull/2581 is showing

![image](https://github.com/openedx/paragon/assets/112954497/de437ec4-bf97-4f0c-9550-047046c038ee)

It seems a test was added that was setting an invalid type on `SelectableBoxSet` and eating the error to make the test pass. 

Before https://github.com/openedx/paragon/pull/2581, there were comments explaining this and `eslint-disable`s.
https://github.com/openedx/paragon/blob/1d6f95ecf845393fc4c7084e719f0b35c5bb4318/src/SelectableBox/tests/SelectableBoxSet.test.jsx#L74-L76

I decided, instead of bringing back the `eslint-disable`s, to
* Pass *no* type into the component instead of an invalid type
  * I believe this properly tests if it "renders with radio type if neither checkbox nor radio is passed"
* Remove the console error eating

## Merge Checklist

* [x] Is there adequate test coverage for your changes?

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
