### PR TITLE
fix: rely on Form.Control and controlId in Form.Group

### DIFF
--- a/src/DataTable/filters/TextFilter.jsx
+++ b/src/DataTable/filters/TextFilter.jsx
@@ -1,7 +1,6 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import Form, { FormLabel } from '../../Form';
-import Input from '../../Input';
+import Form from '../../Form';
 import { newId } from '../../utils';
 
 const formatHeaderForLabel = (header) => {

--- a/src/DataTable/filters/TextFilter.jsx
+++ b/src/DataTable/filters/TextFilter.jsx
@@ -23,10 +23,9 @@ function TextFilter({
   const formattedHeader = formatHeaderForLabel(Header);
   const inputText = React.isValidElement(formattedHeader) ? formattedHeader : `Search ${formattedHeader}`;
   return (
-    <Form.Group>
-      <FormLabel id={ariaLabel.current} className="sr-only">{inputText}</FormLabel>
-      <Input
-        aria-labelledby={ariaLabel.current}
+    <Form.Group controlId={ariaLabel.current}>
+      <Form.Label className="sr-only">{inputText}</Form.Label>
+      <Form.Control
         value={filterValue || ''}
         type="text"
         onChange={e => {


### PR DESCRIPTION
## Description

Resolves https://2u-internal.atlassian.net/browse/TNL-11258.

There was a bug where the `FormLabel` in `DataTable`'s `TextFilter` was including a `for` attribute pointing to an ID that does not exist in the DOM (throws an a11y error).

By instead passing `ariaLabel.current` to `<Form.Group>` as its `controlId` prop, we can ensure that all form component within the `Form.Group` rely on a consistent ID. However, previously, we were using the deprecated `Input` instead of `Form.Control`, so the appropriate `id` was not automatically applied to the input field in the DOM.

Resolution:
* Pass `controlId` to `Form.Group`
* Replace `FormLabel` with `Form.Label`.
* Replace `Input` with `Form.Control`.

In the following image, not that the `<label>`'s `for` attribute now refers to the input with the appropriate, identical `id`:

<img width="1116" alt="image" src="https://github.com/openedx/paragon/assets/2828721/6c8192ce-b894-436c-8a90-90710878ae9d">

### Deploy Preview

https://deploy-preview-2931--paragon-openedx.netlify.app/components/datatable/#frontend-filtering-and-sorting

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
