### PR TITLE
feat: add outlined videoCam icon

### DIFF
--- a/icons/es5/VideocamOutlined.js
+++ b/icons/es5/VideocamOutlined.js
@@ -1,0 +1,13 @@
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import * as React from "react";
+const SvgVideocamOutlined = props => /*#__PURE__*/React.createElement("svg", _extends({
+  width: 24,
+  height: 24,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  xmlns: "http://www.w3.org/2000/svg"
+}, props), /*#__PURE__*/React.createElement("path", {
+  d: "M15 8v8H5V8h10Zm1-2H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4V7c0-.55-.45-1-1-1Z",
+  fill: "currentColor"
+}));
+export default SvgVideocamOutlined;

--- a/icons/es5/index.js
+++ b/icons/es5/index.js
@@ -2183,6 +2183,7 @@ export { default as VideoStable } from "./VideoStable";
 export { default as VideoTranscript } from "./VideoTranscript";
 export { default as Videocam } from "./Videocam";
 export { default as VideocamOff } from "./VideocamOff";
+export { default as VideocamOutlined } from "./VideocamOutlined";
 export { default as VideogameAsset } from "./VideogameAsset";
 export { default as VideogameAssetOff } from "./VideogameAssetOff";
 export { default as ViewAgenda } from "./ViewAgenda";

--- a/icons/jsx/VideocamOutlined.jsx
+++ b/icons/jsx/VideocamOutlined.jsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+const SvgVideocamOutlined = (props) => (
+  <svg
+    width={24}
+    height={24}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M15 8v8H5V8h10Zm1-2H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4V7c0-.55-.45-1-1-1Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+export default SvgVideocamOutlined;

--- a/icons/jsx/index.jsx
+++ b/icons/jsx/index.jsx
@@ -2183,6 +2183,7 @@ export { default as VideoStable } from "./VideoStable";
 export { default as VideoTranscript } from "./VideoTranscript";
 export { default as Videocam } from "./Videocam";
 export { default as VideocamOff } from "./VideocamOff";
+export { default as VideocamOutlined } from "./VideocamOutlined";
 export { default as VideogameAsset } from "./VideogameAsset";
 export { default as VideogameAssetOff } from "./VideogameAssetOff";
 export { default as ViewAgenda } from "./ViewAgenda";

--- a/icons/svg/videocam_outlined.svg
+++ b/icons/svg/videocam_outlined.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 8V16H5V8H15ZM16 6H4C3.45 6 3 6.45 3 7V17C3 17.55 3.45 18 4 18H16C16.55 18 17 17.55 17 17V13.5L21 17.5V6.5L17 10.5V7C17 6.45 16.55 6 16 6Z" fill="#00262B"/>
+</svg>


### PR DESCRIPTION
## Description

Add VideoCamOutline icon.

### Deploy Preview

https://deploy-preview-2750--paragon-openedx.netlify.app/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
