### PR TITLE
feat: migrate example box-shadow token to composite token

### DIFF
--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -1566,7 +1566,7 @@
   --pgn-elevation-box-shadow-level-4: 0 .625rem 1.25rem rgba(0, 0, 0, .15), 0 .5rem 1.25rem rgba(0, 0, 0, .15); /* Basic box shadow of level 4. */
   --pgn-elevation-box-shadow-level-3: 0 0 .625rem rgba(0, 0, 0, .15), 0 0 1rem rgba(0, 0, 0, .15); /* Basic box shadow of level 3. */
   --pgn-elevation-box-shadow-level-2: 0 .125rem .25rem rgba(0, 0, 0, .15), 0 .125rem .5rem rgba(0, 0, 0, .15); /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-1: 0 .0625rem .125rem rgba(0, 0, 0, .15), 0 .0625rem .25rem rgba(0, 0, 0, .15); /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1: 0rem 0.0625rem 0.125rem 0rem rgba(0, 0, 0, 0.15), 0rem 0.0625rem 0.25rem 0rem rgba(0, 0, 0, 0.15); /* Basic box shadow of level 1. */
   --pgn-elevation-input-btn-focus-box-shadow: 0 0 0 var(--pgn-size-input-btn-focus-width) var(--pgn-color-input-btn-focus);
   --pgn-elevation-toast-box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, .15), 0 .5rem 3rem rgba(0, 0, 0, .15);
   --pgn-elevation-sticky-shadow-bottom: 0 .5rem 1rem rgba(0, 0, 0, .15), 0 .25rem .625rem rgba(0, 0, 0, .15);

--- a/tokens/src/themes/light/global/elevation.json
+++ b/tokens/src/themes/light/global/elevation.json
@@ -5,7 +5,22 @@
       "level": {
         "1": {
           "source": "$level-1-box-shadow",
-          "$value": "0 .0625rem .125rem rgba(0, 0, 0, .15), 0 .0625rem .25rem rgba(0, 0, 0, .15)",
+          "$value": [
+            {
+              "color": "rgba(0, 0, 0, 0.15)",
+              "offsetX": "0rem",
+              "offsetY": "0.0625rem",
+              "blur": "0.125rem",
+              "spread": "0rem"
+            },
+            {
+              "color": "rgba(0, 0, 0, 0.15)",
+              "offsetX": "0rem",
+              "offsetY": "0.0625rem",
+              "blur": "0.25rem",
+              "spread": "0rem"
+            }
+          ],
           "$description": "Basic box shadow of level 1."
         },
         "2": {


### PR DESCRIPTION
## Description

Provides example of migrating an existing `shadow` related design token to a [composite token](https://tr.designtokens.org/format/#composite-types).

### Before

```json
{
  "elevation": {
    "$type": "shadow",
    "box-shadow": {
      "level": {
        "1": {
           "$value": "0 .0625rem .125rem rgba(0, 0, 0, .15), 0 .0625rem .25rem rgba(0, 0, 0, .15)",
           ...
        }
      }
    }
  }
}
```

### After (proposed)

```json
{
  "elevation": {
    "$type": "shadow",
    "box-shadow": {
      "level": {
        "1": {
           "$value": [
             {
               "color": "rgba(0, 0, 0, 0.15)",
               "offsetX": "0rem",
               "offsetY": "0.0625rem",
               "blur": "0.125rem",
               "spread": "0rem"
             },
             {
               "color": "rgba(0, 0, 0, 0.15)",
               "offsetX": "0rem",
               "offsetY": "0.0625rem",
               "blur": "0.25rem",
               "spread": "0rem"
              }
           ],
           ...
        }
      }
    }
  }
}
```

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
