### PR TITLE
 fix: set headers so playground works again

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,7 @@
   environment = { SEGMENT_KEY = "", NODE_VERSION = "18.16.0" }
 [functions]
   directory = "www/netlify/functions"
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "frame-ancestors *;"


### PR DESCRIPTION
The playground wasn't loading, it was showing the following error:
```
Refused to display 'https://deploy-preview-3367--paragon-openedx-v23.netlify.app/' in a frame because it set 'X-Frame-Options' to 'deny'.
```

I looked into it a bit and found https://answers.netlify.com/t/breaking-change-x-frame-options-set-to-deny/102220, after which I tried what was recommended in https://answers.netlify.com/t/breaking-change-x-frame-options-set-to-deny/102220/3
> For the Redash project we found that we could overcome this by setting the Content-Security-Policy header in gatsby-config.js
> ```js
>   headers: [
>     {
>       source: '*',
>       headers: [
>         {
>           key: 'Content-Security-Policy',
>           value: 'frame-ancestors *;',
>         },
>       ],
>     },
>   ],
> ```
> This works because X-Frame-Options is obsolete: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

Also see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
> Warning: Instead of this header, use the [frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) directive in a [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) header.

This made it so the main playground loaded correctly, but the iframes nested *within* the playground were failing with the same `X-Frame-Options` error.

I then started looking for ways to set the headers for playroom. I found https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file which mentioned `netlify.toml`, so I just added a `headers` section to our `netlify.toml` file and everything worked!

Everything working: https://deploy-preview-3381--paragon-openedx-v22.netlify.app/playground