### PR TITLE
fix: ensure esc key does not close modals that are blocking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Include a direct link to your changes in this PR's deploy preview here (e.g., a 
 * [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
 * [ ] Were your changes tested in the `example` app?
 * [ ] Is there adequate test coverage for your changes?
-* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.
+* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.
 
 ## Post-merge Checklist
 

--- a/src/Modal/AlertModal.jsx
+++ b/src/Modal/AlertModal.jsx
@@ -41,7 +41,7 @@ AlertModal.propTypes = {
   title: PropTypes.string.isRequired,
   /** Is the modal dialog open or closed */
   isOpen: PropTypes.bool,
-  /** Prevent clicking on the backdrop to close the modal */
+  /** Prevent clicking on the backdrop or pressing Esc to close the modal */
   isBlocking: PropTypes.bool,
   /** Specifies whether the dialog box should contain 'x' icon button in the top right */
   hasCloseButton: PropTypes.bool,

--- a/src/Modal/MarketingModal.jsx
+++ b/src/Modal/MarketingModal.jsx
@@ -36,7 +36,7 @@ MarketingModal.propTypes = {
   title: PropTypes.string.isRequired,
   /** Is the modal dialog open or closed */
   isOpen: PropTypes.bool,
-  /** Prevent clicking on the backdrop to close the modal */
+  /** Prevent clicking on the backdrop or pressing Esc to close the modal */
   isBlocking: PropTypes.bool,
   /** The close 'x' icon button in the top right corner */
   hasCloseButton: PropTypes.bool,

--- a/src/Modal/ModalDialog.jsx
+++ b/src/Modal/ModalDialog.jsx
@@ -115,7 +115,7 @@ ModalDialog.propTypes = {
    */
   isFullscreenOnMobile: PropTypes.bool,
   /**
-   * Prevent clicking on the backdrop to close the modal
+   * Prevent clicking on the backdrop or pressing Esc to close the modal
    */
   isBlocking: PropTypes.bool,
   /**

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -96,7 +96,7 @@ ModalLayer.propTypes = {
   onClose: PropTypes.func.isRequired,
   /** Is the modal dialog open or closed */
   isOpen: PropTypes.bool.isRequired,
-  /** Prevent clicking on the backdrop to close the modal */
+  /** Prevent clicking on the backdrop or pressing Esc to close the modal */
   isBlocking: PropTypes.bool,
   /** Specifies the z-index of the modal */
   zIndex: PropTypes.number,

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -63,7 +63,7 @@ function ModalLayer({
     return null;
   }
 
-  const handleClose = !isBlocking ? onClose : null;
+  const handleClose = isBlocking ? null : onClose;
 
   return (
     <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -63,7 +63,7 @@ function ModalLayer({
     return null;
   }
 
-  const onClickOutside = !isBlocking ? onClose : null;
+  const handleClose = !isBlocking ? onClose : null;
 
   return (
     <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>
@@ -72,15 +72,15 @@ function ModalLayer({
           allowPinchZoom
           scrollLock
           enabled={isOpen}
-          onEscapeKey={onClose}
-          onClickOutside={onClickOutside}
+          onEscapeKey={handleClose}
+          onClickOutside={handleClose}
           className={classNames(
             'pgn__modal-layer',
             zIndex ? `zindex-${zIndex}` : '',
           )}
         >
           <ModalContentContainer>
-            <ModalBackdrop onClick={onClickOutside} />
+            <ModalBackdrop onClick={handleClose} />
             {children}
           </ModalContentContainer>
         </FocusOn>

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -76,7 +76,7 @@ ModalPopup.propTypes = {
   onClose: PropTypes.func.isRequired,
   /** Is the modal dialog open or closed */
   isOpen: PropTypes.bool.isRequired,
-  /** Prevent clicking on the backdrop to close the modal */
+  /** Prevent clicking on the backdrop or pressing Esc to close the modal */
   isBlocking: PropTypes.bool,
   /** Insert modal into a different location in the DOM */
   withPortal: PropTypes.bool,


### PR DESCRIPTION
## Description

The Paragon modal components (e.g., `AlertModal`) generally rely on the underlying `ModalDialog` component and it's optional props such as `isBlocking`. The intent for `isBlocking` should prevent the modal from being dismissed for use cases where there is a required action to be taken within the modal. However, `isBlocking` only prevents clicking of the modal backdrop from dismissing modal; users may still press the `Escape` key to dismiss the modal, despite the intent to have the modal be blocking.

This PR ensures the `Escape` behavior when `isBlocking` is passed to modal components such as `AlertModal` follows the same behavior as the modal backdrop; that is, when a modal `isBlocking`, neither clicking the modal backdrop _or_ pressing `Escape` key should dismiss the modal.

### Deploy Preview

https://deploy-preview-3033--paragon-openedx.netlify.app/components/modal/alert-modal/

**How to test:**
* On the "Basic usage" on the linked deploy preview, add the `isBlocking` prop to the `AlertModal` component.
* Observe that neither clicking on the modal backdrop _or_ pressing `Escape` key dismisses the blocking modal.

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
