### PR TITLE
[BD-46] feat: add i18n support for ProductTour Checkpoint sr-only message

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "example:start:with-theme": "npm run start:with-theme --workspace=example",
     "generate-changelog": "node generate-changelog.js",
     "i18n_compile": "formatjs compile-folder --format transifex ./src/i18n/messages ./src/i18n/messages",
-    "i18n_extract": "formatjs extract 'src/**/*.{jsx,js,tsx,ts}' --out-file ./src/i18n/transifex_input.json --format transifex",
+    "i18n_extract": "formatjs extract 'src/**/*.{jsx,js,tsx,ts}' --out-file ./src/i18n/transifex_input.json --ignore='**/*.d.ts' --format transifex",
     "type-check": "tsc --noEmit && tsc --project www --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "build-types": "tsc --emitDeclarationOnly",

--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import PropTypes from 'prop-types';
 import { createPopper } from '@popperjs/core';
+import { FormattedMessage } from 'react-intl';
 
 import breakpoints from '../utils/breakpoints';
 
@@ -95,8 +96,13 @@ const Checkpoint = React.forwardRef(({
       role="dialog"
       style={{ visibility: checkpointVisible ? 'visible' : 'hidden', pointerEvents: checkpointVisible ? 'auto' : 'none' }}
     >
-      {/* This text is not translated due to Paragon's lack of i18n support */}
-      <span className="sr-only">Top of step {index + 1}</span>
+      <span className="sr-only">
+        <FormattedMessage
+          id="pgn.checkpoint.sr-only.message"
+          defaultMessage={`Top of step ${index + 1}`}
+          description="Screen-reader message to indicate the user's position in a sequence of checkpoints."
+        />
+      </span>
       {(title || !isOnlyCheckpoint) && (
         <div className="pgn__checkpoint-header">
           <CheckpointTitle>{title}</CheckpointTitle>

--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -98,8 +98,9 @@ const Checkpoint = React.forwardRef(({
     >
       <span className="sr-only">
         <FormattedMessage
-          id="pgn.checkpoint.sr-only.message"
-          defaultMessage={`Top of step ${index + 1}`}
+          id="pgn.ProductTour.Checkpoint.position-text"
+          defaultMessage="Top of step {step}"
+          value={{ step: index + 1 }}
           description="Screen-reader message to indicate the user's position in a sequence of checkpoints."
         />
       </span>

--- a/src/ProductTour/Checkpoint.test.jsx
+++ b/src/ProductTour/Checkpoint.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
 
 import * as popper from '@popperjs/core';
 
@@ -24,7 +25,7 @@ describe('Checkpoint', () => {
   describe('second Checkpoint in Tour', () => {
     beforeEach(() => {
       render(
-        <>
+        <IntlProvider locale="en" messages={{}}>
           <div id="target-element">...</div>
           <Checkpoint
             advanceButtonText="Next"
@@ -39,7 +40,7 @@ describe('Checkpoint', () => {
             title="Checkpoint title"
             totalCheckpoints={5}
           />
-        </>,
+        </IntlProvider>,
       );
     });
 
@@ -75,7 +76,7 @@ describe('Checkpoint', () => {
   describe('last Checkpoint in Tour', () => {
     beforeEach(() => {
       render(
-        <>
+        <IntlProvider locale="en" messages={{}}>
           <div id="#last-element" />
           <Checkpoint
             advanceButtonText="Next"
@@ -90,7 +91,7 @@ describe('Checkpoint', () => {
             title="Checkpoint title"
             totalCheckpoints={5}
           />
-        </>,
+        </IntlProvider>,
       );
     });
 
@@ -108,7 +109,7 @@ describe('Checkpoint', () => {
   describe('only one Checkpoint in Tour', () => {
     beforeEach(() => {
       render(
-        <>
+        <IntlProvider locale="en" messages={{}}>
           <div id="#target-element" />
           <Checkpoint
             advanceButtonText="Next"
@@ -123,7 +124,7 @@ describe('Checkpoint', () => {
             title="Checkpoint title"
             totalCheckpoints={1}
           />
-        </>,
+        </IntlProvider>,
       );
     });
 
@@ -140,7 +141,7 @@ describe('Checkpoint', () => {
   describe('only one Checkpoint in Tour and showDismissButton set to true', () => {
     it('it renders dismiss button and end button', () => {
       render(
-        <>
+        <IntlProvider locale="en" messages={{}}>
           <div id="#target-element" />
           <Checkpoint
             advanceButtonText="Next"
@@ -156,7 +157,7 @@ describe('Checkpoint', () => {
             totalCheckpoints={1}
             showDismissButton
           />
-        </>,
+        </IntlProvider>,
       );
       expect(screen.getByText('Dismiss', { selector: 'button' })).toBeInTheDocument();
       expect(screen.getByText('End', { selector: 'button' })).toBeInTheDocument();

--- a/src/ProductTour/ProductTour.test.jsx
+++ b/src/ProductTour/ProductTour.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
 
 import * as popper from '@popperjs/core';
 
@@ -85,17 +86,20 @@ describe('<ProductTour />', () => {
     popperMock.mockReset();
   });
 
+  // eslint-disable-next-line react/prop-types
+  function ProductTourWrapper({ tours }) {
+    return (
+      <IntlProvider locale="en" messages={{}}>
+        <ProductTour tours={tours} />
+        {targets}
+      </IntlProvider>
+    );
+  }
+
   describe('one enabled tour', () => {
     describe('with default settings', () => {
       it('renders checkpoint with correct title, body, and breadcrumbs', () => {
-        render(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[tourData]} />);
 
         expect(screen.getByRole('dialog', { name: 'Checkpoint 1' })).toBeInTheDocument();
         expect(screen.getByText('Checkpoint 1')).toBeInTheDocument();
@@ -103,14 +107,7 @@ describe('<ProductTour />', () => {
       });
 
       it('onClick of advance button advances to next checkpoint', async () => {
-        const { rerender } = render(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        const { rerender } = render(<ProductTourWrapper tours={[tourData]} />);
         // Verify the first Checkpoint has rendered
         expect(screen.getByRole('heading', { name: 'Checkpoint 1' })).toBeInTheDocument();
 
@@ -120,14 +117,7 @@ describe('<ProductTour />', () => {
           await userEvent.click(advanceButton);
         });
 
-        rerender(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        rerender(<ProductTourWrapper tours={[tourData]} />);
 
         const heading = screen.getByRole('heading', { name: 'Checkpoint 2' });
 
@@ -136,14 +126,7 @@ describe('<ProductTour />', () => {
       });
 
       it('onClick of dismiss button disables tour', async () => {
-        render(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[tourData]} />);
 
         // Verify a Checkpoint has rendered
         expect(screen.getByRole('dialog', { name: 'Checkpoint 1' })).toBeInTheDocument();
@@ -161,14 +144,7 @@ describe('<ProductTour />', () => {
       });
 
       it('onClick of end button disables tour', async () => {
-        const { rerender } = render(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        const { rerender } = render(<ProductTourWrapper tours={[tourData]} />);
 
         // Verify a Checkpoint has rendered
         expect(screen.getByRole('dialog', { name: 'Checkpoint 1' })).toBeInTheDocument();
@@ -184,28 +160,14 @@ describe('<ProductTour />', () => {
           await userEvent.click(advanceButton2);
         });
 
-        rerender(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        rerender(<ProductTourWrapper tours={[tourData]} />);
 
         const advanceButton3 = screen.getByRole('button', { name: 'Override advance' });
         await act(async () => {
           await userEvent.click(advanceButton3);
         });
 
-        rerender(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        rerender(<ProductTourWrapper tours={[tourData]} />);
 
         // Click the end button
         const endButton = screen.getByRole('button', { name: 'End' });
@@ -220,14 +182,7 @@ describe('<ProductTour />', () => {
       });
 
       it('onClick of escape key disables tour', async () => {
-        render(
-          <>
-            <ProductTour
-              tours={[tourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[tourData]} />);
 
         // Verify a Checkpoint has rendered
         expect(screen.getByRole('dialog', { name: 'Checkpoint 1' })).toBeInTheDocument();
@@ -283,27 +238,13 @@ describe('<ProductTour />', () => {
         ],
       };
       it('renders correct checkpoint on index override', () => {
-        render(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[overrideTourData]} />);
         expect(screen.getByRole('dialog', { name: 'Checkpoint 3' })).toBeInTheDocument();
         expect(screen.getByRole('heading', { name: 'Checkpoint 3' })).toBeInTheDocument();
       });
 
       it('applies override for advanceButtonText', async () => {
-        const { rerender } = render(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        const { rerender } = render(<ProductTourWrapper tours={[overrideTourData]} />);
         expect(screen.getByRole('button', { name: 'Override advance' })).toBeInTheDocument();
         const advanceButton = screen.getByRole('button', { name: 'Override advance' });
         await act(async () => {
@@ -312,37 +253,16 @@ describe('<ProductTour />', () => {
         expect(screen.queryByRole('button', { name: 'Override advance' })).not.toBeInTheDocument();
         expect(customOnAdvance).toHaveBeenCalledTimes(1);
 
-        rerender(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        rerender(<ProductTourWrapper tours={[overrideTourData]} />);
 
         expect(screen.getByText('Checkpoint 4')).toBeInTheDocument();
       });
       it('applies override for dismissButtonText', () => {
-        render(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[overrideTourData]} />);
         expect(screen.getByRole('button', { name: 'Override dismiss' })).toBeInTheDocument();
       });
       it('calls customHandleDismiss onClick of dismiss button', async () => {
-        render(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[overrideTourData]} />);
         const dismissButton = screen.getByRole('button', { name: 'Override dismiss' });
         await act(async () => {
           await userEvent.click(dismissButton);
@@ -351,27 +271,13 @@ describe('<ProductTour />', () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       });
       it('calls customHandleOnEnd onClick of end button', async () => {
-        const { rerender } = render(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        const { rerender } = render(<ProductTourWrapper tours={[overrideTourData]} />);
         const advanceButton = screen.getByRole('button', { name: 'Override advance' });
         await act(async () => {
           await userEvent.click(advanceButton);
         });
 
-        rerender(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        rerender(<ProductTourWrapper tours={[overrideTourData]} />);
 
         expect(screen.getByText('Checkpoint 4')).toBeInTheDocument();
         const endButton = screen.getByRole('button', { name: 'Override end' });
@@ -383,14 +289,7 @@ describe('<ProductTour />', () => {
         expect(screen.queryByText('Checkpoint 4')).not.toBeInTheDocument();
       });
       it('calls onEscape on escape button key press', async () => {
-        render(
-          <>
-            <ProductTour
-              tours={[overrideTourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[overrideTourData]} />);
         expect(screen.getByText('Checkpoint 3')).toBeInTheDocument();
         const container = screen.getByRole('dialog');
         container.focus();
@@ -421,14 +320,7 @@ describe('<ProductTour />', () => {
           ],
         };
 
-        render(
-          <>
-            <ProductTour
-              tours={[badTourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[badTourData]} />);
 
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       });
@@ -456,14 +348,7 @@ describe('<ProductTour />', () => {
           ],
         };
 
-        render(
-          <>
-            <ProductTour
-              tours={[badTourData]}
-            />
-            {targets}
-          </>,
-        );
+        render(<ProductTourWrapper tours={[badTourData]} />);
 
         expect(screen.queryByRole('dialog', { name: 'Checkpoint 1' })).not.toBeInTheDocument();
         expect(screen.getByRole('dialog', { name: 'Checkpoint 2' })).toBeInTheDocument();
@@ -491,14 +376,7 @@ describe('<ProductTour />', () => {
         ],
       };
 
-      render(
-        <>
-          <ProductTour
-            tours={[disabledTourData, tourData, secondEnabledTourData]}
-          />
-          {targets}
-        </>,
-      );
+      render(<ProductTourWrapper tours={[disabledTourData, tourData, secondEnabledTourData]} />);
 
       expect(screen.getByText('Checkpoint 1')).toBeInTheDocument();
       expect(screen.queryByText('Second enabled tour')).not.toBeInTheDocument();
@@ -507,14 +385,7 @@ describe('<ProductTour />', () => {
 
   describe('disabled tour', () => {
     it('does not render', () => {
-      render(
-        <>
-          <ProductTour
-            tours={[disabledTourData]}
-          />
-          {targets}
-        </>,
-      );
+      render(<ProductTourWrapper tours={[disabledTourData]} />);
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "رفع {filename} جارٍ.",
   "pgn.FormAutosuggest.iconButtonClosed": "إغلاق قائمة الخيارات",
   "pgn.FormAutosuggest.iconButtonOpened": "فتح قائمة الخيارات",
-  "pgn.Toast.closeLabel": "إغلاق "
+  "pgn.Toast.closeLabel": "إغلاق ",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Subiendo {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Cerrar el menú de opciones",
   "pgn.FormAutosuggest.iconButtonOpened": "Abre el menú de opciones",
-  "pgn.Toast.closeLabel": "Cerrar"
+  "pgn.Toast.closeLabel": "Cerrar",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/es_AR.json
+++ b/src/i18n/messages/es_AR.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Subiendo {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Cerrar el menú de opciones",
   "pgn.FormAutosuggest.iconButtonOpened": "Abre el menú de opciones",
-  "pgn.Toast.closeLabel": "Cerrar"
+  "pgn.Toast.closeLabel": "Cerrar",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/es_ES.json
+++ b/src/i18n/messages/es_ES.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Subiendo {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Cerrar el menú de opciones",
   "pgn.FormAutosuggest.iconButtonOpened": "Abre el menú de opciones",
-  "pgn.Toast.closeLabel": "Cerrar"
+  "pgn.Toast.closeLabel": "Cerrar",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/it_IT.json
+++ b/src/i18n/messages/it_IT.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Caricamento {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Chiudi"
+  "pgn.Toast.closeLabel": "Chiudi",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/ko_KR.json
+++ b/src/i18n/messages/ko_KR.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Zamknij"
+  "pgn.Toast.closeLabel": "Zamknij",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/pt_BR.json
+++ b/src/i18n/messages/pt_BR.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/pt_PT.json
+++ b/src/i18n/messages/pt_PT.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Carregando {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Fechar o menu de opções",
   "pgn.FormAutosuggest.iconButtonOpened": "Abrir o menu de opções",
-  "pgn.Toast.closeLabel": "Fechar"
+  "pgn.Toast.closeLabel": "Fechar",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/tr_TR.json
+++ b/src/i18n/messages/tr_TR.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "{filename} yükleniyor.",
   "pgn.FormAutosuggest.iconButtonClosed": "Seçenekler menüsünü kapat",
   "pgn.FormAutosuggest.iconButtonOpened": "Seçenekler menüsünü aç",
-  "pgn.Toast.closeLabel": "Kapat"
+  "pgn.Toast.closeLabel": "Kapat",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/uk.json
+++ b/src/i18n/messages/uk.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -27,5 +27,6 @@
   "pgn.Dropzone.UploadProgress.uploadLabel": "Uploading {filename}.",
   "pgn.FormAutosuggest.iconButtonClosed": "Close the options menu",
   "pgn.FormAutosuggest.iconButtonOpened": "Open the options menu",
-  "pgn.Toast.closeLabel": "Close"
+  "pgn.Toast.closeLabel": "Close",
+  "pgn.ProductTour.Checkpoint.position-text": "Top of step {step}"
 }


### PR DESCRIPTION
## Description
Add i18n support for ProductTour Checkpoint sr-only message
[Issue](https://github.com/openedx/paragon/issues/2706)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
