### PR TITLE
fix: Wrong propTypes for SearchFieldAdvanced.icons

### DIFF
--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -170,8 +170,8 @@ SearchFieldAdvanced.propTypes = {
   value: PropTypes.string,
   /** specifies the icon element(s) to use for the clear and submit buttons. */
   icons: PropTypes.shape({
-    submit: PropTypes.element.isRequired,
-    clear: PropTypes.element,
+    submit: PropTypes.elementType.isRequired,
+    clear: PropTypes.elementType,
   }),
   /** specifies the aria-label attribute on the form element. This is useful if you use the `SearchField` component
    * more than once on a page. */

--- a/src/SearchField/index.jsx
+++ b/src/SearchField/index.jsx
@@ -132,8 +132,8 @@ SearchField.propTypes = {
    * ```
    */
   icons: PropTypes.shape({
-    submit: PropTypes.element.isRequired,
-    clear: PropTypes.element,
+    submit: PropTypes.elementType.isRequired,
+    clear: PropTypes.elementType,
   }),
   /**
    * Specifies the aria-label attribute on the form element.


### PR DESCRIPTION
## Description

Bug: Merely using the default [`<SearchField />`](https://paragon-openedx.netlify.app/components/searchfield/) in an MFE without setting the optional `icons` property results in the following console warning:

```
 console.error
    Warning: Failed prop type: Invalid prop `icons.submit` of type `function` supplied to `SearchFieldAdvanced`, expected a single ReactElement.
        at SearchFieldAdvanced (frontend-app-course-authoring/node_modules/@openedx/paragon/src/SearchField/SearchFieldAdvanced.jsx:18:5)
        at SearchField (frontend-app-course-authoring/node_modules/@openedx/paragon/src/SearchField/index.jsx:28:5)
```

From [the `SearchField` docs](https://paragon-openedx.netlify.app/components/searchfield/), you can easily verify that the `icons` prop takes `elementType` values, not `element` values by trying these two:

✅ Works: pass an element type (or leave `icons` unspecified)
```tsx
<SearchField
  onSubmit={value => console.log(`search submitted: ${value}`)}
  icons={{submit: Search}}
/>
```

🛑 Doesn't work: pass an actual `element` :

```tsx
<SearchField
  onSubmit={value => console.log(`search submitted: ${value}`)}
  icons={{submit: <Search />}}
/>
```

I don't know why this warning isn't showing up on the docs site console. Perhaps warnings are suppressed there?

### Deploy Preview

This doesn't change the implementation, just the runtime console warning.

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
