### PR TITLE
[BD-46] fix: hyperlink alignment

### DIFF
--- a/src/Hyperlink/index.scss
+++ b/src/Hyperlink/index.scss
@@ -1,9 +1,9 @@
 .pgn__hyperlink {
+  display: inline-flex;
+  align-items: center;
   text-align: start;
 
   &__external-icon {
-    display: inline-block;
-    vertical-align: middle;
     margin-inline-start: map_get($spacers, 2);
   }
 }


### PR DESCRIPTION
## Description

Fix hyperlink alignment
[Issue2398](https://github.com/openedx/paragon/issues/2398)

### Deploy Preview

[deploy-preview-2971](https://deploy-preview-2971--paragon-openedx.netlify.app/components/hyperlink/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
