### PR TITLE
[BD-46] fix: use fixed position for ProductTour Checkpoints's

### DIFF
--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -30,6 +30,7 @@ const Checkpoint = React.forwardRef(({
       // Use the Popper library to translate the Checkpoint to its target's coordinates
       const checkpointPopper = createPopper(targetElement, checkpoint, {
         placement: isMobile ? 'top' : placement,
+        strategy: 'fixed',
         modifiers: [
           {
             name: 'arrow',


### PR DESCRIPTION
## Description

Fixes a bug with `ProductTour`'s positioning.

https://github.com/openedx/paragon/assets/52399399/0fd3385b-fd14-4831-a99e-887e2ff21ab5


### Deploy Preview

https://deploy-preview-2863--paragon-openedx.netlify.app/components/producttour/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
