### PR TITLE
build: update analyze-dependents base branch to next

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -175,12 +175,6 @@ jobs:
       with:
         repository: openedx/frontend-template-application
         path: dependent-usage-analyzer/.projects/frontend-template-application
-    - name: Checkout edx/prospectus
-      uses: actions/checkout@v3
-      with:
-        repository: edx/prospectus
-        path: dependent-usage-analyzer/.projects/prospectus
-        token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
     - name: Checkout openedx/studio-frontend
       uses: actions/checkout@v3
       with:
@@ -274,7 +268,7 @@ jobs:
         body: "Contains automated changes to the dependent-usage.json file, which provides the data for Paragon Usage Insights."
         labels: automerge
         branch: dependent-usage-analyzer/update-dependent-usage-json
-        base: master
+        base: next
     - name: Auto-approve pull request for dependent project usages
       uses: hmarr/auto-approve-action@v2
       with:

--- a/dependent-usage-analyzer/checkout-dependents.sh
+++ b/dependent-usage-analyzer/checkout-dependents.sh
@@ -35,7 +35,6 @@ mkdir .projects
   git clone git@github.com:edx/frontend-lib-special-exams.git --depth 1
   git clone git@github.com:openedx/frontend-platform.git --depth 1
   git clone git@github.com:openedx/frontend-template-application.git --depth 1
-  git clone git@github.com:edx/prospectus.git --depth 1
   git clone git@github.com:openedx/studio-frontend.git --depth 1
   git clone git@github.com:edx/frontend-app-communications --depth 1
   git clone git@github.com:edx/frontend-app-learner-dashboard.git -- depth 1


### PR DESCRIPTION
## Description

The GitHub Action workflow file that operates on a cron is still trying to create PRs against `master` and subsequently hanging on the required Netlify deploy preview step that's no longer running for `master` branch since the release branches were modified.

This PR updates the base branch for the PR generated by the `analyze-dependents.yml` GitHub Action workflow to be `next` so the primary docs site is updated.

I'm also removing Prospectus (a private repo for edX.org) from the dependents list.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
