### PR TITLE
chore: enforce correct TypeScript types for dependent-usage.json object

### DIFF
--- a/www/src/types/types.ts
+++ b/www/src/types/types.ts
@@ -9,7 +9,7 @@ export interface IUsage {
   filePath: string,
   line: number,
   column: number,
-  version: string,
+  index: number,
 }
 
 export interface IComponentUsageData {
@@ -24,14 +24,14 @@ export interface IComponentUsageData {
 export interface IDependentProjectsUsages extends Omit<IDependentUsage, 'count'> {
   version: string,
   name: string,
-  repository: { type: string, url: string },
+  repository: { type: string, url: string } | string,
   folderName: string,
 }
 
 export interface IDependentUsage {
   version?: string,
   name?: string,
-  repository?: { type: string, url: string },
+  repository?: { type: string, url: string } | string,
   repositoryUrl?: string,
   count: number,
   folderName?: string,

--- a/www/src/utils/getDependentProjectsUsages.tsx
+++ b/www/src/utils/getDependentProjectsUsages.tsx
@@ -3,9 +3,8 @@ import dependentProjectsAnalysis from '../../../dependent-usage.json'; // eslint
 import getGithubProjectUrl from './getGithubProjectUrl';
 import { IDependentProjectsUsages, IDependentUsage, IUsage } from '../types/types';
 
-const {
-  projectUsages: dependentProjectsUsages,
-} = dependentProjectsAnalysis;
+const { projectUsages } = dependentProjectsAnalysis;
+const dependentProjectsUsages = projectUsages as unknown as IDependentProjectsUsages[];
 
 export default function getDependentProjectsUsages() {
   const dependentProjects: IDependentUsage[] = [];


### PR DESCRIPTION
## Description

Fixes a bug with types for dependent-usage.json file, see rationale for the solution in [this comment](https://github.com/openedx/paragon/pull/2941#issuecomment-1862280442)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
