### PR TITLE
[BD-46] fix: fixed ModalDialog.Header sizes

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -26,6 +26,18 @@
     max-height: none;
     margin: $modal-dialog-margin;
   }
+
+  .pgn__modal-header {
+    padding-bottom: calc(#{$modal-inner-padding} / 2);
+  }
+
+  .pgn__modal-body {
+    padding: calc(#{$modal-inner-padding} / 2) $modal-inner-padding;
+
+    &::before {
+      top: calc(#{$modal-inner-padding} / 2 * -1);
+    }
+  }
 }
 
 // Sizes

--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -230,22 +230,6 @@
 
 // Color Variants
 
-.pgn__modal-default {
-  // Default style modals don't have a background on the header which
-  // ends up looking spaced too far away from the body content.
-  .pgn__modal-header {
-    padding-bottom: calc(#{$modal-inner-padding} / 2);
-  }
-
-  .pgn__modal-body {
-    padding: calc(#{$modal-inner-padding} / 2) $modal-inner-padding;
-
-    &::before {
-      top: calc(#{$modal-inner-padding} / 2 * -1);
-    }
-  }
-}
-
 .pgn__modal-dark {
   .pgn__modal-header,
   .pgn__modal-hero {
@@ -255,10 +239,6 @@
     * {
       color: inherit;
     }
-  }
-
-  .pgn__modal-header {
-    border-bottom: solid 1px $light;
   }
 }
 


### PR DESCRIPTION
## Description

**Issue:** https://github.com/openedx/paragon/issues/2850

### Deploy Preview

[MadalDialog component](https://deploy-preview-2925--paragon-openedx.netlify.app/components/modal/modal-dialog/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
