### PR TITLE
[BD-46] fix: show skeleton while loading src in CardImageCap

### DIFF
--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -27,6 +27,22 @@ const CardImageCap = React.forwardRef(({
   const [showImageCap, setShowImageCap] = useState(false);
   const [showLogoCap, setShowLogoCap] = useState(false);
 
+  const showSkeleton = useMemo(() => {
+    let show;
+    if (src && logoSrc) {
+      show = !(showImageCap && showLogoCap);
+    } else if (src) {
+      show = !showImageCap;
+    } else if (logoSrc) {
+      show = !showLogoCap;
+    }
+    return show;
+  }, [src, logoSrc, showImageCap, showLogoCap]);
+
+  const imageSkeletonHeight = useMemo(() => (
+    orientation === 'horizontal' ? '100%' : skeletonHeight
+  ), [orientation, skeletonHeight]);
+
   const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
 
   if (isLoading) {
@@ -37,7 +53,7 @@ const CardImageCap = React.forwardRef(({
       >
         <Skeleton
           containerClassName="pgn__card-image-cap-loader"
-          height={orientation === 'horizontal' ? '100%' : skeletonHeight}
+          height={imageSkeletonHeight}
           width={skeletonWidth}
         />
         {logoSkeleton && (
@@ -57,6 +73,7 @@ const CardImageCap = React.forwardRef(({
     if (!altSrc || currentTarget.src.endsWith(altSrc)) {
       if (imageKey === 'imageCap') {
         currentTarget.src = cardSrcFallbackImg;
+        setShowImageCap(false);
       } else {
         setShowLogoCap(false);
       }
@@ -69,9 +86,26 @@ const CardImageCap = React.forwardRef(({
 
   return (
     <div className={classNames(className, wrapperClassName)} ref={ref}>
+      <div
+        className={classNames('image-loader', className, { show: showSkeleton })}
+        data-testid="image-loader-wrapper"
+      >
+        <Skeleton
+          containerClassName="pgn__card-image-cap-loader"
+          height={imageSkeletonHeight}
+          width={skeletonWidth}
+        />
+        {logoSkeleton && (
+          <Skeleton
+            containerClassName="pgn__card-logo-cap"
+            height={logoSkeletonHeight}
+            width={logoSkeletonWidth}
+          />
+        )}
+      </div>
       {!!src && (
         <img
-          className={classNames('pgn__card-image-cap', { show: showImageCap })}
+          className={classNames('pgn__card-image-cap', { show: !showSkeleton })}
           src={src}
           onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
           onLoad={() => setShowImageCap(true)}
@@ -81,7 +115,7 @@ const CardImageCap = React.forwardRef(({
       )}
       {!!logoSrc && (
         <img
-          className={classNames('pgn__card-logo-cap', { show: showLogoCap })}
+          className={classNames('pgn__card-logo-cap', { show: !showSkeleton })}
           src={logoSrc}
           onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
           onLoad={() => setShowLogoCap(true)}

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -306,6 +306,16 @@ a.pgn__card {
   .pgn__card-wrapper-image-cap {
     position: relative;
 
+    .image-loader {
+      display: none;
+
+        &.show {
+          display: block;
+          height: 100%;
+        }
+    }
+
+
     &.horizontal {
       max-width: $card-image-horizontal-max-width;
       min-width: $card-image-horizontal-min-width;


### PR DESCRIPTION
## Description

issue with the fact that the markup jumps when loading a picture.
The CardImageCap component will display the Skeleton if Contexts isLoading=true (but this applies to the data itself), if isLoading=false, the img tag with the received data will be rendered, and the actual loading of the image will begin.

Couple solutions:
- show Skeleton not only when data isLoading, but when image is loading also; (here)
- prefetch images before render; [PR(hook)](https://github.com/openedx/paragon/pull/2846)

[Issue#2480](https://github.com/openedx/paragon/issues/2480)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
