### PR TITLE
[BD-46] refactor: removed semantic release version preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
       run: npm run build-docs
     - name: Coverage
       uses: codecov/codecov-action@v3
-    - name: Extract branch name
-      shell: bash
-      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-      id: extract_branch
+    - name: Preview semantic-release version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+      run: |
+        git checkout $GITHUB_HEAD_REF
+        unset GITHUB_ACTIONS
+        npx semantic-release --dry-run --no-ci --branches=$GITHUB_HEAD_REF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ github.head_ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Setup Nodejs Env
       run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Nodejs
@@ -23,21 +25,18 @@ jobs:
       run: npm ci
     - name: Check Types
       run: npm run type-check
-    - name: Lint
-      run: npm run lint
-    - name: Test
-      run: npm run test
-    - name: Build
-      run: npm run build
-    - name: Build Docs
-      run: npm run build-docs
-    - name: Coverage
-      uses: codecov/codecov-action@v3
+    - name: Extract branch name
+      shell: bash
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+      id: extract_branch
     - name: Preview semantic-release version
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
       run: |
-        git checkout $GITHUB_HEAD_REF
+        echo "$GITHUB_HEAD_REF"
+        echo "${{ github.event.pull_request.head.ref }}"
+        echo "${{ github.event.pull_request.head.repo.full_name }}"
+        git rev-parse --abbrev-ref HEAD
         unset GITHUB_ACTIONS
-        npx semantic-release --dry-run --no-ci --branches=$GITHUB_HEAD_REF
+        npx semantic-release --dry-run --no-ci --branches Peter_Kulko/removed-semantic-realise-version --repositoryUrl https://github.com/raccoongang/paragon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,3 @@ jobs:
       shell: bash
       run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch
-    - name: Preview semantic-release version
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-      run: npx semantic-release --dry-run --branches=${{ steps.extract_branch.outputs.branch}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: ${{ github.head_ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Setup Nodejs Env
       run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Nodejs
@@ -25,18 +23,13 @@ jobs:
       run: npm ci
     - name: Check Types
       run: npm run type-check
-    - name: Extract branch name
-      shell: bash
-      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-      id: extract_branch
-    - name: Preview semantic-release version
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-      run: |
-        echo "$GITHUB_HEAD_REF"
-        echo "${{ github.event.pull_request.head.ref }}"
-        echo "${{ github.event.pull_request.head.repo.full_name }}"
-        git rev-parse --abbrev-ref HEAD
-        unset GITHUB_ACTIONS
-        npx semantic-release --dry-run --no-ci --branches Peter_Kulko/removed-semantic-realise-version --repositoryUrl https://github.com/raccoongang/paragon
+    - name: Lint
+      run: npm run lint
+    - name: Test
+      run: npm run test
+    - name: Build
+      run: npm run build
+    - name: Build Docs
+      run: npm run build-docs
+    - name: Coverage
+      uses: codecov/codecov-action@v3

--- a/src/ActionRow/README.md
+++ b/src/ActionRow/README.md
@@ -37,7 +37,9 @@ ActionRow can also be used with a helper component ``ActionRow.Spacer`` to inser
 
 ```jsx live
 <ActionRow>
-  <Form.Checkbox className="flex-column flex-sm-row">Don't ask me again.</Form.Checkbox>
+  <Form.Checkbox className="flex-column flex-sm-row">
+      Don't ask me again.
+  </Form.Checkbox>
   <ActionRow.Spacer />
   <Button variant="tertiary">
     Cancel

--- a/src/ActionRow/README.md
+++ b/src/ActionRow/README.md
@@ -17,6 +17,7 @@ A layout utility for the common use case of aligning buttons, links or text
 in a row in a control bar or nav.
 
 ActionRow assumes that its last child is the primary action and lays out actions so that the last item is in a primary location. If horizontal, the primary action sits on the right. If stacked, the primary action sits at the top of the stack (this is done via `flex-direction: column-reverse;`).
+
 ## Basic Usage
 
 ```jsx live
@@ -48,7 +49,6 @@ ActionRow can also be used with a helper component ``ActionRow.Spacer`` to inser
 ```
 
 ## Stacked Usage
-
 
 ```jsx live
 <ActionRow isStacked>


### PR DESCRIPTION
## Description

- removed semantic release version preview.

**Issue:** https://github.com/openedx/paragon/issues/2778

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
