### PR TITLE
[BD-46] docs: fixed large font in code examples

### DIFF
--- a/www/src/components/LayoutGenerator.tsx
+++ b/www/src/components/LayoutGenerator.tsx
@@ -107,22 +107,22 @@ function LayoutGenerator() {
         [`offset-${offset}`]: offset > 0,
       });
       return `
-  <div className="${className}">
-    ${width || 'auto'}
-  </div>
+        <div className="${className}">
+          ${width || 'auto'}
+        </div>
       `;
     });
 
     const rowString = `
-<div className="row">
-${columnsString.join('')}
-</div>
+      <div className="row">
+        ${columnsString.join('')}
+      </div>
     `;
     return rowString;
   };
 
   return (
-    <div>
+    <>
       <p>
         Drag the slider to add or remove columns. Edit the width and offset
         values for each column and see the output below.
@@ -145,9 +145,8 @@ ${columnsString.join('')}
         </Form.Group>
       </div>
       <div className="row">{columns}</div>
-
       <CodeBlock className="language-jsx">{renderMarkupString()}</CodeBlock>
-    </div>
+    </>
   );
 }
 

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -163,7 +163,7 @@ export default function ColorsPage({ data, pageContext }: IColorsPage) {
         <p>Include these colors in scss files in one of two ways:</p>
 
         <h4>Variable name</h4>
-        <code className="d-block mb-4 lead bg-gray-100 p-3">
+        <code className="d-block mb-4 bg-gray-100 p-3">
           {'// $color_name-level '}
           <br />
           $primary-100
@@ -176,7 +176,7 @@ export default function ColorsPage({ data, pageContext }: IColorsPage) {
         </code>
 
         <h4>Mixin (deprecated)</h4>
-        <code className="d-block mb-4 lead bg-gray-100 p-3">
+        <code className="d-block mb-4 bg-gray-100 p-3">
           theme-color($color-name, $variant)
         </code>
 

--- a/www/src/pages/foundations/elevation.jsx
+++ b/www/src/pages/foundations/elevation.jsx
@@ -312,7 +312,7 @@ export default function ElevationPage({ pageContext }) {
         <p>Include these box-shadows colors in scss files in this ways:</p>
 
         <h4>Mixin</h4>
-        <code className="d-block mb-4 lead bg-gray-100 p-3">
+        <code className="d-block mb-4 bg-gray-100 p-3">
           pgn-box-shadow($level, $side)
         </code>
         <div className="pgn-doc__box-shadow--table-wrapper">


### PR DESCRIPTION
## Description

**Issue:** https://github.com/openedx/paragon/issues/2849

### Deploy Preview

[Colors page](https://deploy-preview-2924--paragon-openedx.netlify.app/foundations/colors/)
[Elevation page](https://deploy-preview-2924--paragon-openedx.netlify.app/foundations/elevation/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
