### PR TITLE
docs: "Controlled usage" demo of <Collapsible> wasn't working

### DIFF
--- a/src/Collapsible/README.md
+++ b/src/Collapsible/README.md
@@ -185,13 +185,13 @@ See the developer console for logging.
 ### Controlled usage
 
 ```jsx live
-function() {
+() => {
   const [collapseIsOpen, setCollapseOpen] = React.useState(true);
 
   return (
     <Collapsible.Advanced
       open={collapseIsOpen}
-      onToggle={isOpen => setCollapseOpen(!isOpen)}
+      onToggle={isOpen => setCollapseOpen(isOpen)}
       className="collapsible-card"
     >
       <Collapsible.Trigger className="collapsible-trigger">


### PR DESCRIPTION
## Description

The ["Controlled usage" demo of `Collapsible`](https://paragon-openedx.netlify.app/components/collapsible/#controlled-usage) is not working. Clicking on either the heading or the Close button has no effect. This PR fixes it.

### Deploy Preview

["Controlled usage" demo of `Collapsible` - ✅ fixed (deploy preview)](https://deploy-preview-3312--paragon-openedx.netlify.app/components/collapsible/#controlled-usage)

## Merge Checklist

n/a in this case.