### PR TITLE
refactor: corrected ratio tokens type and renamed edx theme

### DIFF
--- a/tokens/src/core/components/Dropdown.json
+++ b/tokens/src/core/components/Dropdown.json
@@ -54,7 +54,7 @@
     }
   },
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "dropdown": {
       "zindex": { "source": "$zindex-dropdown", "$value": "1000" }
     }

--- a/tokens/src/core/components/Modal.json
+++ b/tokens/src/core/components/Modal.json
@@ -1,6 +1,6 @@
 {
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "modal": {
       "backdrop-zindex": { "source": "$zindex-modal-backdrop", "$value": "1040" },
       "zindex": { "source": "$zindex-modal", "$value": "1050" }

--- a/tokens/src/core/components/Popover.json
+++ b/tokens/src/core/components/Popover.json
@@ -24,7 +24,7 @@
     }
   },
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "popover": {
       "zindex": { "source": "$zindex-popover", "$value": "1060" }
     }

--- a/tokens/src/core/components/ProductTour.json
+++ b/tokens/src/core/components/ProductTour.json
@@ -16,7 +16,7 @@
     }
   },
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "product-tour": {
       "checkpoint": {
         "zindex": { "source": "$checkpoint-z-index", "$value": "1060" }

--- a/tokens/src/core/components/Sheet.json
+++ b/tokens/src/core/components/Sheet.json
@@ -1,6 +1,6 @@
 {
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "sheet": {
       "zindex": {
         "backdrop": { "source": "$zindex-sheet-backdrop", "$value": "1031" },

--- a/tokens/src/core/components/Tooltip.json
+++ b/tokens/src/core/components/Tooltip.json
@@ -16,7 +16,7 @@
     }
   },
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "tooltip": {
       "zindex": { "source": "$zindex-tooltip", "$value": "1070" }
     }

--- a/tokens/src/core/global/elevation.json
+++ b/tokens/src/core/global/elevation.json
@@ -1,6 +1,6 @@
 {
   "elevation": {
-    "$type": "ratio",
+    "$type": "number",
     "zindex": {
       "0": {
         "$value": 0,

--- a/tokens/src/themes/light/components/Button/core.json
+++ b/tokens/src/themes/light/components/Button/core.json
@@ -15,7 +15,7 @@
     }
   },
   "other": {
-    "$type": "ratio",
+    "$type": "number",
     "btn": {
       "disabled-opacity": { "source": "$btn-disabled-opacity", "$value": ".65" }
     }

--- a/tokens/src/themes/light/components/Carousel.json
+++ b/tokens/src/themes/light/components/Carousel.json
@@ -33,7 +33,7 @@
     }
   },
   "other": {
-    "$type": "ratio",
+    "$type": "number",
     "carousel": {
       "control": {
         "opacity": {

--- a/tokens/src/themes/light/components/Chip.json
+++ b/tokens/src/themes/light/components/Chip.json
@@ -30,7 +30,7 @@
     }
   },
   "other": {
-    "$type": "ratio",
+    "$type": "number",
     "chip": {
       "opacity-disabled": { "source": "$chip-disable-opacity", "$value": ".3" }
     }

--- a/tokens/src/themes/light/components/Form/other.json
+++ b/tokens/src/themes/light/components/Form/other.json
@@ -1,7 +1,7 @@
 {
   "other": {
     "form": {
-      "$type": "ratio",
+      "$type": "number",
       "feedback": {
         "tooltip-opacity": {
           "source": "$form-feedback-tooltip-opacity",

--- a/tokens/src/themes/light/components/SearchField.json
+++ b/tokens/src/themes/light/components/SearchField.json
@@ -17,7 +17,7 @@
     }
   },
   "other": {
-    "$type": "ratio",
+    "$type": "number",
     "search-field": {
       "disabled-opacity": { "source": "$search-disabled-opacity", "$value": ".3" }
     }

--- a/tokens/src/themes/light/components/Tooltip.json
+++ b/tokens/src/themes/light/components/Tooltip.json
@@ -37,7 +37,7 @@
     }
   },
   "other": {
-    "$type": "ratio",
+    "$type": "number",
     "tooltip": {
       "opacity": { "source": "$tooltip-opacity", "$value": "1" }
     }

--- a/www/theme-config.js
+++ b/www/theme-config.js
@@ -17,7 +17,7 @@ const THEMES = [
   },
   {
     id: 'edxorg',
-    label: 'edX',
+    label: 'edX.org',
     stylesheet: 'edxorg-theme',
     pathToVariables: '@edx/brand-edx.org/paragon/_variables.scss',
   },


### PR DESCRIPTION
## Description

This PR provides some minor improvements:

- `ratio` type changed to `number` in Design tokens
- theme title changed from `edx` to `edx.org`

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
