### PR TITLE
feat: Add support for tokens in toml files

### DIFF
--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -31,8 +31,13 @@ async function buildTokensCommand(commandArgs) {
   } = minimist(commandArgs, { alias, default: defaultParams, boolean: 'source-tokens-only' });
 
   const coreConfig = {
-    include: [path.resolve(__dirname, '../tokens/src/core/**/*.json')],
-    source: tokensSource ? [`${tokensSource}/core/**/*.json`] : [],
+    include: [
+      path.resolve(__dirname, '../tokens/src/core/**/*.json'),
+      path.resolve(__dirname, '../tokens/src/core/**/*.toml'),
+    ],
+    source: tokensSource
+      ? [`${tokensSource}/core/**/*.json`, `${tokensSource}/core/**/*.toml`]
+      : [],
     platforms: {
       css: {
         prefix: 'pgn',
@@ -67,8 +72,17 @@ async function buildTokensCommand(commandArgs) {
 
   const getStyleDictionaryConfig = (themeVariant) => ({
     ...coreConfig,
-    include: [...coreConfig.include, path.resolve(__dirname, `../tokens/src/themes/${themeVariant}/**/*.json`)],
-    source: tokensSource ? [`${tokensSource}/themes/${themeVariant}/**/*.json`] : [],
+    include: [
+      ...coreConfig.include,
+      path.resolve(__dirname, `../tokens/src/themes/${themeVariant}/**/*.json`),
+      path.resolve(__dirname, `../tokens/src/themes/${themeVariant}/**/*.toml`),
+    ],
+    source: tokensSource
+      ? [
+        `${tokensSource}/themes/${themeVariant}/**/*.json`,
+        `${tokensSource}/themes/${themeVariant}/**/*.toml`,
+      ]
+      : [],
     transform: {
       'color/sass-color-functions': {
         ...StyleDictionary.transform['color/sass-color-functions'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "file-selector": "^0.6.0",
         "glob": "^8.0.3",
         "inquirer": "^8.2.5",
+        "js-toml": "^1.0.0",
         "lodash.uniqby": "^4.7.0",
         "log-update": "^4.0.0",
         "mailto-link": "^2.0.0",
@@ -2211,6 +2212,40 @@
       "bin": {
         "partytown": "bin/partytown.cjs"
       }
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "dependencies": {
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "dependencies": {
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -12957,6 +12992,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.0.3",
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/regexp-to-ast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "@chevrotain/utils": "11.0.3",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/child_process": {
@@ -24576,6 +24624,15 @@
       "version": "4.0.0",
       "license": "MIT"
     },
+    "node_modules/js-toml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/js-toml/-/js-toml-1.0.0.tgz",
+      "integrity": "sha512-G757004huuG5Cjg8KUoVTS4zNRR4449KG8kjtFQS0yyQnceq3KfxcArThcqUV2cwdpd0C9I+e1WciK3Xm4cWJw==",
+      "dependencies": {
+        "chevrotain": "^11.0.3",
+        "xregexp": "^5.1.1"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "license": "MIT",
@@ -24958,7 +25015,6 @@
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.assignin": {
@@ -39031,6 +39087,14 @@
       "version": "2.0.0",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xregexp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.1.tgz",
+      "integrity": "sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.16.5"
       }
     },
     "node_modules/xss": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "file-selector": "^0.6.0",
     "glob": "^8.0.3",
     "inquirer": "^8.2.5",
+    "js-toml": "^1.0.0",
     "lodash.uniqby": "^4.7.0",
     "log-update": "^4.0.0",
     "mailto-link": "^2.0.0",

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -1,6 +1,7 @@
 /**
  * This module creates and exports custom StyleDictionary instance for Paragon.
  */
+const toml = require('js-toml');
 const StyleDictionary = require('style-dictionary');
 const chroma = require('chroma-js');
 const { colorYiq, darken, lighten } = require('./sass-helpers');
@@ -214,6 +215,11 @@ StyleDictionary.registerFileHeader({
 StyleDictionary.registerFilter({
   name: 'isSource',
   matcher: token => token?.isSource === true,
+});
+
+StyleDictionary.registerParser({
+  pattern: /\.toml$/,
+  parse: ({ contents }) => toml.load(contents),
 });
 
 module.exports = {


### PR DESCRIPTION
## Description


Currently, the only way to specify tokens is using JSON, however there are some unique benefits to using the TOML format for design tokens. TOML is a format for configuration files that resembles the `ini` but can support richer nested data. It has been embraced as the default format by Python for `pyproject` files and by Rust for it's `Cargo.toml` files. 

There are a couple of reasons why it's particularly good for the usecase of design tokens. 

1. It has a simpler way of representing deeply nested data

Design tokens are deeply nested and in JSON it can get a bit clumsy to represent this. To take a particularly deeply nested value, we have `other.content.form.control.checkbox.indicator.icon-checked.base` which is 8 levels deep. The JSON for such deeply nested values can be pretty verbose and can be hard to follow. In comparison with TOML this is just:

```toml
[other.content.form.control.checkbox.indicator.icon-checked.base]
value = "..."
type = "..."
source = "..."
```

The above dot notiation very easily maps to the final variable name, and you can quickly do a search for such nested data without checking the full heirarchy.

2. The order of nested TOML documents can be arbitrary

In the above example, if you wanted to add value for `other.content.form` you can simply do that at any point 
in the document. Unlike JSON where you'd need to have it nested in the correct hierarchy. 

3. Changes in nesting can be done much quicker

If in the above example, you wanted to change from the `checkbox.indicator` to `checkbox-indicator` or move from `other.content.form` to `other.form` only for this value without affecting other values, you can do that with just a single change without impacting any otherpart of the hierarchy. With JSON if you rename an attribute that automatically affects all the values in that heirarchy, so you'd have to move this bit of the document to a new attribute. TOML really simplifies refactoring.

4. TOML has native support for comments

While design tokens can support comments via field, this is part of the document and will be processed as such. This is not a huge issue, but still a nice to have. 

NOTE: This PR merely adds a way to support TOML for design tokens. It is not a recommendation to switch the entirety of the token system to use toml instead of JSON.

While doing some work on design tokens I had to deal with a lot of cases where I'd expressed the hierarchy of values incorrectly and it was a pain to make the changes. I found this much easier with toml so began converting JSON to TOML to make the changes and then convert back. I figured it would be nice to simply add support to Paragon itself since it was a small enough change. 

### Testing

You can test this by creating a minimal setup for design tokens. 

- Create a new directory with the following directory structure inside it: themes/light . (e.g. /tmp/toml-tokens/
- Inside the `light` folder create a `toml` file with some design tokens, for example:
  ```toml
   [color.testing]
   value = "#123456"
  ```
- Check out this version of Paragon, install the dependencies and run:  `./bin/paragon-scripts.js build-tokens --source  /tmp/toml-tokens/ --build-dir  /tmp/toml-tokens/build --source-tokens-only`
- Check the output `build` directory in the folder and you'll see a file called `themes/light/variables.css` that has a css variable called `--pgn-color-testing` with the above value. 

### Deploy Preview

NA

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
