### PR TITLE
[BD-46] docs: change breadcrumbs links for the basic usage example

### DIFF
--- a/src/Breadcrumb/README.md
+++ b/src/Breadcrumb/README.md
@@ -38,9 +38,9 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
 ```jsx live
 <Breadcrumb ariaLabel="Breadcrumb mobile view"
   links={[
-    { label: 'Link 1', href: '/link-1' },
-    { label: 'Link 2', href: '/link-2' },
-    { label: 'Link 3', href: '/link-3' },
+    { label: 'Link 1', href: '#link-1' },
+    { label: 'Link 2', href: '#link-2' },
+    { label: 'Link 3', href: '#link-3' },
   ]}
   isMobile
 />
@@ -56,9 +56,9 @@ Use as a secondary navigation pattern to help convey hierarchy and enable naviga
     <div className="bg-dark-700 p-4">
       <Breadcrumb ariaLabel="Breadcrumb inverse pallete"
         links={[
-          {label: 'Link 1', href: '/link-1'},
-          {label: 'Link 2', href: '/link-2'},
-          {label: 'Link 3', href: '/link-3'},
+          {label: 'Link 1', href: '#link-1'},
+          {label: 'Link 2', href: '#link-2'},
+          {label: 'Link 3', href: '#link-3'},
         ]}
         variant="dark"
         isMobile={isExtraSmall}


### PR DESCRIPTION
## Description

Change links for the Basic Usage example
[Issue](https://github.com/openedx/paragon/issues/2684)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
