### PR TITLE
[BD-46] fix: fixed borders for the Dropzone component

### DIFF
--- a/src/Dropzone/_variables.scss
+++ b/src/Dropzone/_variables.scss
@@ -1,9 +1,9 @@
 $dropzone-padding:                          1.5rem !default;
 $dropzone-border-default:                   1px dashed $gray-500 !default;
-$dropzone-border-hover:                     2px solid $info-300 !default;
-$dropzone-border-focus:                     2px solid $info-300 !default;
-$dropzone-border-active:                    2px solid $primary-500 !default;
-$dropzone-border-error:                     2px solid $danger-300 !default;
+$dropzone-box-shadow-hover:                 inset 0 0 0 2px $info-300 !default;
+$dropzone-box-shadow-focus:                 inset 0 0 0 2px $info-300 !default;
+$dropzone-box-shadow-active:                inset 0 0 0 2px $primary-500 !default;
+$dropzone-box-shadow-error:                 inset 0 0 0 2px $danger-300 !default;
 $dropzone-error-wrapper-color:              $danger-500 !default;
 $dropzone-restriction-msg-font-size:        $x-small-font-size !default;
 $dropzone-restriction-msg-color:            $gray-500 !default;

--- a/src/Dropzone/index.scss
+++ b/src/Dropzone/index.scss
@@ -10,20 +10,27 @@
   box-sizing: border-box;
   cursor: pointer;
 
+  &:hover,
+  &:focus,
+  &.pgn__dropzone-validation-error,
+  &.pgn__dropzone-active {
+    border-color: transparent;
+  }
+
   &:hover {
-    border: $dropzone-border-hover;
+    box-shadow: $dropzone-box-shadow-hover;
   }
 
   &:focus {
-    border: $dropzone-border-focus;
+    box-shadow: $dropzone-box-shadow-focus;
   }
 
   &.pgn__dropzone-validation-error {
-    border: $dropzone-border-error;
+    box-shadow: $dropzone-box-shadow-error;
   }
 
   &.pgn__dropzone-active {
-    border: $dropzone-border-active;
+    box-shadow: $dropzone-box-shadow-active;
   }
 }
 


### PR DESCRIPTION
## Description

- fixed borders for the Dropzone component.

**Issue:** https://github.com/openedx/paragon/issues/2796

### Deploy Preview

[Dropzone component](https://deploy-preview-2855--paragon-openedx.netlify.app/components/dropzone/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
