### PR TITLE
Mark deprecated components as deprecated using JSDoc/TypeScript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,9 @@ export const
 export const
   Carousel: any, CarouselItem: any, CAROUSEL_NEXT_LABEL_TEXT: any, CAROUSEL_PREV_LABEL_TEXT: any;
 // from './Carousel';
+/** @deprecated Replaced by `Form.Checkbox`. */
 export const CheckBox: any; // from './CheckBox';
+/** @deprecated Replaced by `Form.Checkbox` and `Form.CheckboxSet`. */
 export const CheckBoxGroup: any; // from './CheckBoxGroup';
 export const CloseButton: any; // from './CloseButton';
 export const Layout: any, Col: any, Row: any; // from './Layout';
@@ -53,6 +55,7 @@ export const
   SplitButton: any;
 // from './Dropdown';
 export const Fade: any; // from './Fade';
+/** @deprecated */
 export const Fieldset: any; // from './Fieldset';
 export const
   Form: any,
@@ -77,17 +80,23 @@ export const
   InputGroup: any;
 // from './Form';
 export const IconButtonToggle: any; // from './IconButtonToggle';
+/** @deprecated Replaced by `Form.Control`. */
 export const Input: any; // from './Input';
+/** @deprecated Replaced by `Form.Control`. */
 export const InputSelect: any; // from './InputSelect';
+/** @deprecated Replaced by `Form.Control`. */
 export const InputText: any; // from './InputText';
 export const Image: any, Figure; // from './Image';
+/** @deprecated */
 export const ListBox: any; // from './ListBox';
+/** @deprecated */
 export const ListBoxOption: any; // from './ListBoxOption';
 export const MailtoLink: any, MAIL_TO_LINK_EXTERNAL_LINK_ALTERNATIVE_TEXT: string, MAIL_TO_LINK_EXTERNAL_LINK_TITLE: string; // from './MailtoLink';
 export const Media: any; // from './Media';
 export const Menu: any; // from './Menu';
 export const MenuItem: any; // from './Menu/MenuItem';
 export const SelectMenu: any, SELECT_MENU_DEFAULT_MESSAGE: string; // from './Menu/SelectMenu';
+/** @deprecated Use `ModalDialog` instead. */
 export const Modal: any; // from './Modal';
 export const ModalCloseButton: any; // from './Modal/ModalCloseButton';
 export const FullscreenModal: any, FULLSCREEN_MODAL_CLOSE_LABEL: string; // from './Modal/FullscreenModal';
@@ -122,6 +131,7 @@ export const
 export const Popover: any, PopoverTitle: any, PopoverContent: any; // from './Popover';
 export const ProgressBar: any; // from './ProgressBar';
 export const ProductTour: any; // from './ProductTour';
+/** @deprecated Replaced by `Form.Radio` and `Form.RadioSet`. */
 export const RadioButtonGroup: any, RadioButton: any; // from './RadioButtonGroup';
 export const ResponsiveEmbed: any; // from './ResponsiveEmbed';
 export const
@@ -135,7 +145,9 @@ export const Sheet: any; // from './Sheet';
 export const Spinner: any; // from './Spinner';
 export const Stepper: any; // from './Stepper';
 export const StatefulButton: any; // from './StatefulButton';
+/** @deprecated Replaced by `Alert`. */
 export const StatusAlert: any; // from './StatusAlert';
+/** @deprecated Replaced by `DataTable`. */
 export const Table: any; // from './Table';
 export const
   Tabs: any,
@@ -144,8 +156,10 @@ export const
   TabContent: any,
   TabPane: any;
 // from './Tabs';
+/** @deprecated Replaced by `Form.Control`. */
 export const TextArea: any; // from './TextArea';
 export const Toast: any, TOAST_CLOSE_LABEL_TEXT: string, TOAST_DELAY: number; // from './Toast';
+/** @deprecated Replaced by `Form.Group`. */
 export const ValidationFormGroup: any; // from './ValidationFormGroup';
 export const TransitionReplace: any; // from './TransitionReplace';
 export const ValidationMessage: any; // from './ValidationMessage';

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export { default as Bubble } from './Bubble';
 export { default as Button, ButtonGroup, ButtonToolbar } from './Button';
 export { default as Chip, CHIP_PGN_CLASS } from './Chip';
 export { default as ChipCarousel } from './ChipCarousel';
+export { default as Container } from './Container';
 export { default as Hyperlink, HYPER_LINK_EXTERNAL_LINK_ALT_TEXT, HYPER_LINK_EXTERNAL_LINK_TITLE } from './Hyperlink';
 export { default as Icon } from './Icon';
 export { default as IconButton, IconButtonWithTooltip } from './IconButton';
@@ -38,10 +39,11 @@ export {
 export {
   default as Carousel, CarouselItem, CAROUSEL_NEXT_LABEL_TEXT, CAROUSEL_PREV_LABEL_TEXT,
 } from './Carousel';
+/** @deprecated Replaced by `Form.Checkbox`. */
 export { default as CheckBox } from './CheckBox';
+/** @deprecated Replaced by `Form.Checkbox` and `Form.CheckboxSet`. */
 export { default as CheckBoxGroup } from './CheckBoxGroup';
 export { default as CloseButton } from './CloseButton';
-export { default as Container } from './Container';
 export { default as Layout, Col, Row } from './Layout';
 export { default as Collapse } from './Collapse';
 export { default as Collapsible } from './Collapsible';
@@ -53,6 +55,7 @@ export {
   SplitButton,
 } from './Dropdown';
 export { default as Fade } from './Fade';
+/** @deprecated */
 export { default as Fieldset } from './Fieldset';
 export {
   default as Form,
@@ -77,17 +80,23 @@ export {
   InputGroup,
 } from './Form';
 export { default as IconButtonToggle } from './IconButtonToggle';
+/** @deprecated Replaced by `Form.Control`. */
 export { default as Input } from './Input';
+/** @deprecated Replaced by `Form.Control`. */
 export { default as InputSelect } from './InputSelect';
+/** @deprecated Replaced by `Form.Control`. */
 export { default as InputText } from './InputText';
 export { default as Image, Figure } from './Image';
+/** @deprecated */
 export { default as ListBox } from './ListBox';
+/** @deprecated */
 export { default as ListBoxOption } from './ListBoxOption';
 export { default as MailtoLink, MAIL_TO_LINK_EXTERNAL_LINK_ALTERNATIVE_TEXT, MAIL_TO_LINK_EXTERNAL_LINK_TITLE } from './MailtoLink';
 export { default as Media } from './Media';
 export { default as Menu } from './Menu';
 export { default as MenuItem } from './Menu/MenuItem';
 export { default as SelectMenu, SELECT_MENU_DEFAULT_MESSAGE } from './Menu/SelectMenu';
+/** @deprecated Use `ModalDialog` instead. */
 export { default as Modal } from './Modal';
 export { default as ModalCloseButton } from './Modal/ModalCloseButton';
 export { default as FullscreenModal, FULLSCREEN_MODAL_CLOSE_LABEL } from './Modal/FullscreenModal';
@@ -122,6 +131,7 @@ export {
 export { default as Popover, PopoverTitle, PopoverContent } from './Popover';
 export { default as ProgressBar } from './ProgressBar';
 export { default as ProductTour } from './ProductTour';
+/** @deprecated Replaced by `Form.Radio` and `Form.RadioSet`. */
 export { default as RadioButtonGroup, RadioButton } from './RadioButtonGroup';
 export { default as ResponsiveEmbed } from './ResponsiveEmbed';
 export {
@@ -135,7 +145,9 @@ export { default as Sheet } from './Sheet';
 export { default as Spinner } from './Spinner';
 export { default as Stepper } from './Stepper';
 export { default as StatefulButton } from './StatefulButton';
+/** @deprecated Replaced by `Alert`. */
 export { default as StatusAlert } from './StatusAlert';
+/** @deprecated Replaced by `DataTable`. */
 export { default as Table } from './Table';
 export {
   default as Tabs,
@@ -144,8 +156,10 @@ export {
   TabContent,
   TabPane,
 } from './Tabs';
+/** @deprecated Replaced by `Form.Control`. */
 export { default as TextArea } from './TextArea';
 export { default as Toast, TOAST_CLOSE_LABEL_TEXT, TOAST_DELAY } from './Toast';
+/** @deprecated Replaced by `Form.Group`. */
 export { default as ValidationFormGroup } from './ValidationFormGroup';
 export { default as TransitionReplace } from './TransitionReplace';
 export { default as ValidationMessage } from './ValidationMessage';


### PR DESCRIPTION
## Description

On [the docs site](https://paragon-openedx.netlify.app/), many components are marked as deprecated:

![Screenshot showing deprecated components](https://github.com/user-attachments/assets/833cac4d-950d-447b-86dd-d77e2a6fa20d)

This PR updates the types so that those same components will appear as deprecated if used in an IDE:

![Screenshot showing usage of deprecated components is flagged](https://github.com/user-attachments/assets/00903d86-cf94-41fb-80b3-900d933deda1)

As you can see, the message about the replacement components is also shown in by VS Code.

### Deploy Preview

No discernible changes to the docs site.

## Merge Checklist

n/a

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
