### PR TITLE
fix: use `any` in `getDependentProjectUsages` to work around type-check errors

### DIFF
--- a/www/src/utils/getDependentProjectsUsages.tsx
+++ b/www/src/utils/getDependentProjectsUsages.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore
 import dependentProjectsAnalysis from '../../../dependent-usage.json'; // eslint-disable-line
 import getGithubProjectUrl from './getGithubProjectUrl';
-import { IDependentProjectsUsages, IDependentUsage, IUsage } from '../types/types';
+import { IDependentUsage, IUsage } from '../types/types';
 
 const {
   projectUsages: dependentProjectsUsages,
@@ -10,7 +10,7 @@ const {
 export default function getDependentProjectsUsages() {
   const dependentProjects: IDependentUsage[] = [];
 
-  dependentProjectsUsages.forEach((project: IDependentProjectsUsages) => {
+  dependentProjectsUsages.forEach((project: any) => {
     dependentProjects.push({
       ...project,
       repositoryUrl: getGithubProjectUrl(project.repository),


### PR DESCRIPTION
## Description

As of https://github.com/openedx/paragon/commit/e6967cf63ed1b15dc0c0d5f236b867743afe73a7, the "Check Types" step of the CI has been failing. This is currently a problem for every open PR. I tried digging into the problem and seeing if I could fix the type definitions to get past the error, but didn't come to a good solution. I posted about what I learned in slack [here](https://openedx.slack.com/archives/C02NR285KV4/p1702662593338799) 

I would prefer to fix this in a way that doesn't rely on using `any`, but I figured it's better to have *some* way to get the error to disappear PR'd than nothing.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
