### PR TITLE
[BD-46] feat: added ability to remove outline-border in SelectableBox component

### DIFF
--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -6,9 +6,9 @@ components:
 - SelectableBoxSet
 categories:
 - Forms
-status: 'New'
+status: 'Stable'
 designStatus: 'Done'
-devStatus: 'In progress'
+devStatus: 'Done'
 notes: |
 ---
 
@@ -26,7 +26,7 @@ As ``Checkbox``
   const allCheeseOptions = ['swiss', 'cheddar', 'pepperjack'];
   const [checkedCheeses, { add, remove, set, clear }] = useCheckboxSetValues(['swiss']);
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     e.target.checked ? add(e.target.value) : remove(e.target.value);
   };
   
@@ -34,35 +34,32 @@ As ``Checkbox``
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
   
   return (
-    <div className="bg-light-200 p-3">
-      <SelectableBox.Set
-        value={checkedCheeses}
+    <SelectableBox.Set
+      className="bg-light-200 p-3"
+      value={checkedCheeses}
+      type={type}
+      onChange={handleChange}
+      name="cheeses"
+      columns={isExtraSmall ? 1 : 2}
+      ariaLabel="cheese selection"
+    >
+      <SelectableBox value="swiss" type={type} aria-label="swiss checkbox">
+        <h3>It is my first SelectableBox</h3>
+        <p>Swiss</p>
+      </SelectableBox>
+      <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="cheddar checkbox">
+        <h3>Cheddar</h3>
+      </SelectableBox>
+      <SelectableBox
+        value="pepperjack"
+        inputHidden={false}
         type={type}
-        onChange={handleChange}
-        name="cheeses"
-        columns={isExtraSmall ? 1 : 2}
-        ariaLabel="cheese selection"
+        isInvalid={isInvalid()}
+        aria-label="pepperjack checkbox"
       >
-        <SelectableBox value="swiss" type={type} aria-label="swiss checkbox">
-          <div>
-            <h3>It is my first SelectableBox</h3>
-            <p>Swiss</p>
-          </div>
-        </SelectableBox>
-        <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="cheddar checkbox">
-          Cheddar
-        </SelectableBox>
-        <SelectableBox
-          value="pepperjack"
-          inputHidden={false}
-          type={type}
-          isInvalid={isInvalid()}
-          aria-label="pepperjack checkbox"
-        >
-          <h3>Pepperjack</h3>
-        </SelectableBox>
-      </SelectableBox.Set>
-    </div>
+        <h3>Pepperjack</h3>
+      </SelectableBox>
+    </SelectableBox.Set>
   );
 }
 ```
@@ -71,31 +68,27 @@ As ``Checkbox``
 
 ```jsx live
 () => {
-  const type = 'radio';
   const [value, setValue] = useState('green');
-  const handleChange = e => setValue(e.target.value);
+  const handleChange = (e) => setValue(e.target.value);
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (
     <SelectableBox.Set
-      type={type}
       value={value}
       onChange={handleChange}
       name="colors"
       columns={isExtraSmall ? 1 : 3}
       ariaLabel="color selection"
     >
-      <SelectableBox value="red" type={type} aria-label="red checkbox">
-        <div>
-          <h3>It is Red color</h3>
-          <p>Select me</p>
-        </div>
+      <SelectableBox value="red" aria-label="red checkbox">
+        <h3>It is Red color</h3>
+        <p>Select me</p>
       </SelectableBox>
-      <SelectableBox value="green" inputHidden={false} type={type} aria-label="green-checkbox">
+      <SelectableBox value="green" inputHidden={false} aria-label="green radio-button">
         <h3>Green</h3>
         <p>Leaves and grass</p>
       </SelectableBox>
-      <SelectableBox value="blue" inputHidden={false} type={type} aria-label="blue checkbox">
+      <SelectableBox value="blue" inputHidden={false} aria-label="blue radio-button">
         <h3>Blue</h3>
         <p>The sky</p>
       </SelectableBox>
@@ -103,6 +96,7 @@ As ``Checkbox``
   );
 }
 ```
+
 ## As Checkbox
 As ``Checkbox`` with ``isIndeterminate``
 
@@ -117,7 +111,7 @@ As ``Checkbox`` with ``isIndeterminate``
   const isIndeterminate = someChecked && !allChecked;
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     e.target.checked ? add(e.target.value) : remove(e.target.value);
   };
 
@@ -127,18 +121,17 @@ As ``Checkbox`` with ``isIndeterminate``
 
   return (
     <>
-      <div className="mb-3">
-        <SelectableBox
-          checked={allChecked}
-          isIndeterminate={isIndeterminate}
-          onClick={handleCheckAllChange}
-          inputHidden={false}
-          type={type}
-          aria-label="all options checkbox"
-        >
-          All the cheese
-        </SelectableBox>
-      </div>
+      <SelectableBox
+        className="mb-3"
+        checked={allChecked}
+        isIndeterminate={isIndeterminate}
+        onClick={handleCheckAllChange}
+        inputHidden={false}
+        type={type}
+        aria-label="all options checkbox"
+      >
+        All the cheese
+      </SelectableBox>
       <SelectableBox.Set
         value={checkedCheeses}
         type={type}
@@ -148,13 +141,11 @@ As ``Checkbox`` with ``isIndeterminate``
         ariaLabel="cheese selection"
       >
         <SelectableBox value="swiss" type={type} aria-label="swiss checkbox">
-          <div>
-            <h3>It is my first SelectableBox</h3>
-            <p>Swiss</p>
-          </div>
+          <h3>It is my first SelectableBox</h3>
+          <p>Swiss</p>
         </SelectableBox>
         <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="cheddar checkbox">
-          Cheddar
+          <h3>Cheddar</h3>
         </SelectableBox>
         <SelectableBox value="pepperjack" inputHidden={false} type={type} aria-label="pepperjack checkbox">
           <h3>Pepperjack</h3>
@@ -173,16 +164,16 @@ As ``Checkbox`` with ``ariaLabelledby``
   const allCheeseOptions = ['swiss', 'cheddar', 'pepperjack'];
   const [checkedCheeses, { add, remove, set, clear }] = useCheckboxSetValues(['swiss']);
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     e.target.checked ? add(e.target.value) : remove(e.target.value);
   };
   
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
   
   return (
-    <div className="bg-light-200 p-3">
+    <Stack className="bg-light-200 p-3">
       <h3 id="cheese selection" className="mb-4">
-        Select your favorite cheese
+        Select your favorite cheese:
       </h3>
       <SelectableBox.Set
         value={checkedCheeses}
@@ -193,22 +184,16 @@ As ``Checkbox`` with ``ariaLabelledby``
         ariaLabelledby="cheese selection"
       >
         <SelectableBox value="swiss" inputHidden={false} type={type} aria-label="swiss checkbox">
-          <h3>
-            Swiss
-          </h3>
+          <h3>Swiss</h3>
         </SelectableBox>
         <SelectableBox value="cheddar" inputHidden={false} type={type} aria-label="cheddar checkbox">
-          <h3>
-            Cheddar
-          </h3>
+          <h3>Cheddar</h3>
         </SelectableBox>
         <SelectableBox value="pepperjack" inputHidden={false} type={type} aria-label="pepperjack checkbox">
-          <h3>
-            Pepperjack
-          </h3>
+          <h3>Pepperjack</h3>
         </SelectableBox>
       </SelectableBox.Set>
-    </div>
+    </Stack>
   );
 }
 ```
@@ -220,7 +205,7 @@ If a component has no input, the border is always rendered in an active state.
 ```jsx live
 () => {
   const [value, setValue] = useState('apples');
-  const handleChange = e => setValue(e.target.value);
+  const handleChange = (e) => setValue(e.target.value);
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   return (

--- a/src/SelectableBox/README.md
+++ b/src/SelectableBox/README.md
@@ -212,3 +212,50 @@ As ``Checkbox`` with ``ariaLabelledby``
   );
 }
 ```
+
+## Without active outline
+The `showActiveBoxState` property only affects `SelectableBox` that have `inputHidden` set to `false`.
+If a component has no input, the border is always rendered in an active state.
+
+```jsx live
+() => {
+  const [value, setValue] = useState('apples');
+  const handleChange = e => setValue(e.target.value);
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
+
+  return (
+    <SelectableBox.Set
+      value={value}
+      onChange={handleChange}
+      name="fruits"
+      columns={isExtraSmall ? 1 : 3}
+      ariaLabel="fruits selection"
+    >
+      <SelectableBox
+        value="apples"
+        inputHidden={false}
+        showActiveBoxState={false}
+        aria-label="apple radio-button"
+      >
+        <h3>Apples</h3>
+      </SelectableBox>
+      <SelectableBox
+        value="oranges"
+        inputHidden={false}
+        showActiveBoxState={false}
+        aria-label="orange radio-button"
+      >
+        <h3>Oranges</h3>
+      </SelectableBox>
+      <SelectableBox
+        value="bananas"
+        inputHidden={false}
+        showActiveBoxState={false}
+        aria-label="banana radio-button"
+      >
+        <h3>Bananas</h3>
+      </SelectableBox>
+    </SelectableBox.Set>
+  );
+}
+```

--- a/src/SelectableBox/index.jsx
+++ b/src/SelectableBox/index.jsx
@@ -22,6 +22,7 @@ const SelectableBox = React.forwardRef(({
   onFocus,
   inputHidden,
   className,
+  showActiveBoxState,
   ...props
 }, ref) => {
   const inputType = getInputType('SelectableBox', type);
@@ -63,7 +64,7 @@ const SelectableBox = React.forwardRef(({
       onClick={() => inputRef.current.click()}
       onFocus={onFocus}
       className={classNames('pgn__selectable_box', className, {
-        'pgn__selectable_box-active': isChecked() || checked,
+        'pgn__selectable_box-active': (!inputHidden && !showActiveBoxState) ? false : isChecked() || checked,
         'pgn__selectable_box-invalid': isInvalid,
       })}
       tabIndex={0}
@@ -97,6 +98,8 @@ SelectableBox.propTypes = {
   isInvalid: PropTypes.bool,
   /** A class that is appended to the base element. */
   className: PropTypes.string,
+  /** Controls the visibility of the active state for the `SelectableBox`. */
+  showActiveBoxState: PropTypes.bool,
 };
 
 SelectableBox.defaultProps = {
@@ -109,6 +112,7 @@ SelectableBox.defaultProps = {
   isIndeterminate: false,
   isInvalid: false,
   className: undefined,
+  showActiveBoxState: true,
 };
 
 SelectableBox.Set = SelectableBoxSet;

--- a/src/SelectableBox/tests/SelectableBox.test.jsx
+++ b/src/SelectableBox/tests/SelectableBox.test.jsx
@@ -100,6 +100,13 @@ describe('<SelectableBox />', () => {
       rerender(<SelectableCheckbox inputHidden={false} />);
       expect(inputElement.getAttribute('hidden')).toBeNull();
     });
+    it('renders with active state and updates to inactive when showActiveBoxState is false', async () => {
+      const { rerender } = render(<SelectableCheckbox inputHidden={false} checked />);
+      const selectableBox = screen.getByRole('button');
+      expect(selectableBox.classList.contains('pgn__selectable_box-active')).toEqual(true);
+      rerender(<SelectableCheckbox inputHidden={false} showActiveBoxState={false} checked />);
+      expect(selectableBox.classList.contains('pgn__selectable_box-active')).toEqual(false);
+    });
   });
   describe('correct interactions', () => {
     it('correct checkbox state change when checked is changed', () => {


### PR DESCRIPTION
## Description

**Issue:** https://github.com/openedx/paragon/issues/2903

### Deploy Preview

[SelectableBox component](https://deploy-preview-2923--paragon-openedx.netlify.app/components/selectablebox/#without-active-outline)

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
