### PR TITLE
[BD-46] fix: remove props spreading in `DataTable` components

### DIFF
--- a/src/DataTable/ExpandRow.jsx
+++ b/src/DataTable/ExpandRow.jsx
@@ -6,9 +6,9 @@ import IconButton from '../IconButton';
 
 const EXPAND_COLLAPSE_ICON_SIZE = 'inline';
 
-function ExpandRow({ row, ...rest }) {
+function ExpandRow({ row }) {
   return (
-    <span {...row.getToggleRowExpandedProps()} {...rest}>
+    <span {...row.getToggleRowExpandedProps()}>
       {row.isExpanded
         ? <IconButton src={ExpandLess} iconAs={Icon} alt="Collapse row" size={EXPAND_COLLAPSE_ICON_SIZE} />
         : <IconButton src={ExpandMore} iconAs={Icon} alt="Expand row" size={EXPAND_COLLAPSE_ICON_SIZE} />}

--- a/src/DataTable/selection/ControlledSelect.jsx
+++ b/src/DataTable/selection/ControlledSelect.jsx
@@ -10,7 +10,7 @@ import {
   addSelectedRowAction,
 } from './data/actions';
 
-function ControlledSelect({ row, ...rest }) {
+function ControlledSelect({ row }) {
   const {
     itemCount,
     controlledTableSelections: [, dispatch],
@@ -34,7 +34,6 @@ function ControlledSelect({ row, ...rest }) {
       <CheckboxControl
         {...updatedProps}
         onChange={toggleSelected}
-        {...rest}
       />
     </div>
   );

--- a/src/DataTable/selection/ControlledSelectHeader.jsx
+++ b/src/DataTable/selection/ControlledSelectHeader.jsx
@@ -9,7 +9,7 @@ import {
   setSelectedRowsAction,
 } from './data/actions';
 
-function ControlledSelectHeader({ rows, ...rest }) {
+function ControlledSelectHeader({ rows }) {
   const {
     itemCount,
     controlledTableSelections: [, dispatch],
@@ -44,7 +44,6 @@ function ControlledSelectHeader({ rows, ...rest }) {
       <CheckboxControl
         {...toggleAllPageRowsSelectedProps}
         onChange={toggleAllPageRowsSelected}
-        {...rest}
       />
     </div>
   );

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -14,7 +14,7 @@ import {
   getRowIds,
 } from './data/helpers';
 
-function ControlledSelectionStatus({ className, clearSelectionText, ...rest }) {
+function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
     page,
@@ -44,7 +44,6 @@ function ControlledSelectionStatus({ className, clearSelectionText, ...rest }) {
     clearSelectionText,
     onSelectAll: () => dispatch(setSelectAllRowsAllPagesAction()),
     onClear: () => dispatch(clearSelectionAction()),
-    ...rest,
   };
   return <BaseSelectionStatus {...selectionStatusProps} />;
 }

--- a/src/DataTable/tests/ExpandRow.test.jsx
+++ b/src/DataTable/tests/ExpandRow.test.jsx
@@ -10,10 +10,7 @@ const row = {
 
 describe('<ExpandRow />', () => {
   it('renders expand row element if rows is not expanded', () => {
-    const { getByTestId, getByLabelText } = render(<ExpandRow row={row} data-testid="span-expand-row" />);
-
-    const labelWrapper = getByTestId('span-expand-row');
-    expect(labelWrapper).toBeInTheDocument();
+    const { getByLabelText } = render(<ExpandRow row={row} />);
 
     const iconButton = getByLabelText('Expand row');
     expect(iconButton).toBeInTheDocument();
@@ -21,10 +18,7 @@ describe('<ExpandRow />', () => {
 
   it('renders collapse row element if row is expanded', () => {
     const expandedRow = { ...row, isExpanded: true };
-    const { getByTestId, getByLabelText } = render(<ExpandRow row={expandedRow} data-testid="span-collapse-row" />);
-
-    const labelWrapper = getByTestId('span-collapse-row');
-    expect(labelWrapper).toBeInTheDocument();
+    const { getByLabelText } = render(<ExpandRow row={expandedRow} />);
 
     const iconButton = getByLabelText('Collapse row');
     expect(iconButton).toBeInTheDocument();


### PR DESCRIPTION
## Description

Removes redundant props spreading in DataTable subcomponents that cause a lot of console errors during development, more details in https://github.com/openedx/paragon/issues/2751

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
