### PR TITLE
fix: update docstring to prevent jsx closing tag error

### DIFF
--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -143,7 +143,7 @@ IconButton.propTypes = {
   size: PropTypes.oneOf(['sm', 'md', 'inline']),
   /** whether to show the `IconButton` in an active state, whose styling is distinct from default state */
   isActive: PropTypes.bool,
-  /** Used with <IconButtonToggle> */
+  /** Used with `IconButtonToggle` */
   value: PropTypes.string,
 };
 


### PR DESCRIPTION
## Description

The latest run of "Build Docs" (https://github.com/openedx/paragon/actions/runs/12241372269/job/34146296486) led to a silent failure. I haven't investigated why the failure was silent yet but the error hiding in there was:

```sh
unknown: Expected corresponding JSX closing tag for <IconButtonToggle>. (7:35)

   5 |       {...props}
   6 |       components={components}>
>  7 | <p>{`Used with `}<IconButtonToggle></p>
     |                                    ^
   8 |     </MDXLayout>
   9 |   )
  10 | };undefined: unknown: Expected corresponding JSX closing tag for <IconButtonToggle>. (7:35)

   5 |       {...props}
   6 |       components={components}>
>  7 | <p>{`Used with `}<IconButtonToggle></p>
     |                                    ^
   8 |     </MDXLayout>
   9 |   )
  10 | };


  SyntaxError:unknown: Expected corresponding JSX closing tag for <IconButtonTo  ggle>. (7:35)
     5 |       {...props}
    6 |       components={components}>
  >  7 |<p>{`Us  ed with `}<IconButtonToggle><[0m  m/p>
      |^
    8 |</MDXLayout>
    9 |   )
   10 | };undefined: unknown: Expected corresponding JS  X closing tag for <IconButtonToggle>. (7:35)
     5 |       {...props}
    6 |       components={components}>
  >  7 |<p>{`Us  ed with `}<IconButtonToggle><[0m  m/p>
      |^
    8 |</MDXLayout>
    9 |   )
   10 | };
```

I was able to reproduce the error locally by running `npm run build-docs`, and verified the error was gone with this change.