### PR TITLE
fix: unrecognized prop warning in form autosuggest

### DIFF
--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -92,7 +92,7 @@ const FormAutosuggest = forwardRef(
 
         return React.cloneElement(child, {
           ...rest,
-          childChildren,
+          children: childChildren,
           'data-value': childChildren,
           onClick: (e) => handleItemSelect(e, onClick),
           id: menuItemId,


### PR DESCRIPTION
## Description

We encountered an issue where the `childChildren` prop passed to the `MenuItem` component was flagged as an unrecognized prop to DOM (locally), leading to a console warning. Simultaneously, this warning caused the occurrence of duplicate API calls within our MFE (frontend-app-authn).

**Resolution:** We renamed the `childChildren` to `childchildren` and the warning stopped appearing and the duplicate API calls issue was resolved.

We are still unsure why we were having duplicate API calls due to this warning. Maybe React was trying to re-render due to invalid props? But we made sure that there was no issue with our implementation and it was due to the unrecognized prop. But we would like to understand the actual reason behind this if possible.

Console Warning screenshot.
<img width="635" alt="Screenshot 2024-02-13 at 12 15 43 PM" src="https://github.com/openedx/paragon/assets/52817156/847e046d-4009-4d98-b0c4-92ac3ed060ab">

### Before
In this video, we can notice that we are getting single API calls until we click on the `FormAutoSuggest` field. On clicking the field, we get the console warning and all our API calls start firing twice. 

https://github.com/openedx/paragon/assets/52817156/5a5fc154-64d7-4177-a658-90f97c4f0bf3

### After
In this video, (after the fix) we can see that we are neither getting console warnings nor duplicate API calls. All the API calls are being fired once.

https://github.com/openedx/paragon/assets/52817156/bd6dd6f3-3c73-4570-b192-2138e20d3984

### Deploy Preview

https://deploy-preview-3003--paragon-openedx.netlify.app/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
