### PR TITLE
[BD-46] fix: replace filter names with header names

### DIFF
--- a/src/DataTable/FilterStatus.jsx
+++ b/src/DataTable/FilterStatus.jsx
@@ -7,12 +7,16 @@ import Button from '../Button';
 function FilterStatus({
   className, variant, size, clearFiltersText, buttonClassName, showFilteredFields,
 }) {
-  const { state, setAllFilters } = useContext(DataTableContext);
+  const { state, setAllFilters, headers } = useContext(DataTableContext);
   if (!setAllFilters) {
     return null;
   }
 
-  const filterNames = state.filters ? state.filters.map((filter) => filter.id) : [];
+  const headersMap = headers.reduce((cur, acc) => {
+    cur[acc.id] = acc.Header;
+    return cur;
+  }, {});
+  const filterNames = state.filters ? state.filters.map((filter) => headersMap[filter.id]) : [];
   const filterTexts = <p>Filtered by {filterNames.join(', ')}</p>;
 
   return (

--- a/src/DataTable/tests/FilterStatus.test.jsx
+++ b/src/DataTable/tests/FilterStatus.test.jsx
@@ -7,8 +7,9 @@ import FilterStatus from '../FilterStatus';
 import DataTableContext from '../DataTableContext';
 
 const filterNames = ['color', 'breed', 'discipline'];
+const headers = [{ id: 'color', Header: 'color' }, { id: 'breed', Header: 'breed' }, { id: 'discipline', Header: 'discipline' }];
 const filters = filterNames.map((name) => ({ id: name }));
-const instance = { state: { filters }, setAllFilters: () => {} };
+const instance = { state: { filters }, setAllFilters: () => {}, headers };
 const filterProps = {
   buttonClassName: 'buttonClass',
   variant: 'variant',

--- a/src/DataTable/tests/SmartStatus.test.jsx
+++ b/src/DataTable/tests/SmartStatus.test.jsx
@@ -9,6 +9,7 @@ import RowStatus from '../RowStatus';
 import SelectionStatus from '../selection/SelectionStatus';
 
 const filters = [{ id: 'name' }, { id: 'age' }];
+const headers = [{ id: 'name', Header: 'name' }, { id: 'age', Header: 'age' }];
 const filterNames = ['name', 'age'];
 const itemCount = 101;
 const instance = {
@@ -22,6 +23,7 @@ const instance = {
   SelectionStatusComponent: SelectionStatus,
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
+  headers,
 };
 
 // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
## Description
Update DataTable's filter status bar's messaging by replacing the accessor with the header name
[Issue](https://github.com/openedx/paragon/issues/2676)

### Deploy Preview

[https://deploy-preview-2757--paragon-openedx.netlify.app/](https://deploy-preview-2757--paragon-openedx.netlify.app/components/datatable/#frontend-filtering-and-sorting)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
