### PR TITLE
refactor: [BD-46] Component generator refactoring

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+component-generator/**
+example/**

--- a/README.md
+++ b/README.md
@@ -316,8 +316,7 @@ If your component requires additional styling (which most likely is the case), e
 component's directory `/src/MyComponent/index.scss` which by default contains an empty class for your component.
 
 If you wish to use CSS variables (which is the preferred way of styling the components since values can be
-easily overridden and customized by the consumers of Paragon), create specific design tokens in `tokens` directory (in the `core` and `themes` directories) and then generate (`npm run build-tokens`) CSS variables for your component.
-This way the variables will also get automatically picked up by documentation site and displayed on your component's page.
+easily overridden and customized by the consumers of Paragon), you can do so by utilizing [design tokens](/tokens).
 
 **Please note that you need to follow [Paragon's CSS styling conventions](docs/decisions/0012-css-styling-conventions).**
 

--- a/README.md
+++ b/README.md
@@ -274,8 +274,7 @@ This will create a directory in `/src/` that will contain templates for all nece
 MyComponent
 ├── index.jsx
 ├── README.md
-├── MyComponent.scss
-├── _variables.scss
+├── index.scss
 └── MyComponent.test.jsx
 ```
 
@@ -314,10 +313,10 @@ export default MyComponent;
 ##### 4. (Optional) Add styles to your component.
 
 If your component requires additional styling (which most likely is the case), edit created SCSS style sheet in your
-component's directory `/src/MyComponent/MyComponent.scss` which by default contains an empty class for your component.
+component's directory `/src/MyComponent/index.scss` which by default contains an empty class for your component.
 
-If you wish to use SASS variables (which is the preferred way of styling the components since values can be
-easily overridden and customized by the consumers of Paragon), add them in `/src/MyComponent/_variables.scss` (this file should contain all variables specific to your component).
+If you wish to use CSS variables (which is the preferred way of styling the components since values can be
+easily overridden and customized by the consumers of Paragon), create specific design tokens in `tokens` directory (in the `core` and `themes` directories) and then generate (`npm run build-tokens`) CSS variables for your component.
 This way the variables will also get automatically picked up by documentation site and displayed on your component's page.
 
 **Please note that you need to follow [Paragon's CSS styling conventions](docs/decisions/0012-css-styling-conventions).**

--- a/component-generator/constants.js
+++ b/component-generator/constants.js
@@ -15,10 +15,6 @@ exports.COMPONENT_FILES = [
     templatePath: path.resolve(__dirname, './templates/index.jsx'),
   },
   {
-    targetPath: path.resolve(__dirname, '../src/componentName/_variables.scss'),
-    templatePath: path.resolve(__dirname, './templates/_variables.scss'),
-  },
-  {
     targetPath: path.resolve(__dirname, '../src/componentName/README.md'),
     templatePath: path.resolve(__dirname, './templates/README.md'),
   },

--- a/component-generator/templates/_variables.scss
+++ b/component-generator/templates/_variables.scss
@@ -1,2 +1,0 @@
-// Put SASS variables related to your component here,
-// you can safely delete this file if you do not intend to use any variables

--- a/component-generator/templates/index.scss
+++ b/component-generator/templates/index.scss
@@ -1,6 +1,5 @@
-// Put styles related to your component here
-
-@import "variables";
+// Put design tokens in `tokens` directory if you need to create variables related to your component,
+// you can safely delete this file if you do not intend to use any styles
 
 .pgn__css-class {
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -1,7 +1,6 @@
 # Design Tokens
 
-This module is responsible for handling design tokens in Paragon, for rationale behind design tokens see [Scaling Paragon's styles architecture with design tokens](https://openedx.atlassian.net/wiki/spaces/BPL/pages/3630923811/Scaling+Paragon+s+styles+architecture+with+design+tokens)
-and relevant ADR(TODO: add link when we merge an ADR). 
+This module is responsible for handling design tokens in Paragon, for rationale behind design tokens see [Scaling Paragon's styles architecture with design tokens](https://openedx.atlassian.net/wiki/spaces/BPL/pages/3630923811/Scaling+Paragon+s+styles+architecture+with+design+tokens). 
 
 ## Overview
 

--- a/www/src/pages/tools/component-generator.mdx
+++ b/www/src/pages/tools/component-generator.mdx
@@ -72,8 +72,7 @@ If your component requires additional styling (which most likely is the case), e
 component's directory `/src/MyComponent/index.scss` which by default contains an empty class for your component.
 
 If you wish to use CSS variables (which is the preferred way of styling the components since values can be
-easily overridden and customized by the consumers of Paragon), create specific design tokens in `tokens` directory (in the `core` and `themes` directories) and then generate (`npm run build-tokens`) CSS variables for your component.
-This way the variables will also get automatically picked up by documentation site and displayed on your component's page.
+easily overridden and customized by the consumers of Paragon), you can do so by utilizing [design tokens](/tokens).
 
 **Please note that you need to follow [Paragon's CSS styling conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions).**
 

--- a/www/src/pages/tools/component-generator.mdx
+++ b/www/src/pages/tools/component-generator.mdx
@@ -30,8 +30,7 @@ This will create a directory in `/src/` that will contain templates for all nece
 MyComponent
 ├── index.jsx
 ├── README.md
-├── MyComponent.scss
-├── _variables.scss
+├── index.scss
 └── MyComponent.test.jsx
 ```
 
@@ -70,10 +69,10 @@ export default MyComponent;
 ## 4. (Optional) Add styles to your component.
 
 If your component requires additional styling (which most likely is the case), edit created SCSS style sheet in your
-component's directory `/src/MyComponent/MyComponent.scss` which by default contains an empty class for your component.
+component's directory `/src/MyComponent/index.scss` which by default contains an empty class for your component.
 
-If you wish to use SASS variables (which is the preferred way of styling the components since values can be
-easily overridden and customized by the consumers of Paragon), add them in `/src/MyComponent/_variables.scss` (this file should contain all variables specific to your component).
+If you wish to use CSS variables (which is the preferred way of styling the components since values can be
+easily overridden and customized by the consumers of Paragon), create specific design tokens in `tokens` directory (in the `core` and `themes` directories) and then generate (`npm run build-tokens`) CSS variables for your component.
 This way the variables will also get automatically picked up by documentation site and displayed on your component's page.
 
 **Please note that you need to follow [Paragon's CSS styling conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions).**


### PR DESCRIPTION
## Description

Since the file structure of Paragon components has changed, the component generator was refactored
- File creation `_variables.scss` has been removed from the template
- Updated documentation
- the `component-generator` directory was excluded from `stylelint` checking

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
