### PR TITLE
Remove reference to deprecated frontend-lib-content-components

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -160,11 +160,6 @@ jobs:
       with:
         repository: openedx/frontend-learner-portal-base
         path: dependent-usage-analyzer/.projects/frontend-learner-portal-base
-    - name: Checkout openedx/frontend-lib-content-components
-      uses: actions/checkout@v3
-      with:
-        repository: openedx/frontend-lib-content-components
-        path: dependent-usage-analyzer/.projects/frontend-lib-content-components
     - name: Checkout openedx/frontend-lib-special-exams
       uses: actions/checkout@v3
       with:

--- a/dependent-usage-analyzer/checkout-dependents.sh
+++ b/dependent-usage-analyzer/checkout-dependents.sh
@@ -32,7 +32,6 @@ mkdir .projects
   git clone git@github.com:openedx/frontend-component-header.git --depth 1
   git clone git@github.com:openedx/frontend-enterprise.git --depth 1
   git clone git@github.com:openedx/frontend-learner-portal-base.git --depth 1
-  git clone git@github.com:edx/frontend-lib-content-components.git --depth 1
   git clone git@github.com:edx/frontend-lib-special-exams.git --depth 1
   git clone git@github.com:openedx/frontend-platform.git --depth 1
   git clone git@github.com:openedx/frontend-template-application.git --depth 1


### PR DESCRIPTION
In https://github.com/openedx/frontend-app-course-authoring/pull/1208 we merged `frontend-lib-content-components` into `frontend-app-course-authoring`, and there is no remaining usage of `frontend-lib-content-components` (which will soon be archived). So we can remove it from the dependents analysis.