### PR TITLE
fix: Dropzone className prop

### DIFF
--- a/src/Dropzone/index.jsx
+++ b/src/Dropzone/index.jsx
@@ -178,8 +178,7 @@ function Dropzone({
     <div
       data-testid="dropzone-container"
       {...getRootProps({
-        className: classNames('pgn__dropzone', {
-          className,
+        className: classNames('pgn__dropzone', className, {
           'pgn__dropzone-validation-error': isMultipleDragged || errors.length > 0 || isDragReject,
           'pgn__dropzone-active': isDragActive && !isDragReject,
         }),


### PR DESCRIPTION
## Description

Minor fix related to the `className` props of the `Dropzone` component.

When passed `className="some-class"`, the current implementation adds a property `{ className: 'some-class', ...}` to the object passed in the `classNames` function.

This results in the rendered object having the literal `className` as a CSS class, not the actual `some-class`.

![image](https://github.com/openedx/paragon/assets/849463/0441da6b-e792-482d-990b-9caa731117fb)

### More info
Closes:
- #2954

### Deploy Preview

N/A

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
