### PR TITLE
fix: update customFileHeader during tokens build

### DIFF
--- a/styles/css/core/custom-media-breakpoints.css
+++ b/styles/css/core/custom-media-breakpoints.css
@@ -1,6 +1,6 @@
 /**
- * Do not edit directly, this file was auto-generated. while transforming design tokens.
- * See <root>/tokens/README.md for more details.
+ * Do not edit directly, this file was auto-generated.
+ * See <PARAGON_ROOT>/tokens/README.md for more details.
  */
 
 @custom-media --pgn-size-breakpoint-min-width-xs (min-width: 0px);

--- a/styles/css/core/variables.css
+++ b/styles/css/core/variables.css
@@ -1,6 +1,6 @@
 /**
- * Do not edit directly, this file was auto-generated. while transforming design tokens.
- * See <root>/tokens/README.md for more details.
+ * Do not edit directly, this file was auto-generated.
+ * See <PARAGON_ROOT>/tokens/README.md for more details.
  */
 
 :root {

--- a/styles/css/themes/light/utility-classes.css
+++ b/styles/css/themes/light/utility-classes.css
@@ -1,6 +1,6 @@
 /**
- * Do not edit directly, this file was auto-generated. while transforming design tokens.
- * See <root>/tokens/README.md for more details.
+ * Do not edit directly, this file was auto-generated.
+ * See <PARAGON_ROOT>/tokens/README.md for more details.
  */
 
 .bg-accent-a {

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -1,6 +1,6 @@
 /**
- * Do not edit directly, this file was auto-generated. while transforming design tokens.
- * See <root>/tokens/README.md for more details.
+ * Do not edit directly, this file was auto-generated.
+ * See <PARAGON_ROOT>/tokens/README.md for more details.
  */
 
 :root {

--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -410,8 +410,8 @@ const initializeStyleDictionary = async ({ themes }) => {
   StyleDictionary.registerFileHeader({
     name: 'customFileHeader',
     fileHeader: (defaultMessage) => [
-      `${defaultMessage} while transforming design tokens.`,
-      'See <root>/tokens/README.md for more details.',
+      `${defaultMessage}`,
+      'See <PARAGON_ROOT>/tokens/README.md for more details.',
     ],
   });
 


### PR DESCRIPTION
## Description

Updates the custom file header auto-generated in output CSS files from the build-tokens NPM script:
* Removes the erroneous "while transforming design tokens" message.
* Updates `<root>` to `<PARAGON_ROOT>` as this message is output in custom brand packages, too, which might not define a README.

**Old**

```css
/**
 * Do not edit directly, this file was auto-generated. while transforming design tokens.
 * See <root>/tokens/README.md for more details.
 */
```

**New**

```css
/**
 * Do not edit directly, this file was auto-generated.
 * See <PARAGON_ROOT>/tokens/README.md for more details.
 */
```

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
