### PR TITLE
feat!: deprecate `Truncate` component

### DIFF
--- a/src/Truncate/README.md
+++ b/src/Truncate/README.md
@@ -5,9 +5,11 @@ components:
 - Truncate
 categories:
 - Content
-status: 'New'
+status: 'Deprecate Soon'
 designStatus: 'Done'
 devStatus: 'Done'
+notes: |
+  Plan to replace with native css implementation as per https://github.com/openedx/paragon/issues/3311
 ---
 
 A Truncate component can help you crop multiline text. There will be three dots at the end of the text.
@@ -15,34 +17,34 @@ A Truncate component can help you crop multiline text. There will be three dots 
 ## Basic Usage
 
 ```jsx live
-  <Truncate lines={2}>
+  <Truncate.Deprecated lines={2}>
     Learners, course teams, researchers, developers: the edX community includes groups with a range of reasons 
     for using the platform and objectives to accomplish. To help members of each group learn about what edX 
     offers, reach goals, and solve problems, edX provides a variety of information resources.
     Learners, course teams, researchers, developers: the edX community includes groups with a range of reasons
     for using the platform and objectives to accomplish. To help members of each group learn about what edX
     offers, reach goals, and solve problems, edX provides a variety of information resources.
-  </Truncate>
+  </Truncate.Deprecated>
 ```
 
 ### With the custom ellipsis
 
 ```jsx live
-    <Truncate lines={2} ellipsis="🎉🎉🎉" whiteSpace>
+    <Truncate.Deprecated lines={2} ellipsis="🎉🎉🎉" whiteSpace>
         Learners, course teams, researchers, developers: the edX community includes groups with a range of reasons
         for using the platform and objectives to accomplish. To help members of each group learn about what edX
         offers, reach goals, and solve problems, edX provides a variety of information resources.
-    </Truncate>
+    </Truncate.Deprecated>
 ```
 
 ### With the onTruncate
 
 ```jsx live
-    <Truncate lines={2} onTruncate={() => console.log('onTruncate')}>
+    <Truncate.Deprecated lines={2} onTruncate={() => console.log('onTruncate')}>
         Learners, course teams, researchers, developers: the edX community includes groups with a range of reasons
         for using the platform and objectives to accomplish. To help members of each group learn about what edX
         offers, reach goals, and solve problems, edX provides a variety of information resources.
-    </Truncate>
+    </Truncate.Deprecated>
 ```
 
 ### Example usage in Card
@@ -59,22 +61,22 @@ A Truncate component can help you crop multiline text. There will be three dots 
       />
       <Card.Header
         title={
-          <Truncate lines={2}>
+          <Truncate.Deprecated lines={2}>
             Using Enhanced Capabilities In Your Course
-          </Truncate>}
+          </Truncate.Deprecated>}
       />
       <Card.Section>
-        <Truncate lines={4}>
+        <Truncate.Deprecated lines={4}>
           Learners, course teams, researchers, developers: the edX community includes groups with a range of reasons
           for using the platform and objectives to accomplish. To help members of each group learn about what edX
           offers, reach goals, and solve problems, edX provides a variety of information resources.
-        </Truncate>
+        </Truncate.Deprecated>
       </Card.Section>
       <Card.Footer
         textElement={
-          <Truncate lines={2}>
+          <Truncate.Deprecated lines={2}>
             Using Enhanced Capabilities In Your Course
-          </Truncate>}
+          </Truncate.Deprecated>}
       >
         <Button style={{ minWidth: 100 }}>Action 1</Button>
       </Card.Footer>
@@ -88,7 +90,7 @@ A Truncate component can help you crop multiline text. There will be three dots 
 **Note**: `Truncate` supports only plain `HTML` children and not `jsx`.
 
 ```jsx live
-<Truncate lines={1}>
+<Truncate.Deprecated lines={1}>
   <a href="#">Learners</a>, course teams, researchers, developers: the edX community includes <strong class="strong-class"><i class="i-class">groups with <u>a range</u> of <q>reasons</q></i></strong> for using the platform and objectives to accomplish.
-</Truncate>
+</Truncate.Deprecated>
 ```

--- a/src/Truncate/Truncate.test.jsx
+++ b/src/Truncate/Truncate.test.jsx
@@ -4,9 +4,9 @@ import Truncate from '.';
 
 describe('<Truncate />', () => {
   render(
-    <Truncate className="pgn__truncate">
+    <Truncate.Deprecated className="pgn__truncate">
       Learners, course teams, researchers, developers.
-    </Truncate>,
+    </Truncate.Deprecated>,
   );
   it('render with className', () => {
     const element = screen.getByText(/Learners, course teams, researchers, developers./i);
@@ -18,9 +18,9 @@ describe('<Truncate />', () => {
   it('render with onTruncate', () => {
     const mockFn = jest.fn();
     render(
-      <Truncate className="pgn__truncate" onTruncate={mockFn}>
+      <Truncate.Deprecated className="pgn__truncate" onTruncate={mockFn}>
         Learners, course teams, researchers, developers.
-      </Truncate>,
+      </Truncate.Deprecated>,
     );
     expect(mockFn).toHaveBeenCalledTimes(2);
   });

--- a/src/Truncate/index.jsx
+++ b/src/Truncate/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useLayoutEffect, useRef,
+  useLayoutEffect, useRef, useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { truncateLines } from './utils';
@@ -9,7 +9,7 @@ const DEFAULT_TRUNCATE_LINES = 1;
 const DEFAULT_TRUNCATE_ELLIPSIS = '...';
 const DEFAULT_TRUNCATE_ELEMENT_TYPE = 'div';
 
-function Truncate({
+function TruncateDeprecated({
   children, lines, ellipsis, elementType, className, whiteSpace, onTruncate,
 }) {
   const textContainer = useRef();
@@ -40,7 +40,7 @@ function Truncate({
   });
 }
 
-Truncate.propTypes = {
+TruncateDeprecated.propTypes = {
   /** The expected text to which the ellipsis would be applied. */
   children: PropTypes.string.isRequired,
   /** The number of lines the text to be truncated to. */
@@ -57,7 +57,7 @@ Truncate.propTypes = {
   onTruncate: PropTypes.func,
 };
 
-Truncate.defaultProps = {
+TruncateDeprecated.defaultProps = {
   lines: DEFAULT_TRUNCATE_LINES,
   ellipsis: DEFAULT_TRUNCATE_ELLIPSIS,
   whiteSpace: false,
@@ -65,5 +65,14 @@ Truncate.defaultProps = {
   className: undefined,
   onTruncate: undefined,
 };
+
+function Truncate() {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('Please use Truncate.Deprecated until a replacement is created');
+  }, []);
+  return null;
+}
+Truncate.Deprecated = TruncateDeprecated;
 
 export default Truncate;


### PR DESCRIPTION
## Description

See https://github.com/openedx/paragon/issues/3311#issuecomment-2517957583

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
