### PR TITLE
fix: `Toast` children prop type

### DIFF
--- a/src/Toast/index.jsx
+++ b/src/Toast/index.jsx
@@ -78,7 +78,7 @@ Toast.defaultProps = {
 
 Toast.propTypes = {
   /** A string or an element that is rendered inside the main body of the `Toast`. */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   /**
    * A function that is called on close. It can be used to perform
    * actions upon closing of the `Toast`, such as setting the "show"

--- a/src/Toast/index.jsx
+++ b/src/Toast/index.jsx
@@ -77,7 +77,7 @@ Toast.defaultProps = {
 };
 
 Toast.propTypes = {
-  /** A string or an element that is rendered inside the main body of the `Toast`. */
+  /** A node that is rendered inside the main body of the `Toast`. */
   children: PropTypes.node.isRequired,
   /**
    * A function that is called on close. It can be used to perform

--- a/src/Toast/index.jsx
+++ b/src/Toast/index.jsx
@@ -78,7 +78,7 @@ Toast.defaultProps = {
 
 Toast.propTypes = {
   /** A string or an element that is rendered inside the main body of the `Toast`. */
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  children: PropTypes.node.isRequired,
   /**
    * A function that is called on close. It can be used to perform
    * actions upon closing of the `Toast`, such as setting the "show"


### PR DESCRIPTION
## Description

This is a small fix of the typing for the `children` prop of the `Toast` component. This was generating some warnings in the `frontend-app-course-authoring` when the `Toast` was used with an `Element` instead of a `string`.

Example (from [here](https://github.com/openedx/frontend-app-course-authoring/blob/6255768c97de8507ce3e9fee6a4b10ab677e828b/src/editors/containers/TextEditor/index.jsx#L80-L82)):
```jsx
<Toast show={blockFailed} onClose={hooks.nullMethod}>
  <FormattedMessage {...messages.couldNotLoadTextContext}
</Toast>
```

### Deploy Preview

https://deploy-preview-3232--paragon-openedx.netlify.app/components/toast/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
