### PR TITLE
fix: remove ~ from import of react-loading-skeleton

### DIFF
--- a/styles/scss/core/core.scss
+++ b/styles/scss/core/core.scss
@@ -6,7 +6,7 @@
 @import "~bootstrap/scss/reboot";
 @import "typography";
 @import "grid";
-@import "~react-loading-skeleton/dist/skeleton.css";
+@import "react-loading-skeleton/dist/skeleton.css";
 @import "~bootstrap/scss/transitions";
 @import "utilities";
 @import "~bootstrap/scss/media";


### PR DESCRIPTION
## Description

Since https://github.com/openedx/paragon/pull/2858 added the import of `react-loading-skeleton`'s stylesheet to the core.scss file, the core stylesheet has seemingly been failing to build (i.e., `@import "~react-loading-skeleton/dist/skeleton.css";`):

<img width="1125" alt="image" src="https://github.com/openedx/paragon/assets/2828721/935b471b-ff80-4488-9308-1116503dc045">

Removing the `~` resolves the issue in the build command and Skeleton styles still appear on the docs site. I have not verified the `Skeleton` styles on a consuming MFE running `alpha` yet. 

It also ensures `core` is included in this output of `theme-urls.json`, resolving a bug in https://github.com/openedx/frontend-build/pull/365:

```json
{
  "themeUrls": {
    "defaults": {
      "light": "light"
    },
    "variants": {
      "light": {
        "paths": {
          "default": "./light.css",
          "minified": "./light.min.css"
        }
      }
    },
    "core": {
      "paths": {
        "default": "./core.css",
        "minified": "./core.min.css"
      }
    }
  }
}
```

### Deploy Preview

https://deploy-preview-2912--paragon-openedx.netlify.app/components/skeleton/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
