### PR TITLE
[BD-46] feat: added description for @edx/brand package rollback

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -33,7 +33,7 @@ const COMMANDS = {
   */
   'install-theme': {
     executor: themeCommand,
-    description: 'Installs the specific @edx/brand package.',
+    description: 'Installs the specific @edx/brand package. \n    Run npm install is necessary to reset to default.',
     parameters: [
       {
         name: 'theme',


### PR DESCRIPTION
## Description

- document (either in README and/or CLI tool itself) that npm install is necessary to reset to default `@edx/brand-openedx`.

**Issue:** https://github.com/openedx/paragon/issues/2644

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
