### PR TITLE
build: ignore npm scripts when installing dependencies in dependent analyzer workflow

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -2,8 +2,8 @@ name: Analyze Dependents
 
 on:
   workflow_dispatch:
-  # schedule:
-  # - cron: "0 14 * * *" # daily at 10am EST (Github Actions works with UTC)
+   schedule:
+   - cron: "0 14 * * *" # daily at 10am EST (Github Actions works with UTC)
 
 jobs:
   # clones known dependent Git repositories from Open edX
@@ -227,7 +227,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VER }}
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --ignore-scripts
       working-directory: dependent-usage-analyzer
     - name: Download dependent project checkouts
       uses: actions/download-artifact@v2

--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -227,7 +227,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VER }}
     - name: Install dependencies
-      run: npm ci --ignore-scripts
+      run: npm ci
       working-directory: dependent-usage-analyzer
     - name: Download dependent project checkouts
       uses: actions/download-artifact@v2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
-        "husky": "^8.0.1",
+        "husky": "^9.0.11",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^28.1.3",
         "jest-cli": "^28.1.2",
@@ -21145,14 +21145,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "build-types": "tsc --emitDeclarationOnly",
     "playroom:start": "npm run playroom:start --workspace=www",
     "playroom:build": "npm run playroom:build --workspace=www",
-    "prepare": "husky install"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
@@ -123,7 +123,7 @@
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
-    "husky": "^8.0.1",
+    "husky": "^9.0.11",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^28.1.3",
     "jest-cli": "^28.1.2",


### PR DESCRIPTION
## Description

Fixes #3000 which was caused by adding `prepare` life cycle script to the root package.json file which installs husky. It works fine if you run the script in the root directory but it fails if you run it from somewhere else (e.g. `dependent-usage-analyzer` directory from which `npm ci` is run during the workflow which I assume triggers `npm run prepare` of root package.json because we use workspaces). The reason is that husky is configured to be run from the root directory.

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
