### PR TITLE
[BD-46] docs: added skeleton display on the documentation site

### DIFF
--- a/www/src/scss/base.scss
+++ b/www/src/scss/base.scss
@@ -8,6 +8,7 @@
 @import "../components/Search/Search";
 @import "../components/IconsTable";
 @import "../components/exampleComponents/ExamplePropsForm";
+@import "~react-loading-skeleton/dist/skeleton";
 
 body {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Description

- added skeleton display on the documentation site.

### Deploy Preview

[Skeleton component](https://deploy-preview-2865--paragon-openedx.netlify.app/components/skeleton/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
