### PR TITLE
fix: scales down card logo cap

### DIFF
--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -353,6 +353,8 @@ a.pgn__card {
       bottom: #{-$card-logo-bottom-offset};
       width: $card-logo-width;
       height: $card-logo-height;
+      object-fit: scale-down;
+      object-position: center center;
       border-radius: $card-logo-border-radius;
       box-shadow: $level-1-box-shadow;
       padding: map_get($spacers, 2);


### PR DESCRIPTION
## Description

Scales down the logo cap for card images for instances where a logo cap's aspect ratio is different then the default aspect ratio of the container. 

Use cases for this change are GetSmarter course card image caps.
Example 
Before:
![Screenshot 2024-09-06 at 11 12 19 AM](https://github.com/user-attachments/assets/1f0f6408-8719-4934-bc27-b310d274c006)

After:
![Screenshot 2024-09-06 at 11 13 24 AM](https://github.com/user-attachments/assets/cea93ef0-ccbb-4690-87fa-79f86ac1fced)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
