### PR TITLE
feat: Better support for multiple themes

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -107,6 +107,16 @@ const COMMANDS = {
         description: 'Enable verbose logging.',
         defaultValue: false,
       },
+      {
+        name: '--base-theme',
+        description: 'Specify the base theme to use in the token build. For example, to build the "high-contrast" theme on top of the light theme use "--theme high-contrast --base-theme light".',
+        defaultValue: 'Same as theme',
+      },
+      {
+        name: '--all-themes',
+        description: 'Build tokens for all themes in the source directory.',
+        defaultValue: false,
+      },
     ],
   },
   'replace-variables': {

--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -94,7 +94,8 @@ const COMMANDS = {
       {
         name: '-t, --themes',
         description: `Specify themes to include in the token build.
-          Can be provided as a comma-separated list (e.g., "light,dark") or multiple arguments (e.g., "-t light -t dark").`,
+          Can be provided as a comma-separated list (e.g., "light,dark") or multiple arguments (e.g., "-t light -t dark").
+          Cannot be used with --all-themes`,
         defaultValue: 'light',
       },
       {
@@ -114,7 +115,7 @@ const COMMANDS = {
       },
       {
         name: '--all-themes',
-        description: 'Build tokens for all themes in the source directory.',
+        description: 'Build tokens for all themes in the source directory. Cannot be used with --themes.',
         defaultValue: false,
       },
     ],

--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -108,8 +108,8 @@ const COMMANDS = {
         defaultValue: false,
       },
       {
-        name: '--base-theme',
-        description: 'Specify the base theme to use in the token build. For example, to build the "high-contrast" theme on top of the light theme use "--theme high-contrast --base-theme light".',
+        name: '--base-paragon-theme',
+        description: 'Specify the base theme to use in the token build. For example, to build the "high-contrast" theme on top of the light theme use "--theme high-contrast --base-paragon-theme light".',
         defaultValue: 'Same as theme',
       },
       {

--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -14,7 +14,8 @@ const { createIndexCssFile } = require('../tokens/utils');
  * @param {string[]} commandArgs - Command line arguments for building tokens.
  * @param {string} [commandArgs.build-dir='./build/'] - The directory where the build output will be placed.
  * @param {string} [commandArgs.source] - The source directory containing JSON token files.
- * @param {string} [commandArgs.base-theme] - The base theme to use from Paragon if named differently than the theme.
+ * @param {string} [commandArgs.base-paragon-theme] - The base theme to use from Paragon if named differently than
+ *                                                    the theme.
  * @param {boolean} [commandArgs.source-tokens-only=false] - Indicates whether to include only source tokens.
  * @param {string|string[]} [commandArgs.themes=['light']] - The themes (variants) for which to build tokens.
  * @param {boolean} [commandArgs.all-themes] - Indicated whether to process all themes.
@@ -22,7 +23,7 @@ const { createIndexCssFile } = require('../tokens/utils');
 async function buildTokensCommand(commandArgs) {
   const defaultParams = {
     themes: 'light',
-    'base-theme': null,
+    'base-paragon-theme': null,
     'build-dir': './build/',
     'source-tokens-only': false,
     'output-references': true,
@@ -44,7 +45,7 @@ async function buildTokensCommand(commandArgs) {
     'output-references': outputReferences,
     themes,
     verbose,
-    'base-theme': baseTheme,
+    'base-paragon-theme': baseParagonTheme,
     'all-themes': allThemes,
     'exclude-core': excludeCore,
   } = minimist(
@@ -177,10 +178,10 @@ async function buildTokensCommand(commandArgs) {
   }
 
   //  Add theme variants
-  for (const themeVariant of parsedThemes) {
-    const config = getStyleDictionaryConfig(themeVariant, baseTheme || themeVariant);
+  themesToProcess.forEach(themeVariant => {
+    const config = getStyleDictionaryConfig(themeVariant, baseParagonTheme || themeVariant);
     configs.push({ config, themeVariant });
-  }
+  });
 
   // Build tokens for each configuration
   await Promise.all(configs.map(async ({ config, themeVariant }) => {

--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const minimist = require('minimist');
 const {
@@ -13,17 +14,21 @@ const { createIndexCssFile } = require('../tokens/utils');
  * @param {string[]} commandArgs - Command line arguments for building tokens.
  * @param {string} [commandArgs.build-dir='./build/'] - The directory where the build output will be placed.
  * @param {string} [commandArgs.source] - The source directory containing JSON token files.
+ * @param {string} [commandArgs.base-theme] - The base theme to use from Paragon if named differently than the theme.
  * @param {boolean} [commandArgs.source-tokens-only=false] - Indicates whether to include only source tokens.
  * @param {string|string[]} [commandArgs.themes=['light']] - The themes (variants) for which to build tokens.
+ * @param {boolean} [commandArgs.all-themes] - Indicated whether to process all themes.
  */
 async function buildTokensCommand(commandArgs) {
   const defaultParams = {
-    themes: ['light'],
+    themes: 'light',
+    'base-theme': null,
     'build-dir': './build/',
     'source-tokens-only': false,
     'output-references': true,
     'exclude-core': false,
     verbose: false,
+    'all-themes': false,
   };
 
   const alias = {
@@ -39,19 +44,32 @@ async function buildTokensCommand(commandArgs) {
     'output-references': outputReferences,
     themes,
     verbose,
+    'base-theme': baseTheme,
+    'all-themes': allThemes,
     'exclude-core': excludeCore,
   } = minimist(
     commandArgs,
     {
       alias,
       default: defaultParams,
-      boolean: ['source-tokens-only', 'output-references', 'exclude-core', 'verbose'],
+      boolean: ['source-tokens-only', 'output-references', 'exclude-core', 'verbose', 'all-themes'],
     },
   );
+  let themesToProcess = null;
 
-  const parsedThemes = Array.isArray(themes) ? themes : themes.split(',').map(t => t.trim());
+  if (allThemes) {
+    const tokensPath = tokensSource || path.resolve(__dirname, '../tokens/src');
+    themesToProcess = fs
+      .readdirSync(`${tokensPath}/themes/`, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name);
+  } else if (Array.isArray(themes)) {
+    themesToProcess = themes;
+  } else {
+    themesToProcess = themes.split(',').map(t => t.trim());
+  }
 
-  const StyleDictionary = await initializeStyleDictionary({ themes: parsedThemes });
+  const StyleDictionary = await initializeStyleDictionary({ themes: themesToProcess });
 
   const coreConfig = {
     include: [
@@ -100,12 +118,12 @@ async function buildTokensCommand(commandArgs) {
     },
   };
 
-  const getStyleDictionaryConfig = (themeVariant) => ({
+  const getStyleDictionaryConfig = (themeVariant, baseThemeVariant) => ({
     ...coreConfig,
     include: [
       ...coreConfig.include,
-      path.resolve(__dirname, `../tokens/src/themes/${themeVariant}/**/*.json`),
-      path.resolve(__dirname, `../tokens/src/themes/${themeVariant}/**/*.toml`),
+      path.resolve(__dirname, `../tokens/src/themes/${baseThemeVariant}/**/*.json`),
+      path.resolve(__dirname, `../tokens/src/themes/${baseThemeVariant}/**/*.toml`),
     ],
     source: tokensSource
       ? [
@@ -160,7 +178,7 @@ async function buildTokensCommand(commandArgs) {
 
   //  Add theme variants
   for (const themeVariant of parsedThemes) {
-    const config = getStyleDictionaryConfig(themeVariant);
+    const config = getStyleDictionaryConfig(themeVariant, baseTheme || themeVariant);
     configs.push({ config, themeVariant });
   }
 

--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -22,7 +22,7 @@ const { createIndexCssFile } = require('../tokens/utils');
  */
 async function buildTokensCommand(commandArgs) {
   const defaultParams = {
-    themes: 'light',
+    themes: null,
     'base-paragon-theme': null,
     'build-dir': './build/',
     'source-tokens-only': false,
@@ -56,6 +56,10 @@ async function buildTokensCommand(commandArgs) {
       boolean: ['source-tokens-only', 'output-references', 'exclude-core', 'verbose', 'all-themes'],
     },
   );
+
+  if (themes !== null && allThemes) {
+    throw Error('Cannot specify themes with `--themes` when using `--all-themes`.');
+  }
   let themesToProcess = null;
 
   if (allThemes) {
@@ -67,7 +71,7 @@ async function buildTokensCommand(commandArgs) {
   } else if (Array.isArray(themes)) {
     themesToProcess = themes;
   } else {
-    themesToProcess = themes.split(',').map(t => t.trim());
+    themesToProcess = (themes || 'light').split(',').map(t => t.trim());
   }
 
   const StyleDictionary = await initializeStyleDictionary({ themes: themesToProcess });


### PR DESCRIPTION
This change adds support for two CLI options to the build-tokens command.

The first, --all-themes makes the build-tokens command process all themes in the source directory as opposed to specifying all the names via --theme.

Secondly, --base-theme allows you to have multiple themes derived from the same common base. If specified, you can have a derived theme that still loads tokens from the light theme. For example, you can have a site theme called 'theme-one' and set the base theme to light so it will reuse the core light theme tokens and layer on changes from 'theme-one'.

**Testing instructions:**

- Create a base tokens directory structure from which tokens will be loaded, this will involve creating an empty directory with a folder called 'themes' inside which there will be multiple folders, with names other than 'light' i.e. test1, test2. So you have folders called 'test1' and 'test2' inside '/tmp/pr-2792/themes/' for example. 
- Just for test purposes create some tokens in both directories. You can just create a file called `colors.json' with the following contents: 
  ```json
  {
      "color": {
          "test-color": {
              "$value": "#112233"
          }
      }
  }
  ```
  You can use different color values or variable names to see if things are really working as expected. 
- You can now build tokens using `./bin/paragon-scripts.js build-tokens --source /tmp/pr-2792 --build-dir /tmp/pr-2792/build --themes test1 --themes test2`. You will need to specify both themes since currently, if you specify only one it will fail. 
- You should see `build` directory inside `/tmp/pr-2792` that a `core` an `themes` directory where the themes directory in turn will have a `variables.css` file with the variable defined above, and `utility-classes.css` will be empty. Delete this directory. 
- Check out this branch and try the following:
  * `./bin/paragon-scripts.js build-tokens --source /tmp/pr-2792 --build-dir /tmp/pr-2792/build --themes test1`: This would error before but will work now. 
  * `./bin/paragon-scripts.js build-tokens --source /tmp/pr-2792 --build-dir /tmp/pr-2792/build --all-themes`: This will build all themes without specifying a name.
  * `./bin/paragon-scripts.js build-tokens --source /tmp/pr-2792 --build-dir /tmp/pr-2792/build --themes test1 --base-theme light`: This will compile the test1 theme using the light theme as a base. So `utility-classes.css` will not longer be empty but contain styles from the light theme. 