### PR TITLE
[BD-46] add loading state to CSS variables table

### DIFF
--- a/styles/scss/core/core.scss
+++ b/styles/scss/core/core.scss
@@ -6,6 +6,7 @@
 @import "~bootstrap/scss/reboot";
 @import "typography";
 @import "grid";
+@import "~react-loading-skeleton/dist/skeleton.css";
 @import "~bootstrap/scss/transitions";
 @import "utilities";
 @import "~bootstrap/scss/media";

--- a/www/src/components/ComponentVariablesTable.tsx
+++ b/www/src/components/ComponentVariablesTable.tsx
@@ -1,9 +1,11 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { DataTable } from '~paragon-react';
+import { DataTable, Skeleton } from '~paragon-react';
 import { SettingsContext } from '../context/SettingsContext';
 
+const initialTableData = Array(5).fill({ variableName: <Skeleton />, computedValue: <Skeleton /> });
+
 function ComponentVariablesTable({ rawStylesheet }: ComponentVariablesTableProps) {
-  const [tableData, setTableData] = useState<Array<TableRowData>>([]);
+  const [tableData, setTableData] = useState<Array<TableRowData>>(initialTableData);
   const { settings: { theme } } = useContext(SettingsContext);
 
   useEffect(() => {

--- a/www/src/scss/base.scss
+++ b/www/src/scss/base.scss
@@ -8,6 +8,7 @@
 @import "../components/Search/Search";
 @import "../components/IconsTable";
 @import "../components/exampleComponents/ExamplePropsForm";
+@import "~react-loading-skeleton/dist/skeleton";
 
 :root {
   --pgn-elevation-modal-zindex: 2503;


### PR DESCRIPTION
## Description

Show skeleton in CSS variables table when loading them.

### Deploy Preview

https://deploy-preview-2858--paragon-openedx.netlify.app/components/nav/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
