### PR TITLE
fix: add background to modal body to fix overflow

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -40,10 +40,10 @@
   }
 
   &.pgn__modal-visible-overflow {
-    overflow: visible;
+    overflow-y: visible;
 
     .pgn__modal-body {
-      overflow: visible;
+      overflow-y: visible;
     }
   }
 }


### PR DESCRIPTION
## Description

### Before
![image](https://github.com/user-attachments/assets/b1030eff-0c98-45b8-a861-a15dbf8af117)

### After
![image](https://github.com/user-attachments/assets/2410f67e-bdb9-41b3-8e02-d6215cd8d691)

### Deploy Preview

https://deploy-preview-3238--paragon-openedx.netlify.app/components/modal/modal-dialog/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
