### PR TITLE
chore(deps): removed stylelint-config-standard-scss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@babel/preset-env": "^7.16.8",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
-        "@edx/eslint-config": "^4.2.0",
+        "@edx/eslint-config": "^4.3.0",
         "@edx/stylelint-config-edx": "^2.3.0",
         "@edx/typescript-config": "^1.0.1",
         "@formatjs/cli": "^5.0.2",
@@ -103,7 +103,6 @@
         "sass": "^1.32.13",
         "semantic-release": "^20.1.3",
         "stylelint": "^14.7.1",
-        "stylelint-config-standard-scss": "^4.0.0",
         "ts-jest": "^29.1.2",
         "typescript": "^4.7.4"
       },
@@ -2368,9 +2367,9 @@
       "license": "UNLICENSED"
     },
     "node_modules/@edx/eslint-config": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.2.0.tgz",
-      "integrity": "sha512-2wuIw49uyj6gRwS74qJ8WhBU+X2FOP4uot40sthIC4YU9qCM7WJOcOuAhkRPP1FvZKd3UQH3gZM7eJ85xzDBqA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.3.0.tgz",
+      "integrity": "sha512-4W9wFG4ALr3xocakCsncgJbK67RHfSmDwHDXKHReFtjxl/FRkxhS6qayz189oChqfANieeV3zRCLaq44bLf+/A==",
       "dev": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -36973,39 +36972,6 @@
       "license": "MIT",
       "dependencies": {
         "stylelint-config-recommended": "^7.0.0"
-      },
-      "peerDependencies": {
-        "stylelint": "^14.4.0"
-      }
-    },
-    "node_modules/stylelint-config-standard-scss": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stylelint-config-recommended-scss": "^6.0.0",
-        "stylelint-config-standard": "^25.0.0"
-      },
-      "peerDependencies": {
-        "stylelint": "^14.4.0"
-      }
-    },
-    "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-recommended": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "stylelint": "^14.4.0"
-      }
-    },
-    "node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-recommended-scss": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-scss": "^4.0.2",
-        "stylelint-config-recommended": "^7.0.0",
-        "stylelint-scss": "^4.0.0"
       },
       "peerDependencies": {
         "stylelint": "^14.4.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@babel/preset-env": "^7.16.8",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@edx/eslint-config": "^4.2.0",
+    "@edx/eslint-config": "^4.3.0",
     "@edx/stylelint-config-edx": "^2.3.0",
     "@edx/typescript-config": "^1.0.1",
     "@formatjs/cli": "^5.0.2",
@@ -140,7 +140,6 @@
     "sass": "^1.32.13",
     "semantic-release": "^20.1.3",
     "stylelint": "^14.7.1",
-    "stylelint-config-standard-scss": "^4.0.0",
     "ts-jest": "^29.1.2",
     "typescript": "^4.7.4"
   },


### PR DESCRIPTION
## Description

- removed stylelint-config-standard-scss
- updated @edx/eslint-config

**Issue:** https://github.com/openedx/paragon/issues/3294

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
