### PR TITLE
fix: display of menu items with checkboxes

### DIFF
--- a/src/Menu/index.scss
+++ b/src/Menu/index.scss
@@ -74,6 +74,16 @@
         margin-left: calc(#{$menu-item-icon-margin-left} * -1);
       }
     }
+
+    &.pgn__form-checkbox {
+      > input {
+        flex-shrink: 0;  // When the menu item text is long, don't squish the checkbox, if present
+      }
+
+      > div {
+        overflow: hidden;  // Ensure text gets truncated properly if needed
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description

1. Go to the [`MenuItem` with form example](https://paragon-openedx.netlify.app/components/menu/#with-form)
2. Change the last two menu items' code to:
    ```tsx
          <MenuItem as={Form.Checkbox} value="green">Green with super long item text that doesn't get truncated </MenuItem>
          <MenuItem value="yellow">Yellow with super long text that does get truncated</MenuItem>
    ```

| ❌ Before this fix | ✅ After this fix |
|-|-|
| ![Screenshot 2024-03-25 at 1 57 32 PM](https://github.com/openedx/paragon/assets/945577/0f5b19f3-9eea-4508-98eb-80d9904753d7) | ![Screenshot 2024-03-25 at 1 57 52 PM](https://github.com/openedx/paragon/assets/945577/71d4248c-c880-4896-b0c9-f2322d623a0d) |

### Deploy Preview

You can test the fix here: https://deploy-preview-3019--paragon-openedx.netlify.app/components/menu/#with-form

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
