### PR TITLE
ci(deploy): Remove pages deploy step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_NPM_TOKEN }}
       run: npx semantic-release
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: www/public # The folder the action should deploy.
-        clean: true # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
## Description

Simply removes the Github Pages deploy step from `release.yml` as mentioned in #2465

This is one of a couple `help-wanted` issues I'm going to grab as part of an application to come work with you folks! :smile: 

~~_Note: I'm waiting on my Contributor Agreement to be sent, but this seems pretty benign_~~
_CLA has been executed as of 1100 MST (GMT-7) Nov 16th_

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] ~~If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.~~
* [ ] ~~Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?~~
* [ ] ~~Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?~~
* [ ] ~~Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?~~
* [ ] ~~Were your changes tested in the `example` app?~~
* [ ] ~~Is there adequate test coverage for your changes?~~
* [ ] ~~Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.~~

(Wow actually _none_ of them apply)

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
