### PR TITLE
[BD-46] fix: fixed design token for icon btn active state

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build-types": "tsc --emitDeclarationOnly",
     "playroom:start": "npm run playroom:start --workspace=www",
     "playroom:build": "npm run playroom:build --workspace=www",
-    "build-tokens": "./bin/paragon-scripts.js build-tokens --build-dir ../styles/css",
+    "build-tokens": "./bin/paragon-scripts.js build-tokens --build-dir ./styles/css",
     "replace-variables-usage-with-css": "./bin/paragon-scripts.js replace-variables -p src -t usage",
     "replace-variables-definition-with-css": "./bin/paragon-scripts.js replace-variables -p src -t definition"
   },

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Fri, 22 Sep 2023 08:20:17 GMT
+ * Generated on Mon, 30 Oct 2023 14:36:05 GMT
  */
 
 :root {
@@ -439,7 +439,6 @@
   --pgn-color-icon-button-bg-secondary-inverse-base: var(--pgn-color-icon-button-bg-base);
   --pgn-color-icon-button-bg-secondary-focus: var(--pgn-color-icon-button-bg-base);
   --pgn-color-icon-button-bg-secondary-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-primary-inverse-active-base: var(--pgn-color-icon-button-bg-base);
   --pgn-color-icon-button-bg-primary-inverse-focus: var(--pgn-color-icon-button-bg-base);
   --pgn-color-icon-button-bg-primary-inverse-base: var(--pgn-color-icon-button-bg-base);
   --pgn-color-icon-button-bg-primary-focus: var(--pgn-color-icon-button-bg-base);
@@ -881,6 +880,7 @@
   --pgn-color-icon-button-bg-secondary-hover: var(--pgn-color-secondary-base);
   --pgn-color-icon-button-bg-primary-inverse-active-focus: var(--pgn-color-icon-button-accent);
   --pgn-color-icon-button-bg-primary-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-primary-inverse-active-base: var(--pgn-color-icon-button-accent);
   --pgn-color-icon-button-bg-primary-active-focus: var(--pgn-color-icon-button-text-primary-base);
   --pgn-color-icon-button-bg-primary-active-hover: var(--pgn-color-icon-button-text-primary-base);
   --pgn-color-icon-button-bg-primary-active-base: var(--pgn-color-icon-button-text-primary-base);

--- a/tokens/src/themes/light/components/IconButton.json
+++ b/tokens/src/themes/light/components/IconButton.json
@@ -18,7 +18,7 @@
             "focus": { "value": "{color.icon-button.text.primary.base}", "type": "color" }
           },
           "inverse-active": {
-            "base": { "value": "{color.icon-button.bg.base}", "type": "color" },
+            "base": { "value": "{color.icon-button.accent}", "type": "color" },
             "hover": { "value": "{color.icon-button.accent}", "type": "color" },
             "focus": { "value": "{color.icon-button.accent}", "type": "color" }
           }


### PR DESCRIPTION
## Description
- The inverse-primary IconButton component does not have a white background;
- Fixed path to the build directory.

**Issue:** https://github.com/openedx/paragon/issues/2688

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
