### PR TITLE
feat: add ability to disable SelectMenu

### DIFF
--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -15,6 +15,7 @@ function SelectMenu({
   children,
   className,
   variant,
+  disabled,
   ...props
 }) {
   const [triggerTarget, setTriggerTarget] = useState(null);
@@ -89,6 +90,7 @@ function SelectMenu({
         variant={variant}
         iconAfter={ExpandMore}
         onClick={open}
+        disabled={disabled}
       >
         {selected !== undefined && children[selected] ? children[selected].props.children : defaultMessage}
       </Button>
@@ -131,12 +133,15 @@ SelectMenu.propTypes = {
   className: PropTypes.string,
   /** Specifies variant to use. */
   variant: PropTypes.string,
+  /** Specifies if the `SelectMenu` is disabled. */
+  disabled: PropTypes.bool,
 };
 
 SelectMenu.defaultProps = {
   defaultMessage: SELECT_MENU_DEFAULT_MESSAGE,
   className: undefined,
   variant: 'outline-primary',
+  disabled: false,
 };
 
 const SelectMenuWithDeprecatedProp = withDeprecatedProps(SelectMenu, 'SelectMenu', {

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -58,6 +58,12 @@ describe('correct rendering', () => {
     const button = screen.getByRole('button');
     expect(button).toHaveClass('btn-brand');
   });
+
+  it('renders as disabled', () => {
+    render(DefaultSelectMenu({ disabled: true }));
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
 });
 
 describe('mouse behavior & keyboard behavior', () => {

--- a/src/Menu/select-menu.md
+++ b/src/Menu/select-menu.md
@@ -56,3 +56,11 @@ The ``Modal`` brings focus to the first menu element upon the click of the trigg
   <MenuItem>M. Hortens</MenuItem>
 </SelectMenu>
 ```
+
+## Disabled 
+
+```jsx live
+<SelectMenu disabled>
+  <MenuItem>A Menu Item</MenuItem>
+</SelectMenu>
+```


### PR DESCRIPTION
## Description

I noticed that passing `disabled` as a prop to the `SelectMenu` component in a PR that I was working was not having the desired effect. That is because the `Button` component in the `SelectMenu` component is wrapped by a [div that is receiving the additional props](https://github.com/openedx/paragon/blob/cecbc9f0ac0e3c486dd37e28832b8f438711af63/src/Menu/SelectMenu.jsx#L84). 

I opted to add an additional `disabled` prop to the `SelectMenu` component with a default value of `false`. This additional prop is then used to determine whether or not the button is disabled or not.

### Deploy Preview

https://deploy-preview-3138--paragon-openedx.netlify.app/components/menu/select-menu/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
