### PR TITLE
chore: use gh cli for automerge instead of action

### DIFF
--- a/.github/workflows/sync-23-next.yml
+++ b/.github/workflows/sync-23-next.yml
@@ -29,7 +29,6 @@ jobs:
           pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
           github-token: ${{ secrets.requirements_bot_github_token }}
       - name: Enable Pull Request Automerge
-        uses: peter-evans/enable-pull-request-automerge@v2
-        with:
-          token: ${{ secrets.requirements_bot_github_token }}
-          pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
+        run: gh pr merge --merge --auto "${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}"
+        env:
+          GH_TOKEN: ${{ secrets.requirements_bot_github_token }}


### PR DESCRIPTION
## Description

The README for the action we were using for automerge (https://github.com/peter-evans/enable-pull-request-automerge?tab=readme-ov-file#usage) states:

> | :exclamation:  Using this action is no longer necessary   |
> |-----------------------------------------------------------|
> 
> The same functionality exists in the GitHub CLI. See the documentation [here](https://cli.github.com/manual/gh_pr_merge).
> ```yml
>     - name: Enable Pull Request Automerge
>       run: gh pr merge --merge --auto "1"
>       env:
>         GH_TOKEN: ${{ secrets.PAT }}
> ```

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
