### PR TITLE
feat: add-newsstand-icon

### DIFF
--- a/icons/es5/Newsstand.js
+++ b/icons/es5/Newsstand.js
@@ -1,0 +1,15 @@
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import * as React from "react";
+var SvgNewsstand = function SvgNewsstand(props) {
+  return /*#__PURE__*/React.createElement("svg", _extends({
+    xmlns: "http://www.w3.org/2000/svg",
+    height: 24,
+    viewBox: "0 -960 960 960",
+    width: 24,
+    fill: "none"
+  }, props), /*#__PURE__*/React.createElement("path", {
+    d: "M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z",
+    fill: "currentColor"
+  }));
+};
+export default SvgNewsstand;

--- a/icons/es5/index.js
+++ b/icons/es5/index.js
@@ -1381,6 +1381,7 @@ export { default as NetworkWifi3Bar } from "./NetworkWifi3Bar";
 export { default as NewLabel } from "./NewLabel";
 export { default as NewReleases } from "./NewReleases";
 export { default as Newspaper } from "./Newspaper";
+export { default as Newsstand } from "./Newsstand";
 export { default as NextPlan } from "./NextPlan";
 export { default as NextWeek } from "./NextWeek";
 export { default as Nfc } from "./Nfc";

--- a/icons/es5/index.ts
+++ b/icons/es5/index.ts
@@ -1382,6 +1382,7 @@ export { default as NetworkWifi3Bar } from "./NetworkWifi3Bar";
 export { default as NewLabel } from "./NewLabel";
 export { default as NewReleases } from "./NewReleases";
 export { default as Newspaper } from "./Newspaper";
+export { default as Newsstand } from "./Newsstand";
 export { default as NextPlan } from "./NextPlan";
 export { default as NextWeek } from "./NextWeek";
 export { default as Nfc } from "./Nfc";

--- a/icons/jsx/Newsstand.jsx
+++ b/icons/jsx/Newsstand.jsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+const SvgNewsstand = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={24}
+    viewBox="0 -960 960 960"
+    width={24}
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+export default SvgNewsstand;

--- a/icons/jsx/index.jsx
+++ b/icons/jsx/index.jsx
@@ -1381,6 +1381,7 @@ export { default as NetworkWifi3Bar } from "./NetworkWifi3Bar";
 export { default as NewLabel } from "./NewLabel";
 export { default as NewReleases } from "./NewReleases";
 export { default as Newspaper } from "./Newspaper";
+export { default as Newsstand } from "./Newsstand";
 export { default as NextPlan } from "./NextPlan";
 export { default as NextWeek } from "./NextWeek";
 export { default as Nfc } from "./Nfc";

--- a/icons/svg/newsstand.svg
+++ b/icons/svg/newsstand.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px"><path d="M80-160v-80h800v80H80Zm80-160v-320h80v320h-80Zm160 0v-480h80v480h-80Zm160 0v-480h80v480h-80Zm280 0L600-600l70-40 160 280-70 40Z"/></svg>


### PR DESCRIPTION
## Description
This PR adds the  `newsstand` icon from `material-symbols` to Paragon.
![newsstand](https://github.com/user-attachments/assets/404fb67d-4f1f-408d-ba69-91ca8792bc92)

The icon was sourced from here:
- https://fonts.google.com/icons?selected=Material+Symbols+Outlined:newsstand:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=newsstand&icon.size=24&icon.color=%235f6368&icon.platform=web&icon.set=Material+Symbols

### Deploy Preview

https://deploy-preview-3275--paragon-openedx.netlify.app/foundations/icons/

Check the `newsstand` icon

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
