### PR TITLE
[BD-46] docs: remove technical documentation label update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Documentation lives at https://paragon-openedx.netlify.app/.
 
 ## Getting Started
 
+### Getting Help
+
+Please reach out to the Paragon Working Group (PWG):
+
+* Open edX Slack ([request an invite](https://openedx.org/slack)): [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4)
+* [Github Issues](https://github.com/openedx/paragon/issues/new?template=blank-issue.md)
+* [Weekly PWG Meeting](https://calendar.google.com/calendar/embed?src=c_v86shrnegshsqgp4fj2k94u7bc%40group.calendar.google.com&ctz=America%2FNew_York)
+
 ### React Components
 
 Paragon components require React 16 or higher. To install Paragon into your project:
@@ -64,14 +72,6 @@ The Paragon CLI (Command Line Interface) is a tool that provides various utility
 - `paragon install-theme [theme]`: Installs the specific @edx/brand package.
 
 Use `paragon help` to see more information.
-
-## Getting Help
-
-Please reach out to the Paragon Working Group (PWG):
-
-* Open edX Slack ([request an invite](https://openedx.org/slack)): [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4)
-* [Github Issues](https://github.com/openedx/paragon/issues/new?template=blank-issue.md)
-* [Weekly PWG Meeting](https://calendar.google.com/calendar/embed?src=c_v86shrnegshsqgp4fj2k94u7bc%40group.calendar.google.com&ctz=America%2FNew_York)
 
 ## Internationalization
 

--- a/www/src/components/header/SiteTitle.tsx
+++ b/www/src/components/header/SiteTitle.tsx
@@ -28,9 +28,6 @@ export default function SiteTitle({ title, isFullVersion, className } : SiteTitl
         {isFullVersion && (
           <div className="ml-3 mr-3">
             <h1 className="pgn-doc__header-title-heading h4">{title}</h1>
-            <p className="pgn-doc__header-title-description x-small">
-              Technical Documentation
-            </p>
           </div>
         )}
       </div>

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -10,9 +10,6 @@ function HomePage() {
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Home" />
       <div className="bg-dark text-white text-center py-5">
-        <p className="x-small text-uppercase text-monospace mb-0">
-          Technical Documentation{' '}
-        </p>
         <h1 className="display-3 text-white">Paragon Design System</h1>
         <p className="lead mx-auto my-3 mb-4" style={{ maxWidth: '28em' }}>
           An accessible, theme-ready, and open source design system built for


### PR DESCRIPTION
## Description

[Issue](https://github.com/openedx/paragon/issues/2775)
- Removed the "Technical documentation" label.
- README moved the "Getting Help" above the "Getting started".

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
