### PR TITLE
fix: Changed type for design token print-page-size

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -218,7 +218,7 @@ const COMMANDS = {
     sendTrackInfo('openedx.paragon.cli-command.used', { command, status: 'success' });
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error(chalk.red.bold('An error occurred:', error.message));
+    console.error(chalk.red.bold('An error occurred:', error));
     sendTrackInfo('openedx.paragon.cli-command.used', { command, status: 'error', errorMsg: error.message });
     process.exit(1);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-table": "^7.7.0",
         "react-transition-group": "^4.4.2",
         "sass": "^1.58.3",
-        "style-dictionary": "^4.0.1",
+        "style-dictionary": "^4.3.2",
         "tabbable": "^5.3.3",
         "uncontrollable": "^7.2.1",
         "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-table": "^7.7.0",
     "react-transition-group": "^4.4.2",
     "sass": "^1.58.3",
-    "style-dictionary": "^4.0.1",
+    "style-dictionary": "^4.3.2",
     "tabbable": "^5.3.3",
     "uncontrollable": "^7.2.1",
     "uuid": "^9.0.0"

--- a/styles/css/core/variables.css
+++ b/styles/css/core/variables.css
@@ -4,664 +4,664 @@
  */
 
 :root {
-  --pgn-print-page-size: a3;
-  --pgn-theme-interval: 8%;
-  --pgn-other-form-control-custom-file-content: Browse;
-  --pgn-other-form-control-custom-file-lang: en;
-  --pgn-other-form-control-range-track-cursor: pointer;
-  --pgn-other-form-control-cursor: auto;
-  --pgn-elevation-zindex-fixed: 1030; /* z-index of for fixed element. */
-  --pgn-elevation-zindex-sticky: 1020; /* z-index for sticky element. */
-  --pgn-elevation-zindex-2000: 2000; /* z-index of level 2000. */
-  --pgn-elevation-zindex-1800: 1800; /* z-index of level 1800. */
-  --pgn-elevation-zindex-1600: 1600; /* z-index of level 1600. */
-  --pgn-elevation-zindex-1400: 1400; /* z-index of level 1400. */
-  --pgn-elevation-zindex-1200: 1200; /* z-index of level 1200. */
-  --pgn-elevation-zindex-1000: 1000; /* z-index of level 1000. */
-  --pgn-elevation-zindex-800: 800; /* z-index of level 800. */
-  --pgn-elevation-zindex-600: 600; /* z-index of level 600. */
-  --pgn-elevation-zindex-400: 400; /* z-index of level 400. */
-  --pgn-elevation-zindex-200: 200; /* z-index of level 200. */
-  --pgn-elevation-zindex-0: 0; /* z-index of level 0. */
-  --pgn-elevation-tooltip-zindex: 1070;
-  --pgn-elevation-sheet-zindex-main: 1032;
-  --pgn-elevation-sheet-zindex-backdrop: 1031;
-  --pgn-elevation-product-tour-checkpoint-zindex: 1060;
-  --pgn-elevation-popover-zindex: 1060;
-  --pgn-elevation-modal-zindex: 1050;
-  --pgn-elevation-modal-backdrop-zindex: 1040;
-  --pgn-elevation-dropdown-zindex: 1000;
-  --pgn-transition-collapse-width-behavior: normal; /* Collapse transition for width that takes 350ms */
-  --pgn-transition-collapse-width-delay: 0s; /* Collapse transition for width that takes 350ms */
-  --pgn-transition-collapse-width-timing-function: ease; /* Collapse transition for width that takes 350ms */
-  --pgn-transition-collapse-width-duration: 0.35s; /* Collapse transition for width that takes 350ms */
-  --pgn-transition-collapse-width-property: width; /* Collapse transition for width that takes 350ms */
-  --pgn-transition-collapse-height-behavior: normal; /* Collapse transition for height that takes 350ms */
-  --pgn-transition-collapse-height-delay: 0s; /* Collapse transition for height that takes 350ms */
-  --pgn-transition-collapse-height-timing-function: ease; /* Collapse transition for height that takes 350ms */
-  --pgn-transition-collapse-height-duration: 0.35s; /* Collapse transition for height that takes 350ms */
-  --pgn-transition-collapse-height-property: height; /* Collapse transition for height that takes 350ms */
-  --pgn-transition-fade-behavior: normal; /* Opacity transition that takes 150ms */
-  --pgn-transition-fade-delay: 0s; /* Opacity transition that takes 150ms */
-  --pgn-transition-fade-timing-function: linear; /* Opacity transition that takes 150ms */
-  --pgn-transition-fade-duration: 0.15s; /* Opacity transition that takes 150ms */
-  --pgn-transition-fade-property: opacity; /* Opacity transition that takes 150ms */
-  --pgn-transition-base-behavior: normal; /* Generic transition for any property change */
-  --pgn-transition-base-delay: 0s; /* Generic transition for any property change */
-  --pgn-transition-base-timing-function: ease-in-out; /* Generic transition for any property change */
-  --pgn-transition-base-duration: 0.2s; /* Generic transition for any property change */
-  --pgn-transition-base-property: all; /* Generic transition for any property change */
-  --pgn-transition-progress-bar-transition-behavior: normal;
-  --pgn-transition-progress-bar-transition-delay: 0s;
-  --pgn-transition-progress-bar-transition-timing-function: ease;
-  --pgn-transition-progress-bar-transition-duration: 0.6s;
-  --pgn-transition-progress-bar-transition-property: width;
-  --pgn-transition-progress-bar-animation-timing-iteration-count: infinite;
-  --pgn-transition-progress-bar-animation-timing-delay: 0s;
-  --pgn-transition-progress-bar-animation-timing-timing-function: linear;
-  --pgn-transition-progress-bar-animation-timing-duration: 1s;
-  --pgn-transition-form-control-3-behavior: normal;
-  --pgn-transition-form-control-3-delay: 0s;
-  --pgn-transition-form-control-3-timing-function: ease-in-out;
-  --pgn-transition-form-control-3-duration: 0.15s;
-  --pgn-transition-form-control-3-property: box-shadow;
-  --pgn-transition-form-control-2-behavior: normal;
-  --pgn-transition-form-control-2-delay: 0s;
-  --pgn-transition-form-control-2-timing-function: ease-in-out;
-  --pgn-transition-form-control-2-duration: 0.15s;
-  --pgn-transition-form-control-2-property: border-color;
-  --pgn-transition-form-control-1-behavior: normal;
-  --pgn-transition-form-control-1-delay: 0s;
-  --pgn-transition-form-control-1-timing-function: ease-in-out;
-  --pgn-transition-form-control-1-duration: 0.15s;
-  --pgn-transition-form-control-1-property: background-color;
-  --pgn-transition-form-input-2-behavior: normal;
-  --pgn-transition-form-input-2-delay: 0s;
-  --pgn-transition-form-input-2-timing-function: ease-in-out;
-  --pgn-transition-form-input-2-duration: 0.15s;
-  --pgn-transition-form-input-2-property: box-shadow;
-  --pgn-transition-form-input-1-behavior: normal;
-  --pgn-transition-form-input-1-delay: 0s;
-  --pgn-transition-form-input-1-timing-function: ease-in-out;
-  --pgn-transition-form-input-1-duration: 0.15s;
-  --pgn-transition-form-input-1-property: border-color;
-  --pgn-transition-carousel-control-behavior: normal;
-  --pgn-transition-carousel-control-delay: 0ms;
-  --pgn-transition-carousel-control-timing-function: ease;
-  --pgn-transition-carousel-control-duration: 0.15s;
-  --pgn-transition-carousel-control-property: opacity;
-  --pgn-transition-carousel-indicator-behavior: normal;
-  --pgn-transition-carousel-indicator-delay: 0ms;
-  --pgn-transition-carousel-indicator-timing-function: ease;
-  --pgn-transition-carousel-indicator-duration: var(--pgn-transition-carousel-duration);
-  --pgn-transition-carousel-indicator-property: opacity;
-  --pgn-transition-carousel-duration: 0.6s;
-  --pgn-transition-carousel-base-behavior: normal;
-  --pgn-transition-carousel-base-delay: 0ms;
-  --pgn-transition-carousel-base-timing-function: ease-in-out;
-  --pgn-transition-carousel-base-duration: var(--pgn-transition-carousel-duration);
-  --pgn-transition-carousel-base-property: transform;
-  --pgn-transition-btn: none;
-  --pgn-transition-badge: none;
-  --pgn-typography-line-height-display-mobile: 3.5rem; /* Mobile display line height. */
-  --pgn-typography-line-height-display-base: 1; /* Standard display line height. */
-  --pgn-typography-line-height-micro: 0.938rem; /* Micro utils line height. */
-  --pgn-typography-line-height-sm: 1.5; /* Small line height. */
-  --pgn-typography-line-height-lg: 1.5; /* Large line height. */
-  --pgn-typography-line-height-base: 1.5556; /* Basic line height. */
-  --pgn-typography-font-weight-display-4: var(--pgn-typography-font-weight-bold); /* Font weight of display level 4. */
-  --pgn-typography-font-weight-display-3: var(--pgn-typography-font-weight-bold); /* Font weight of display level 3. */
-  --pgn-typography-font-weight-display-2: var(--pgn-typography-font-weight-bold); /* Font weight of display level 2. */
-  --pgn-typography-font-weight-display-1: var(--pgn-typography-font-weight-bold); /* Font weight of display level 1. */
-  --pgn-typography-font-weight-table-th: 700; /* Table th font weight. */
-  --pgn-typography-font-weight-lead: inherit; /* Lead text font weight. */
-  --pgn-typography-font-weight-base: var(--pgn-typography-font-weight-normal); /* Basic font weight. */
-  --pgn-typography-font-weight-bolder: bolder; /* Bolder font weight. */
-  --pgn-typography-font-weight-bold: 700; /* Bold font weight. */
-  --pgn-typography-font-weight-semi-bold: 500; /* Semi-bold font weight. */
-  --pgn-typography-font-weight-normal: 400; /* Normal font weight. */
-  --pgn-typography-font-weight-light: 300; /* Light font weight. */
-  --pgn-typography-font-weight-lighter: lighter; /* Lighter font weight. */
-  --pgn-typography-font-size-display-mobile-4: var(--pgn-typography-font-size-display-mobile-1); /* Mobile font size for heading of level 4. */
-  --pgn-typography-font-size-display-mobile-3: var(--pgn-typography-font-size-display-mobile-1); /* Mobile font size for heading of level 3. */
-  --pgn-typography-font-size-display-mobile-2: var(--pgn-typography-font-size-display-mobile-1); /* Mobile font size for heading of level 2. */
-  --pgn-typography-font-size-display-mobile-1: 3.25rem; /* Mobile font size for heading of level 1. */
-  --pgn-typography-font-size-display-4: 7.5rem; /* Font size for heading of level 4. */
-  --pgn-typography-font-size-display-3: 5.625rem; /* Font size for heading of level 3. */
-  --pgn-typography-font-size-display-2: 4.875rem; /* Font size for heading of level 2. */
-  --pgn-typography-font-size-display-1: 3.75rem; /* Font size for heading of level 1. */
-  --pgn-typography-font-size-h6-mobile: var(--pgn-typography-font-size-h6-base); /* Mobile font size of heading level 6. */
-  --pgn-typography-font-size-h6-base: 0.75rem; /* Font size of heading level 6. */
-  --pgn-typography-font-size-h5-mobile: var(--pgn-typography-font-size-h5-base); /* Mobile font size of heading level 5. */
-  --pgn-typography-font-size-h5-base: 0.875rem; /* Font size of heading level 5. */
-  --pgn-typography-font-size-h4-mobile: var(--pgn-typography-font-size-h4-base); /* Mobile font size of heading level 4. */
-  --pgn-typography-font-size-h4-base: 1.125rem; /* Font size of heading level 4. */
-  --pgn-typography-font-size-h3-mobile: var(--pgn-typography-font-size-h3-base); /* Mobile font size of heading level 3. */
-  --pgn-typography-font-size-h3-base: 1.375rem; /* Font size of heading level 3. */
-  --pgn-typography-font-size-h2-mobile: var(--pgn-typography-font-size-h2-base); /* Mobile font size of heading level 2. */
-  --pgn-typography-font-size-h2-base: 2rem; /* Font size of heading level 2. */
-  --pgn-typography-font-size-h1-mobile: 2.25rem; /* Mobile font size of heading level 1. */
-  --pgn-typography-font-size-h1-base: 2.5rem; /* Base font size of heading level 1. */
-  --pgn-typography-font-size-micro: 0.688rem; /* Micro utils text font size. */
-  --pgn-typography-font-size-xs: 75%; /* X-small font size. */
-  --pgn-typography-font-size-sm: 87.5%; /* Small font size. */
-  --pgn-typography-font-size-lg: calc(var(--pgn-typography-font-size-base) * 1.25); /* Lead text font size. */
-  --pgn-typography-font-size-base: 1.125rem; /* Base font size. */
-  --pgn-typography-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; /* Monospace font family. */
-  --pgn-typography-font-family-serif: serif; /* Serif font family. */
-  --pgn-typography-font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; /* Sans-serif font family. */
-  --pgn-typography-font-family-base: var(--pgn-typography-font-family-sans-serif); /* Basic font family. */
-  --pgn-typography-blockquote-font-size: calc(var(--pgn-typography-font-size-base) * 1.25);
-  --pgn-typography-blockquote-small-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-dt-font-weight: var(--pgn-typography-font-weight-bold);
-  --pgn-typography-link-decoration-brand-inline-hover: underline;
-  --pgn-typography-link-decoration-brand-inline-base: underline;
-  --pgn-typography-link-decoration-brand-hover: underline;
-  --pgn-typography-link-decoration-brand-base: none;
-  --pgn-typography-link-decoration-muted-inline-hover: underline;
-  --pgn-typography-link-decoration-muted-inline-base: underline;
-  --pgn-typography-link-decoration-muted-hover: underline;
-  --pgn-typography-link-decoration-muted-base: none;
-  --pgn-typography-link-decoration-inline-hover: underline;
-  --pgn-typography-link-decoration-inline-base: underline;
-  --pgn-typography-link-decoration-hover: underline;
-  --pgn-typography-link-decoration-base: none;
-  --pgn-typography-input-btn-line-height-lg: var(--pgn-typography-line-height-lg);
-  --pgn-typography-input-btn-line-height-sm: 1.4286;
-  --pgn-typography-input-btn-line-height-base: 1.3333;
-  --pgn-typography-input-btn-font-size-lg: 1.325rem;
-  --pgn-typography-input-btn-font-size-sm: 0.875rem;
-  --pgn-typography-input-btn-font-size-base: 1.125rem;
-  --pgn-typography-input-btn-font-family: inherit;
-  --pgn-typography-headings-line-height: 1.25;
-  --pgn-typography-headings-font-weight: var(--pgn-typography-font-weight-bold);
-  --pgn-typography-headings-font-family: inherit;
-  --pgn-typography-tooltip-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-toast-font-size: 0.875rem;
-  --pgn-typography-tabs-notification-font-size: var(--pgn-typography-font-size-xs);
-  --pgn-typography-spacer-line-height: 1px;
-  --pgn-typography-progress-bar-font-size: calc(var(--pgn-typography-font-size-base) * .75);
-  --pgn-typography-popover-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-pagination-line-height: 1.5rem;
-  --pgn-typography-pagination-font-size-sm: 0.875rem;
-  --pgn-typography-navbar-toggler-font-size: var(--pgn-typography-font-size-lg);
-  --pgn-typography-navbar-nav-link-height: calc(var(--pgn-typography-font-size-base) * var(--pgn-typography-line-height-base) + .5rem * 2);
-  --pgn-typography-navbar-brand-font-size: var(--pgn-typography-font-size-lg);
-  --pgn-typography-nav-link-text-decoration: none;
-  --pgn-typography-nav-link-font-weight: 500;
-  --pgn-typography-menu-select-btn-link-text-decoration-thickness: 0.125rem;
-  --pgn-typography-menu-select-btn-link-text-decoration-line: underline;
-  --pgn-typography-image-figure-caption-font-size: 90%;
-  --pgn-typography-form-feedback-tooltip-line-height: var(--pgn-typography-line-height-base);
-  --pgn-typography-form-feedback-tooltip-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-form-feedback-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-form-control-file-font-weight: var(--pgn-typography-form-input-font-weight);
-  --pgn-typography-form-control-file-font-family: var(--pgn-typography-form-input-font-family);
-  --pgn-typography-form-control-file-line-height: var(--pgn-typography-form-input-line-height-base);
-  --pgn-typography-form-control-select-line-height: var(--pgn-typography-form-input-line-height-base);
-  --pgn-typography-form-control-select-font-weight: var(--pgn-typography-form-input-font-weight);
-  --pgn-typography-form-control-select-font-size-lg: var(--pgn-typography-form-input-font-size-lg);
-  --pgn-typography-form-control-select-font-size-sm: var(--pgn-typography-form-input-font-size-sm);
-  --pgn-typography-form-control-select-font-size-base: var(--pgn-typography-form-input-font-size-base);
-  --pgn-typography-form-control-select-font-family: var(--pgn-typography-form-input-font-family);
-  --pgn-typography-form-input-line-height-lg: var(--pgn-typography-input-btn-line-height-lg);
-  --pgn-typography-form-input-line-height-sm: var(--pgn-typography-input-btn-line-height-sm);
-  --pgn-typography-form-input-line-height-base: var(--pgn-typography-input-btn-line-height-base);
-  --pgn-typography-form-input-font-weight: var(--pgn-typography-font-weight-base);
-  --pgn-typography-form-input-font-size-lg: var(--pgn-typography-input-btn-font-size-lg);
-  --pgn-typography-form-input-font-size-sm: var(--pgn-typography-input-btn-font-size-sm);
-  --pgn-typography-form-input-font-size-base: var(--pgn-typography-input-btn-font-size-base);
-  --pgn-typography-form-input-font-family: var(--pgn-typography-input-btn-font-family);
-  --pgn-typography-dropzone-restriction-msg-font-size: var(--pgn-typography-font-size-xs);
-  --pgn-typography-dropdown-item-text-decoration: none;
-  --pgn-typography-dropdown-font-size: var(--pgn-typography-font-size-base);
-  --pgn-typography-code-kbd-nested-font-weight: var(--pgn-typography-font-weight-bold);
-  --pgn-typography-code-kbd-font-size: var(--pgn-typography-code-font-size);
-  --pgn-typography-code-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-close-button-font-weight: var(--pgn-typography-font-weight-bold);
-  --pgn-typography-close-button-font-size: calc(var(--pgn-typography-font-size-base) * 1.5);
-  --pgn-typography-footer-text-font-size: var(--pgn-typography-font-size-xs);
-  --pgn-typography-btn-line-height-lg: var(--pgn-typography-input-btn-line-height-lg);
-  --pgn-typography-btn-line-height-sm: var(--pgn-typography-input-btn-line-height-sm);
-  --pgn-typography-btn-line-height-base: var(--pgn-typography-input-btn-line-height-base);
-  --pgn-typography-btn-font-weight: var(--pgn-typography-font-weight-normal);
-  --pgn-typography-btn-font-size-lg: var(--pgn-typography-input-btn-font-size-lg);
-  --pgn-typography-btn-font-size-sm: var(--pgn-typography-input-btn-font-size-sm);
-  --pgn-typography-btn-font-size-base: var(--pgn-typography-input-btn-font-size-base);
-  --pgn-typography-btn-font-family: var(--pgn-typography-input-btn-font-family);
-  --pgn-typography-badge-font-weight: var(--pgn-typography-font-weight-bold);
-  --pgn-typography-badge-font-size: 75%;
-  --pgn-typography-annotation-line-height: var(--pgn-typography-line-height-sm);
-  --pgn-typography-annotation-font-size: var(--pgn-typography-font-size-sm);
-  --pgn-typography-alert-line-height: 1.5rem;
-  --pgn-typography-alert-font-size: 0.875rem;
-  --pgn-typography-alert-font-weight-link: var(--pgn-typography-font-weight-normal);
-  --pgn-spacing-grid-gutter-width: 24px; /* Grid gutter width value. */
-  --pgn-spacing-table-cell-padding-sm: 0.3rem; /* Padding sm for tables. */
-  --pgn-spacing-table-cell-padding-base: 0.75rem; /* Padding for tables. */
-  --pgn-spacing-label-margin-bottom: 0.5rem; /* Margin bottom for label. */
-  --pgn-spacing-spacer-5-5: calc(var(--pgn-spacing-spacer-base) * 4); /* Space value of level 5.5 */
-  --pgn-spacing-spacer-4-5: calc(var(--pgn-spacing-spacer-base) * 2); /* Space value of level 4.5 */
-  --pgn-spacing-spacer-3-5: calc(var(--pgn-spacing-spacer-base) * 1.25); /* Space value of level 3.5 */
-  --pgn-spacing-spacer-2-5: calc(var(--pgn-spacing-spacer-base) * .75); /* Space value of level 2.5 */
-  --pgn-spacing-spacer-1-5: calc(var(--pgn-spacing-spacer-base) * .375); /* Space value of level 1.5 */
-  --pgn-spacing-spacer-base: 1rem; /* Basic space value */
-  --pgn-spacing-spacer-6: calc(var(--pgn-spacing-spacer-base) * 5); /* Space value of level 6 */
-  --pgn-spacing-spacer-5: calc(var(--pgn-spacing-spacer-base) * 3); /* Space value of level 5 */
-  --pgn-spacing-spacer-4: calc(var(--pgn-spacing-spacer-base) * 1.5); /* Space value of level 4 */
-  --pgn-spacing-spacer-3: var(--pgn-spacing-spacer-base); /* Space value of level 3 */
-  --pgn-spacing-spacer-2: calc(var(--pgn-spacing-spacer-base) * .5); /* Space value of level 2 */
-  --pgn-spacing-spacer-1: calc(var(--pgn-spacing-spacer-base) * .25); /* Space value of level 1 */
-  --pgn-spacing-spacer-0: 0rem; /* Space value of level 0 */
-  --pgn-spacing-mark-padding: 0.2em;
-  --pgn-spacing-paragraph-margin-bottom: 1rem;
-  --pgn-spacing-list-group-item-padding-x: 1.25rem;
-  --pgn-spacing-list-group-item-padding-y: 0.75rem;
-  --pgn-spacing-list-inline-padding: 0.5rem;
-  --pgn-spacing-input-btn-padding-lg-x: 1.25rem;
-  --pgn-spacing-input-btn-padding-lg-y: 0.6875rem;
-  --pgn-spacing-input-btn-padding-sm-x: 0.75rem;
-  --pgn-spacing-input-btn-padding-sm-y: 0.4375rem;
-  --pgn-spacing-input-btn-padding-x: 1rem;
-  --pgn-spacing-input-btn-padding-y: 0.5625rem;
-  --pgn-spacing-headings-margin-bottom: 0.5rem;
-  --pgn-spacing-caret-vertical-align: 0.255em;
-  --pgn-spacing-caret-base: 0.255em;
-  --pgn-spacing-tooltip-margin: 0rem;
-  --pgn-spacing-tooltip-padding-x: 0.5rem;
-  --pgn-spacing-tooltip-padding-y: 0.5rem;
-  --pgn-spacing-toast-container-gutter-sm: 0.625rem;
-  --pgn-spacing-toast-container-gutter-lg: 1.25rem;
-  --pgn-spacing-toast-padding-y: 0.25rem;
-  --pgn-spacing-toast-padding-x: 0.75rem;
-  --pgn-spacing-tab-inverse-tabs-link-dropdown-toggle-distance: 5px;
-  --pgn-spacing-tab-inverse-tabs-link-dropdown-toggle-padding-y: var(--pgn-spacing-spacer-base);
-  --pgn-spacing-tab-inverse-tabs-link-dropdown-toggle-padding-x: 0.625rem;
-  --pgn-spacing-tab-inverse-pills-link-dropdown-toggle-padding-y: var(--pgn-spacing-spacer-base);
-  --pgn-spacing-tab-inverse-pills-link-dropdown-toggle-padding-x: 0.625rem;
-  --pgn-spacing-tab-more-link-dropdown-toggle-padding-y: var(--pgn-spacing-spacer-base);
-  --pgn-spacing-tab-more-link-dropdown-toggle-padding-x: 0.7rem;
-  --pgn-spacing-sticky-offset: 0rem;
-  --pgn-spacing-stepper-header-step-list-margin: 0rem;
-  --pgn-spacing-stepper-header-step-list-padding-x: 0rem;
-  --pgn-spacing-stepper-header-step-list-padding-y: 0.25rem;
-  --pgn-spacing-stepper-header-step-padding: 0.25rem;
-  --pgn-spacing-stepper-header-padding-x: var(--pgn-spacing-spacer-base);
-  --pgn-spacing-stepper-header-padding-y: 0.75rem;
-  --pgn-spacing-vertical-align: 0.125em;
-  --pgn-spacing-selectable-box-box-space: 0.75rem;
-  --pgn-spacing-selectable-box-border-radius: 0.25rem;
-  --pgn-spacing-selectable-box-padding: 1rem;
-  --pgn-spacing-search-field-margin-button: 0.5rem;
-  --pgn-spacing-progress-bar-hint-annotation-gap: 0.5rem;
-  --pgn-spacing-popover-icon-margin-right: 0.5rem;
-  --pgn-spacing-popover-body-padding-x: var(--pgn-spacing-popover-header-padding-x);
-  --pgn-spacing-popover-body-padding-y: var(--pgn-spacing-popover-header-padding-y);
-  --pgn-spacing-popover-header-padding-x: 1rem;
-  --pgn-spacing-popover-header-padding-y: 0.5rem;
-  --pgn-spacing-pagination-padding-x-lg: 1.5rem;
-  --pgn-spacing-pagination-padding-x-sm: 0.6rem;
-  --pgn-spacing-pagination-padding-x-base: 1rem;
-  --pgn-spacing-pagination-padding-y-lg: 0.75rem;
-  --pgn-spacing-pagination-padding-y-sm: 0.8rem;
-  --pgn-spacing-pagination-padding-y-base: 0.625rem;
-  --pgn-spacing-navbar-toggler-padding-x: 0.75rem;
-  --pgn-spacing-navbar-toggler-padding-y: 0.25rem;
-  --pgn-spacing-navbar-brand-padding-y: calc((var(--pgn-typography-navbar-nav-link-height) - var(--pgn-size-navbar-brand-height)) / 2);
-  --pgn-spacing-navbar-padding-x-nav-link: 0.5rem;
-  --pgn-spacing-navbar-padding-x-base: var(--pgn-spacing-spacer-base);
-  --pgn-spacing-navbar-padding-y: calc(var(--pgn-spacing-spacer-base) / 2);
-  --pgn-spacing-nav-link-distance-to-border: 4px;
-  --pgn-spacing-nav-link-padding-x: 1rem;
-  --pgn-spacing-nav-link-padding-y: 0.5rem;
-  --pgn-spacing-modal-dialog-margin: 1.5rem;
-  --pgn-spacing-modal-header-padding-y: 1rem;
-  --pgn-spacing-modal-header-padding-base-y: var(--pgn-spacing-modal-header-padding-y);
-  --pgn-spacing-modal-header-padding-base-x: 1.5rem;
-  --pgn-spacing-modal-footer-padding-y: 1rem;
-  --pgn-spacing-modal-footer-padding-base-y: var(--pgn-spacing-modal-footer-padding-y);
-  --pgn-spacing-modal-footer-padding-base-x: 1.5rem;
-  --pgn-spacing-modal-inner-padding-bottom: 0.7rem;
-  --pgn-spacing-modal-inner-padding-base: 1.5rem;
-  --pgn-spacing-menu-item-icon-margin-right: var(--pgn-spacing-menu-item-icon-margin-left);
-  --pgn-spacing-menu-item-icon-margin-left: 0.25em;
-  --pgn-spacing-menu-item-padding-y: var(--pgn-spacing-btn-padding-y-base);
-  --pgn-spacing-menu-item-padding-x: var(--pgn-spacing-btn-padding-x-base);
-  --pgn-spacing-image-thumbnail-padding: 0.25rem;
-  --pgn-spacing-form-control-file-padding-x: var(--pgn-spacing-form-input-padding-x-base);
-  --pgn-spacing-form-control-file-padding-y: var(--pgn-spacing-form-input-padding-y-base);
-  --pgn-spacing-form-control-select-icon-padding: 0.5625rem;
-  --pgn-spacing-form-control-select-feedback-tooltip-padding-x: 0.5rem;
-  --pgn-spacing-form-control-select-feedback-tooltip-padding-y: 0.25rem;
-  --pgn-spacing-form-control-select-feedback-margin-top: var(--pgn-spacing-form-text-margin-top);
-  --pgn-spacing-form-control-select-feedback-icon-position-offset-y: 0;
-  --pgn-spacing-form-control-select-feedback-icon-position-offset-x: calc(var(--pgn-spacing-form-control-select-padding-x-base) + var(--pgn-spacing-form-control-select-indicator-padding));
-  --pgn-spacing-form-control-select-feedback-icon-position-position-x: right;
-  --pgn-spacing-form-control-select-feedback-icon-position-position-y: center;
-  --pgn-spacing-form-control-select-feedback-icon-padding-right: calc((1em + 2 * var(--pgn-spacing-form-control-select-padding-y-base)) * 3 / 4 + var(--pgn-spacing-form-control-select-padding-x-base) + var(--pgn-spacing-form-control-select-indicator-padding));
-  --pgn-spacing-form-control-select-indicator-padding: 1rem;
-  --pgn-spacing-form-control-select-padding-x-lg: var(--pgn-spacing-form-input-padding-x-lg);
-  --pgn-spacing-form-control-select-padding-x-sm: var(--pgn-spacing-form-input-padding-x-sm);
-  --pgn-spacing-form-control-select-padding-x-base: var(--pgn-spacing-form-input-padding-x-base);
-  --pgn-spacing-form-control-select-padding-y-lg: var(--pgn-spacing-form-input-padding-y-lg);
-  --pgn-spacing-form-control-select-padding-y-sm: var(--pgn-spacing-form-input-padding-y-sm);
-  --pgn-spacing-form-control-select-padding-y-base: var(--pgn-spacing-form-input-padding-y-base);
-  --pgn-spacing-form-control-spacer-x: 1rem;
-  --pgn-spacing-form-control-gutter: 0.5rem;
-  --pgn-spacing-form-group-margin-bottom: 1rem;
-  --pgn-spacing-form-check-position-axis: 0.375rem;
-  --pgn-spacing-form-check-inline-margin-x: 0.75rem;
-  --pgn-spacing-form-text-margin-top: 0.25rem;
-  --pgn-spacing-form-input-check-margin-y: 0.3rem;
-  --pgn-spacing-form-input-check-margin-x-inline: 0.3125rem;
-  --pgn-spacing-form-input-check-margin-x-base: 0.25rem;
-  --pgn-spacing-form-input-check-gutter: 1.25rem;
-  --pgn-spacing-form-input-padding-x-lg: var(--pgn-spacing-input-btn-padding-lg-x);
-  --pgn-spacing-form-input-padding-x-sm: var(--pgn-spacing-input-btn-padding-sm-x);
-  --pgn-spacing-form-input-padding-x-base: var(--pgn-spacing-input-btn-padding-x);
-  --pgn-spacing-form-input-padding-y-lg: var(--pgn-spacing-input-btn-padding-lg-y);
-  --pgn-spacing-form-input-padding-y-sm: var(--pgn-spacing-input-btn-padding-sm-y);
-  --pgn-spacing-form-input-padding-y-base: var(--pgn-spacing-input-btn-padding-y);
-  --pgn-spacing-dropzone-border-base: 1px;
-  --pgn-spacing-dropzone-padding: 1.5rem;
-  --pgn-spacing-dropdown-close-container-top: 0.625rem;
-  --pgn-spacing-dropdown-divider-margin-y: calc(var(--pgn-spacing-spacer-base) / 2);
-  --pgn-spacing-dropdown-padding-header-y: 0.5rem;
-  --pgn-spacing-dropdown-padding-header-x: var(--pgn-spacing-dropdown-padding-x-item);
-  --pgn-spacing-dropdown-padding-y-item: 0.25rem;
-  --pgn-spacing-dropdown-padding-y-base: 0.5rem;
-  --pgn-spacing-dropdown-padding-x-item: 1rem;
-  --pgn-spacing-dropdown-padding-x-base: 0rem;
-  --pgn-spacing-dropdown-spacer: 0.125rem;
-  --pgn-spacing-data-table-footer-position: center;
-  --pgn-spacing-data-table-padding-cell-y: 0.75rem;
-  --pgn-spacing-data-table-padding-cell-x: 0.5rem;
-  --pgn-spacing-data-table-padding-small: 0.5rem;
-  --pgn-spacing-data-table-padding-y: 0.75rem;
-  --pgn-spacing-data-table-padding-x: 0.75rem;
-  --pgn-spacing-collapsible-card-spacer-basic-icon: 0.625rem;
-  --pgn-spacing-collapsible-card-spacer-basic-x: 0.5rem;
-  --pgn-spacing-collapsible-card-spacer-basic-y: 0.5rem;
-  --pgn-spacing-collapsible-card-spacer-icon: 2.5rem;
-  --pgn-spacing-collapsible-card-spacer-left-body: 0.75rem;
-  --pgn-spacing-collapsible-card-spacer-x-lg: var(--pgn-spacing-card-spacer-x);
-  --pgn-spacing-collapsible-card-spacer-x-base: 0.5rem;
-  --pgn-spacing-collapsible-card-spacer-y-lg: var(--pgn-spacing-card-spacer-y);
-  --pgn-spacing-collapsible-card-spacer-y-base: 0.5rem;
-  --pgn-spacing-code-kbd-padding-x: 0.4rem;
-  --pgn-spacing-code-kbd-padding-y: 0.2rem;
-  --pgn-spacing-chip-carousel-container-padding-y: 0.313rem;
-  --pgn-spacing-chip-carousel-container-padding-x: 0.625rem;
-  --pgn-spacing-chip-carousel-controls-top-offset: 0.375rem;
-  --pgn-spacing-chip-outline-width: 3px;
-  --pgn-spacing-chip-outline-focus-distance-dark: 0.313rem;
-  --pgn-spacing-chip-outline-focus-distance-light: 0.313rem;
-  --pgn-spacing-chip-outline-selected-distance-dark: 3px;
-  --pgn-spacing-chip-outline-selected-distance-light: 3px;
-  --pgn-spacing-chip-padding-x: 0.5rem;
-  --pgn-spacing-chip-padding-y: 1px;
-  --pgn-spacing-chip-margin-icon: 0.25rem;
-  --pgn-spacing-chip-margin-base: 0.125rem;
-  --pgn-spacing-carousel-indicator-spacer: 3px;
-  --pgn-spacing-card-focus-border-offset: 5px;
-  --pgn-spacing-card-logo-bottom-offset-horizontal: 0.4375rem;
-  --pgn-spacing-card-logo-bottom-offset-base: 1rem;
-  --pgn-spacing-card-logo-left-offset-horizontal: 0.4375rem;
-  --pgn-spacing-card-logo-left-offset-base: 1.5rem;
-  --pgn-spacing-card-loading-skeleton-spacer: 0.313rem;
-  --pgn-spacing-card-footer-action-gap: 0.5rem;
-  --pgn-spacing-card-columns-gap: 1.25rem;
-  --pgn-spacing-card-columns-count: 3;
-  --pgn-spacing-card-columns-margin: var(--pgn-spacing-card-spacer-y);
-  --pgn-spacing-card-margin-grid-bottom: var(--pgn-spacing-spacer-3);
-  --pgn-spacing-card-margin-grid: var(--pgn-spacing-card-margin-group);
-  --pgn-spacing-card-margin-deck-bottom: var(--pgn-spacing-spacer-3);
-  --pgn-spacing-card-margin-deck: var(--pgn-spacing-card-margin-group);
-  --pgn-spacing-card-margin-group: 12px;
-  --pgn-spacing-card-spacer-y: 0.75rem;
-  --pgn-spacing-card-spacer-x: 1.25rem;
-  --pgn-spacing-btn-focus-distance-to-border: calc(var(--pgn-spacing-btn-focus-border-gap) + var(--pgn-size-btn-border-width));
-  --pgn-spacing-btn-focus-border-gap: calc(var(--pgn-size-btn-focus-width) + var(--pgn-spacing-btn-focus-gap));
-  --pgn-spacing-btn-focus-gap: var(--pgn-size-btn-focus-width);
-  --pgn-spacing-btn-block-spacing-y: 0.5rem;
-  --pgn-spacing-btn-padding-x-sm: var(--pgn-spacing-input-btn-padding-sm-x);
-  --pgn-spacing-btn-padding-x-lg: var(--pgn-spacing-input-btn-padding-lg-x);
-  --pgn-spacing-btn-padding-x-base: var(--pgn-spacing-input-btn-padding-x);
-  --pgn-spacing-btn-padding-y-sm: var(--pgn-spacing-input-btn-padding-sm-y);
-  --pgn-spacing-btn-padding-y-lg: var(--pgn-spacing-input-btn-padding-lg-y);
-  --pgn-spacing-btn-padding-y-base: var(--pgn-spacing-input-btn-padding-y);
-  --pgn-spacing-bubble-expandable-padding-x: 0.25rem;
-  --pgn-spacing-bubble-expandable-padding-y: 0rem;
-  --pgn-spacing-breadcrumb-margin-left: 0.5rem;
-  --pgn-spacing-badge-padding-y: 0.125rem;
-  --pgn-spacing-badge-padding-x-pill: 0.6em;
-  --pgn-spacing-badge-padding-x-base: 0.5rem;
-  --pgn-spacing-avatar-button-padding-left-lg: 0.25em;
-  --pgn-spacing-avatar-button-padding-left-sm: 0.25em;
-  --pgn-spacing-avatar-button-padding-left-base: 0.25em;
-  --pgn-spacing-annotation-arrow-side-margin: 0.25rem;
-  --pgn-spacing-annotation-padding: 0.5rem;
-  --pgn-spacing-alert-icon-space: 0.8rem;
-  --pgn-spacing-alert-actions-gap: var(--pgn-spacing-spacer-3);
-  --pgn-spacing-alert-margin-bottom: 1rem;
-  --pgn-spacing-alert-padding-x: 1.5rem;
-  --pgn-spacing-alert-padding-y: 1.5rem;
-  --pgn-spacing-action-row-gap-y: 0.5rem;
-  --pgn-spacing-action-row-gap-x: 0.5rem;
-  --pgn-size-breakpoint-xxl: 1400px; /* Starting breakpoint for large desktops, more than 1400px. */
-  --pgn-size-breakpoint-xl: 1200px; /* Starting breakpoint for large desktops. */
-  --pgn-size-breakpoint-lg: 992px; /* Starting breakpoint for desktops. */
-  --pgn-size-breakpoint-md: 768px; /* Starting breakpoint for tablets. */
-  --pgn-size-breakpoint-sm: 576px; /* Starting breakpoint for landscape phones. */
-  --pgn-size-breakpoint-xs: 0px; /* Starting breakpoint for portrait phones. */
-  --pgn-size-list-group-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-list-group-border-width: var(--pgn-size-border-width);
-  --pgn-size-input-btn-focus-width: 1px;
-  --pgn-size-input-btn-border-width: var(--pgn-size-border-width);
-  --pgn-size-hr-border-margin-y: var(--pgn-spacing-spacer-base);
-  --pgn-size-hr-border-width: var(--pgn-size-border-width);
-  --pgn-size-caret-width: 0.3em;
-  --pgn-size-tooltip-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-tooltip-arrow-width: 0.8rem;
-  --pgn-size-tooltip-arrow-height: 0.4rem;
-  --pgn-size-tooltip-max-width: 200px;
-  --pgn-size-toast-border-radius: 0.25rem;
-  --pgn-size-toast-border-width: 1px;
-  --pgn-size-toast-max-width: 400px;
-  --pgn-size-tabs-notification-width: 1rem;
-  --pgn-size-tabs-notification-height: 1rem;
-  --pgn-size-stepper-step-bubble-error-shadow-width: 3px;
-  --pgn-size-stepper-step-width-min: 0rem;
-  --pgn-size-stepper-header-height-min: 5.13rem;
-  --pgn-size-stack-gap: 0rem;
-  --pgn-size-spinner-sm-border-width: 0.2em;
-  --pgn-size-spinner-sm-height: var(--pgn-size-spinner-sm-width);
-  --pgn-size-spinner-sm-width: 1rem;
-  --pgn-size-spinner-base-border-width: 0.25em;
-  --pgn-size-spinner-base-height: var(--pgn-size-spinner-base-width);
-  --pgn-size-spinner-base-width: 2rem;
-  --pgn-size-search-field-search-input-height: calc(var(--pgn-typography-form-input-line-height-base) * 1em + var(--pgn-spacing-form-input-padding-y-base) * 2);
-  --pgn-size-search-field-border-radius: 0rem;
-  --pgn-size-search-field-border-width-focus: 0.3125rem;
-  --pgn-size-search-field-border-width-base: 0.0625rem;
-  --pgn-size-progress-bar-threshold-circle: 0.5625rem;
-  --pgn-size-progress-bar-border-radius: 0rem;
-  --pgn-size-progress-bar-border-width: 1px;
-  --pgn-size-progress-bar-height-annotated: 0.3125rem;
-  --pgn-size-progress-bar-height-base: 1rem;
-  --pgn-size-product-tour-checkpoint-arrow-transparent: var(--pgn-size-product-tour-checkpoint-width-arrow);
-  --pgn-size-product-tour-checkpoint-arrow-top: var(--pgn-size-product-tour-checkpoint-width-arrow);
-  --pgn-size-product-tour-checkpoint-width-max: 480px;
-  --pgn-size-product-tour-checkpoint-width-arrow: 15px;
-  --pgn-size-product-tour-checkpoint-width-border: 8px;
-  --pgn-size-popover-arrow-height: 0.5rem;
-  --pgn-size-popover-arrow-width: 1rem;
-  --pgn-size-popover-icon-width: 1rem;
-  --pgn-size-popover-icon-height: 1rem;
-  --pgn-size-popover-border-radius: var(--pgn-size-border-radius-sm);
-  --pgn-size-popover-border-width: var(--pgn-size-border-width);
-  --pgn-size-popover-max-width: 480px;
-  --pgn-size-pagination-focus-outline: 0rem;
-  --pgn-size-pagination-toggle-border-sm: 0.25rem;
-  --pgn-size-pagination-toggle-border-base: 0.3125rem;
-  --pgn-size-pagination-reduced-dropdown-min-width: 6rem;
-  --pgn-size-pagination-reduced-dropdown-max-height: 60vh;
-  --pgn-size-pagination-border-radius-lg: var(--pgn-size-border-radius-lg);
-  --pgn-size-pagination-border-radius-sm: var(--pgn-size-border-radius-sm);
-  --pgn-size-pagination-border-width: var(--pgn-size-border-width);
-  --pgn-size-pagination-secondary-height-sm: 2.25rem;
-  --pgn-size-pagination-secondary-height-base: 2.75rem;
-  --pgn-size-pagination-icon-height: 2.25rem;
-  --pgn-size-pagination-icon-width: 2.25rem;
-  --pgn-size-navbar-toggler-border-radius: var(--pgn-size-btn-border-radius-base);
-  --pgn-size-navbar-brand-height: calc(var(--pgn-typography-navbar-brand-font-size) * var(--pgn-typography-line-height-base));
-  --pgn-size-navbar-nav-scroll-max-height: 75vh;
-  --pgn-size-nav-tabs-border-radius: 0rem;
-  --pgn-size-nav-tabs-border-width: 2px;
-  --pgn-size-nav-tabs-inverse-link-active-border-bottom-width: var(--pgn-size-nav-tabs-link-border-bottom-width);
-  --pgn-size-nav-tabs-link-border-bottom-width: 0.188rem;
-  --pgn-size-nav-pills-inverse-link-border-width: var(--pgn-size-nav-pills-link-border-width);
-  --pgn-size-nav-pills-link-border-width: 1px;
-  --pgn-size-nav-pills-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-modal-content-border-radius: var(--pgn-size-border-radius-lg);
-  --pgn-size-modal-content-border-width: 0px;
-  --pgn-size-modal-sm: 400px;
-  --pgn-size-modal-md: 500px;
-  --pgn-size-modal-lg: 800px;
-  --pgn-size-modal-xl: 1140px;
-  --pgn-size-menu-item-border-width: var(--pgn-size-btn-border-width);
-  --pgn-size-menu-item-width-xs: 13.438rem;
-  --pgn-size-menu-item-width-base: 19rem;
-  --pgn-size-menu-item-height: 3rem;
-  --pgn-size-menu-base-max-height: 16.813rem;
-  --pgn-size-menu-base-border-radius: 0.25em;
-  --pgn-size-image-thumbnail-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-image-thumbnail-border-width: var(--pgn-size-border-width);
-  --pgn-size-icon-button-diameter-inline: calc(var(--pgn-typography-line-height-base) * 1em + .1em);
-  --pgn-size-icon-button-diameter-sm: 2.25rem;
-  --pgn-size-icon-button-diameter-md: 2.75rem;
-  --pgn-size-icon-lg: 1.75rem;
-  --pgn-size-icon-md: 1.5rem;
-  --pgn-size-icon-sm: 1.25rem;
-  --pgn-size-icon-xs: 1rem;
-  --pgn-size-icon-inline: 0.8em;
-  --pgn-size-form-feedback-tooltip-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-form-border-radius-width: 0.125rem;
-  --pgn-size-form-border-radius-check-focus: 0.0625rem;
-  --pgn-size-form-autosuggest-border-width: 0.125rem;
-  --pgn-size-form-autosuggest-spinner-height: var(--pgn-size-form-autosuggest-spinner-width);
-  --pgn-size-form-autosuggest-spinner-width: 1.25rem;
-  --pgn-size-form-autosuggest-icon-height: var(--pgn-size-form-autosuggest-icon-width);
-  --pgn-size-form-autosuggest-icon-width: 2.4rem;
-  --pgn-size-form-grid-gutter-width: 0.625rem;
-  --pgn-size-form-control-border-radio-indicator-radius: 50%;
-  --pgn-size-form-control-border-checkbox-indicator-radius: 0rem;
-  --pgn-size-form-control-icon-width: 2rem;
-  --pgn-size-form-control-file-border-radius: var(--pgn-size-form-input-radius-border-base);
-  --pgn-size-form-control-file-height-inner: var(--pgn-size-form-input-height-inner-base);
-  --pgn-size-form-control-file-height-base: var(--pgn-size-form-input-height-base);
-  --pgn-size-form-control-file-width: var(--pgn-size-form-input-width-border);
-  --pgn-size-form-control-range-thumb-focus-width: var(--pgn-size-form-input-width-focus);
-  --pgn-size-form-control-range-thumb-border-radius: 1rem;
-  --pgn-size-form-control-range-thumb-border-base: 0rem;
-  --pgn-size-form-control-range-thumb-height: var(--pgn-size-form-control-range-thumb-width);
-  --pgn-size-form-control-range-thumb-width: 1rem;
-  --pgn-size-form-control-range-track-border-radius: 1rem;
-  --pgn-size-form-control-range-track-height: 0.5rem;
-  --pgn-size-form-control-range-track-width: 100%;
-  --pgn-size-form-control-select-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-form-control-select-border-width-base: var(--pgn-size-form-input-width-border);
-  --pgn-size-form-control-select-feedback-icon: var(--pgn-size-form-input-height-inner-half) var(--pgn-size-form-input-height-inner-half);
-  --pgn-size-form-control-select-height-sm: var(--pgn-size-form-input-height-sm);
-  --pgn-size-form-control-select-height-lg: var(--pgn-size-form-input-height-lg);
-  --pgn-size-form-control-select-height-base: var(--pgn-size-form-input-height-base);
-  --pgn-size-form-control-switch-indicator-border-radius: calc(var(--pgn-size-form-control-indicator-base) / 2);
-  --pgn-size-form-control-switch-indicator-base: calc(var(--pgn-size-form-control-indicator-base) - var(--pgn-size-form-control-indicator-border-width) * 4);
-  --pgn-size-form-control-switch-width: calc(var(--pgn-size-form-control-indicator-base) * 1.75);
-  --pgn-size-form-control-indicator-border-width: 0.125rem;
-  --pgn-size-form-control-indicator-bg: 100%;
-  --pgn-size-form-control-indicator-base: 1.25rem;
-  --pgn-size-form-input-radius-border-sm: var(--pgn-size-border-radius-sm);
-  --pgn-size-form-input-radius-border-lg: var(--pgn-size-border-radius-lg);
-  --pgn-size-form-input-radius-border-base: var(--pgn-size-border-radius-base);
-  --pgn-size-form-input-width-border: var(--pgn-size-input-btn-border-width);
-  --pgn-size-form-input-width-focus: 0.063rem;
-  --pgn-size-form-input-width-hover: 0.063rem;
-  --pgn-size-form-input-height-border: calc(var(--pgn-size-form-input-width-border) * 2);
-  --pgn-size-form-input-height-inner-quarter: calc(var(--pgn-typography-form-input-line-height-base) * .25em + calc(var(--pgn-spacing-form-input-padding-y-base) / 2));
-  --pgn-size-form-input-height-inner-half: calc(var(--pgn-typography-form-input-line-height-base) * .5em + var(--pgn-spacing-form-input-padding-y-base));
-  --pgn-size-form-input-height-inner-base: calc(var(--pgn-typography-form-input-line-height-base) * 1em + var(--pgn-spacing-form-input-padding-y-base) * 2);
-  --pgn-size-form-input-height-lg: calc(var(--pgn-typography-form-input-line-height-lg) * 1em + var(--pgn-spacing-input-btn-padding-lg-y) * 2 + var(--pgn-size-form-input-height-border));
-  --pgn-size-form-input-height-sm: calc(var(--pgn-typography-form-input-line-height-sm) * 1em + var(--pgn-spacing-input-btn-padding-sm-y) * 2 + var(--pgn-size-form-input-height-border));
-  --pgn-size-form-input-height-base: calc(var(--pgn-typography-form-input-line-height-base) * 1em + var(--pgn-spacing-form-input-padding-y-base) * 2 + var(--pgn-size-form-input-height-border));
-  --pgn-size-dropdown-border-radius-inner: calc(var(--pgn-size-dropdown-border-radius-base) - var(--pgn-size-dropdown-border-width));
-  --pgn-size-dropdown-border-radius-base: var(--pgn-size-border-radius-base);
-  --pgn-size-dropdown-border-width: var(--pgn-size-border-width);
-  --pgn-size-dropdown-min-width: 18rem;
-  --pgn-size-data-table-layout-sidebar-width: 12rem;
-  --pgn-size-data-table-dropdown-pagination-min-width: 6rem;
-  --pgn-size-data-table-dropdown-pagination-max-height: 60vh;
-  --pgn-size-data-table-border: 2px;
-  --pgn-size-container-max-width-xl: 1440px;
-  --pgn-size-container-max-width-lg: 1192px;
-  --pgn-size-container-max-width-md: 952px;
-  --pgn-size-container-max-width-sm: 708px;
-  --pgn-size-container-max-width-xs: 464px;
-  --pgn-size-color-picker-md: calc(1.3333em + 1.125rem + 2px);
-  --pgn-size-color-picker-sm: 2rem;
-  --pgn-size-code-pre-scrollable-max-height: 340px;
-  --pgn-size-chip-icon: 1.5rem;
-  --pgn-size-chip-border-radius: 0.375rem;
-  --pgn-size-carousel-caption-width: 70%;
-  --pgn-size-carousel-indicator-height-area-hit: 10px;
-  --pgn-size-carousel-indicator-height-base: 3px;
-  --pgn-size-carousel-indicator-width: 30px;
-  --pgn-size-carousel-control-width-icon: 20px;
-  --pgn-size-carousel-control-width-base: 15%;
-  --pgn-size-card-logo-height: 4.125rem;
-  --pgn-size-card-logo-width: 7.25rem;
-  --pgn-size-card-image-border-radius: var(--pgn-size-card-border-radius-base);
-  --pgn-size-card-image-vertical-max-height: 140px;
-  --pgn-size-card-image-horizontal-width-min: var(--pgn-size-card-image-horizontal-width-max);
-  --pgn-size-card-image-horizontal-width-max: 240px;
-  --pgn-size-card-focus-border-radius: calc(var(--pgn-spacing-card-focus-border-offset) + var(--pgn-size-card-border-radius-base));
-  --pgn-size-card-focus-border-width: 2px;
-  --pgn-size-card-border-radius-inner: calc(var(--pgn-size-card-border-radius-base) - var(--pgn-size-card-border-width));
-  --pgn-size-card-border-radius-logo: 0.25rem;
-  --pgn-size-card-border-radius-base: var(--pgn-size-border-radius-base);
-  --pgn-size-card-border-width: var(--pgn-size-border-width);
-  --pgn-size-btn-focus-border-radius-sm: var(--pgn-size-btn-border-radius-base);
-  --pgn-size-btn-focus-border-radius-lg: var(--pgn-size-btn-focus-border-radius-base);
-  --pgn-size-btn-focus-border-radius-base: calc(var(--pgn-size-btn-border-radius-base) + var(--pgn-spacing-btn-focus-border-gap));
-  --pgn-size-btn-focus-width: 2px;
-  --pgn-size-btn-border-radius-sm: var(--pgn-size-border-radius-sm);
-  --pgn-size-btn-border-radius-lg: var(--pgn-size-border-radius-lg);
-  --pgn-size-btn-border-radius-base: var(--pgn-size-border-radius-base);
-  --pgn-size-btn-border-width: var(--pgn-size-input-btn-border-width);
-  --pgn-size-breadcrumb-border-width-focus: 0.0625rem;
-  --pgn-size-breadcrumb-border-axis-y-focus: 0.5rem;
-  --pgn-size-breadcrumb-border-axis-x-focus: 0.25rem;
-  --pgn-size-breadcrumb-border-radius-focus: 0.125rem;
-  --pgn-size-badge-focus-width: var(--pgn-size-input-btn-focus-width);
-  --pgn-size-badge-border-radius-pill: 10rem;
-  --pgn-size-badge-border-radius-base: 0.25rem;
-  --pgn-size-avatar-border-radius: 100%;
-  --pgn-size-avatar-border-base: 1px;
-  --pgn-size-avatar-huge: 18.75rem;
-  --pgn-size-avatar-xxl: 11.5rem;
-  --pgn-size-avatar-xl: 6rem;
-  --pgn-size-avatar-lg: 4rem;
-  --pgn-size-avatar-sm: 2.25rem;
-  --pgn-size-avatar-xs: 1.5rem;
-  --pgn-size-avatar-base: 3rem;
-  --pgn-size-annotation-border-radius: 0.25rem;
-  --pgn-size-annotation-max-width: 18.75rem;
-  --pgn-size-annotation-arrow-border-width: 0.5rem;
-  --pgn-size-alert-border-width: 0rem;
-  --pgn-size-alert-border-radius: var(--pgn-size-border-radius-base);
-  --pgn-size-rounded-pill: 50rem; /* Pill border radius. */
-  --pgn-size-border-radius-sm: 0.25rem; /* Small border radius. */
-  --pgn-size-border-radius-lg: 0.425rem; /* Large border radius. */
-  --pgn-size-border-radius-base: 0.375rem; /* Default border radius. */
   --pgn-size-border-width: 1px; /* Default border width. */
+  --pgn-size-border-radius-base: 0.375rem; /* Default border radius. */
+  --pgn-size-border-radius-lg: 0.425rem; /* Large border radius. */
+  --pgn-size-border-radius-sm: 0.25rem; /* Small border radius. */
+  --pgn-size-rounded-pill: 50rem; /* Pill border radius. */
+  --pgn-size-alert-border-width: 0;
+  --pgn-size-annotation-arrow-border-width: 0.5rem;
+  --pgn-size-annotation-max-width: 18.75rem;
+  --pgn-size-annotation-border-radius: 0.25rem;
+  --pgn-size-avatar-base: 3rem;
+  --pgn-size-avatar-xs: 1.5rem;
+  --pgn-size-avatar-sm: 2.25rem;
+  --pgn-size-avatar-lg: 4rem;
+  --pgn-size-avatar-xl: 6rem;
+  --pgn-size-avatar-xxl: 11.5rem;
+  --pgn-size-avatar-huge: 18.75rem;
+  --pgn-size-avatar-border-base: 1px;
+  --pgn-size-avatar-border-radius: 100%;
+  --pgn-size-badge-border-radius-base: 0.25rem;
+  --pgn-size-badge-border-radius-pill: 10rem;
+  --pgn-size-breadcrumb-border-radius-focus: 0.125rem;
+  --pgn-size-breadcrumb-border-axis-x-focus: 0.25rem;
+  --pgn-size-breadcrumb-border-axis-y-focus: 0.5rem;
+  --pgn-size-breadcrumb-border-width-focus: 0.0625rem;
+  --pgn-size-btn-focus-width: 2px;
+  --pgn-size-card-border-radius-logo: 0.25rem;
+  --pgn-size-card-focus-border-width: 2px;
+  --pgn-size-card-image-horizontal-width-max: 240px;
+  --pgn-size-card-image-vertical-max-height: 140px;
+  --pgn-size-card-logo-width: 7.25rem;
+  --pgn-size-card-logo-height: 4.125rem;
+  --pgn-size-carousel-control-width-base: 15%;
+  --pgn-size-carousel-control-width-icon: 20px;
+  --pgn-size-carousel-indicator-width: 30px;
+  --pgn-size-carousel-indicator-height-base: 3px;
+  --pgn-size-carousel-indicator-height-area-hit: 10px;
+  --pgn-size-carousel-caption-width: 70%;
+  --pgn-size-chip-border-radius: 0.375rem;
+  --pgn-size-chip-icon: 1.5rem;
+  --pgn-size-code-pre-scrollable-max-height: 340px;
+  --pgn-size-color-picker-sm: 2rem;
+  --pgn-size-color-picker-md: calc(1.3333em + 1.125rem + 2px);
+  --pgn-size-container-max-width-xs: 464px;
+  --pgn-size-container-max-width-sm: 708px;
+  --pgn-size-container-max-width-md: 952px;
+  --pgn-size-container-max-width-lg: 1192px;
+  --pgn-size-container-max-width-xl: 1440px;
+  --pgn-size-data-table-border: 2px;
+  --pgn-size-data-table-dropdown-pagination-max-height: 60vh;
+  --pgn-size-data-table-dropdown-pagination-min-width: 6rem;
+  --pgn-size-data-table-layout-sidebar-width: 12rem;
+  --pgn-size-dropdown-min-width: 18rem;
+  --pgn-size-form-input-width-hover: 0.063rem;
+  --pgn-size-form-input-width-focus: 0.063rem;
+  --pgn-size-form-control-indicator-base: 1.25rem;
+  --pgn-size-form-control-indicator-bg: 100%;
+  --pgn-size-form-control-indicator-border-width: 0.125rem;
+  --pgn-size-form-control-range-track-width: 100%;
+  --pgn-size-form-control-range-track-height: 0.5rem;
+  --pgn-size-form-control-range-track-border-radius: 1rem;
+  --pgn-size-form-control-range-thumb-width: 1rem;
+  --pgn-size-form-control-range-thumb-border-base: 0;
+  --pgn-size-form-control-range-thumb-border-radius: 1rem;
+  --pgn-size-form-control-icon-width: 2rem;
+  --pgn-size-form-control-border-checkbox-indicator-radius: 0;
+  --pgn-size-form-control-border-radio-indicator-radius: 50%;
+  --pgn-size-form-grid-gutter-width: 0.625rem;
+  --pgn-size-form-autosuggest-icon-width: 2.4rem;
+  --pgn-size-form-autosuggest-spinner-width: 1.25rem;
+  --pgn-size-form-autosuggest-border-width: 0.125rem;
+  --pgn-size-form-border-radius-check-focus: 0.0625rem;
+  --pgn-size-form-border-radius-width: 0.125rem;
+  --pgn-size-icon-inline: 0.8em;
+  --pgn-size-icon-xs: 1rem;
+  --pgn-size-icon-sm: 1.25rem;
+  --pgn-size-icon-md: 1.5rem;
+  --pgn-size-icon-lg: 1.75rem;
+  --pgn-size-icon-button-diameter-md: 2.75rem;
+  --pgn-size-icon-button-diameter-sm: 2.25rem;
+  --pgn-size-menu-base-border-radius: 0.25em;
+  --pgn-size-menu-base-max-height: 16.813rem;
+  --pgn-size-menu-item-height: 3rem;
+  --pgn-size-menu-item-width-base: 19rem;
+  --pgn-size-menu-item-width-xs: 13.438rem;
+  --pgn-size-modal-xl: 1140px;
+  --pgn-size-modal-lg: 800px;
+  --pgn-size-modal-md: 500px;
+  --pgn-size-modal-sm: 400px;
+  --pgn-size-modal-content-border-width: 0px;
+  --pgn-size-nav-pills-link-border-width: 1px;
+  --pgn-size-nav-tabs-link-border-bottom-width: 0.188rem;
+  --pgn-size-nav-tabs-border-width: 2px;
+  --pgn-size-nav-tabs-border-radius: 0;
+  --pgn-size-navbar-nav-scroll-max-height: 75vh;
+  --pgn-size-pagination-icon-width: 2.25rem;
+  --pgn-size-pagination-icon-height: 2.25rem;
+  --pgn-size-pagination-secondary-height-base: 2.75rem;
+  --pgn-size-pagination-secondary-height-sm: 2.25rem;
+  --pgn-size-pagination-reduced-dropdown-max-height: 60vh;
+  --pgn-size-pagination-reduced-dropdown-min-width: 6rem;
+  --pgn-size-pagination-toggle-border-base: 0.3125rem;
+  --pgn-size-pagination-toggle-border-sm: 0.25rem;
+  --pgn-size-pagination-focus-outline: 0;
+  --pgn-size-popover-max-width: 480px;
+  --pgn-size-popover-icon-height: 1rem;
+  --pgn-size-popover-icon-width: 1rem;
+  --pgn-size-popover-arrow-width: 1rem;
+  --pgn-size-popover-arrow-height: 0.5rem;
+  --pgn-size-product-tour-checkpoint-width-border: 8px;
+  --pgn-size-product-tour-checkpoint-width-arrow: 15px;
+  --pgn-size-product-tour-checkpoint-width-max: 480px;
+  --pgn-size-progress-bar-height-base: 1rem;
+  --pgn-size-progress-bar-height-annotated: 0.3125rem;
+  --pgn-size-progress-bar-border-width: 1px;
+  --pgn-size-progress-bar-border-radius: 0;
+  --pgn-size-progress-bar-threshold-circle: 0.5625rem;
+  --pgn-size-search-field-border-width-base: 0.0625rem;
+  --pgn-size-search-field-border-width-focus: 0.3125rem;
+  --pgn-size-search-field-border-radius: 0;
+  --pgn-size-spinner-base-width: 2rem;
+  --pgn-size-spinner-base-border-width: 0.25em;
+  --pgn-size-spinner-sm-width: 1rem;
+  --pgn-size-spinner-sm-border-width: 0.2em;
+  --pgn-size-stack-gap: 0;
+  --pgn-size-stepper-header-height-min: 5.13rem;
+  --pgn-size-stepper-step-width-min: 0;
+  --pgn-size-stepper-step-bubble-error-shadow-width: 3px;
+  --pgn-size-tabs-notification-height: 1rem;
+  --pgn-size-tabs-notification-width: 1rem;
+  --pgn-size-toast-max-width: 400px;
+  --pgn-size-toast-border-width: 1px;
+  --pgn-size-toast-border-radius: 0.25rem;
+  --pgn-size-tooltip-max-width: 200px;
+  --pgn-size-tooltip-arrow-height: 0.4rem;
+  --pgn-size-tooltip-arrow-width: 0.8rem;
+  --pgn-size-caret-width: 0.3em;
+  --pgn-size-input-btn-focus-width: 1px;
+  --pgn-size-breakpoint-xs: 0px; /* Starting breakpoint for portrait phones. */
+  --pgn-size-breakpoint-sm: 576px; /* Starting breakpoint for landscape phones. */
+  --pgn-size-breakpoint-md: 768px; /* Starting breakpoint for tablets. */
+  --pgn-size-breakpoint-lg: 992px; /* Starting breakpoint for desktops. */
+  --pgn-size-breakpoint-xl: 1200px; /* Starting breakpoint for large desktops. */
+  --pgn-size-breakpoint-xxl: 1400px; /* Starting breakpoint for large desktops, more than 1400px. */
+  --pgn-spacing-action-row-gap-x: 0.5rem;
+  --pgn-spacing-action-row-gap-y: 0.5rem;
+  --pgn-spacing-alert-padding-y: 1.5rem;
+  --pgn-spacing-alert-padding-x: 1.5rem;
+  --pgn-spacing-alert-margin-bottom: 1rem;
+  --pgn-spacing-alert-icon-space: 0.8rem;
+  --pgn-spacing-annotation-padding: 0.5rem;
+  --pgn-spacing-annotation-arrow-side-margin: 0.25rem;
+  --pgn-spacing-avatar-button-padding-left-base: 0.25em;
+  --pgn-spacing-avatar-button-padding-left-sm: 0.25em;
+  --pgn-spacing-avatar-button-padding-left-lg: 0.25em;
+  --pgn-spacing-badge-padding-x-base: 0.5rem;
+  --pgn-spacing-badge-padding-x-pill: 0.6em;
+  --pgn-spacing-badge-padding-y: 0.125rem;
+  --pgn-spacing-breadcrumb-margin-left: 0.5rem;
+  --pgn-spacing-bubble-expandable-padding-y: 0;
+  --pgn-spacing-bubble-expandable-padding-x: 0.25rem;
+  --pgn-spacing-btn-block-spacing-y: 0.5rem;
+  --pgn-spacing-card-spacer-x: 1.25rem;
+  --pgn-spacing-card-spacer-y: 0.75rem;
+  --pgn-spacing-card-margin-group: 12px;
+  --pgn-spacing-card-columns-count: 3;
+  --pgn-spacing-card-columns-gap: 1.25rem;
+  --pgn-spacing-card-footer-action-gap: 0.5rem;
+  --pgn-spacing-card-loading-skeleton-spacer: 0.313rem;
+  --pgn-spacing-card-logo-left-offset-base: 1.5rem;
+  --pgn-spacing-card-logo-left-offset-horizontal: 0.4375rem;
+  --pgn-spacing-card-logo-bottom-offset-base: 1rem;
+  --pgn-spacing-card-logo-bottom-offset-horizontal: 0.4375rem;
+  --pgn-spacing-card-focus-border-offset: 5px;
+  --pgn-spacing-carousel-indicator-spacer: 3px;
+  --pgn-spacing-chip-margin-base: 0.125rem;
+  --pgn-spacing-chip-margin-icon: 0.25rem;
+  --pgn-spacing-chip-padding-y: 1px;
+  --pgn-spacing-chip-padding-x: 0.5rem;
+  --pgn-spacing-chip-outline-selected-distance-light: 3px;
+  --pgn-spacing-chip-outline-selected-distance-dark: 3px;
+  --pgn-spacing-chip-outline-focus-distance-light: 0.313rem;
+  --pgn-spacing-chip-outline-focus-distance-dark: 0.313rem;
+  --pgn-spacing-chip-outline-width: 3px;
+  --pgn-spacing-chip-carousel-controls-top-offset: 0.375rem;
+  --pgn-spacing-chip-carousel-container-padding-x: 0.625rem;
+  --pgn-spacing-chip-carousel-container-padding-y: 0.313rem;
+  --pgn-spacing-code-kbd-padding-y: 0.2rem;
+  --pgn-spacing-code-kbd-padding-x: 0.4rem;
+  --pgn-spacing-collapsible-card-spacer-y-base: 0.5rem;
+  --pgn-spacing-collapsible-card-spacer-x-base: 0.5rem;
+  --pgn-spacing-collapsible-card-spacer-left-body: 0.75rem;
+  --pgn-spacing-collapsible-card-spacer-icon: 2.5rem;
+  --pgn-spacing-collapsible-card-spacer-basic-y: 0.5rem;
+  --pgn-spacing-collapsible-card-spacer-basic-x: 0.5rem;
+  --pgn-spacing-collapsible-card-spacer-basic-icon: 0.625rem;
+  --pgn-spacing-data-table-padding-x: 0.75rem;
+  --pgn-spacing-data-table-padding-y: 0.75rem;
+  --pgn-spacing-data-table-padding-small: 0.5rem;
+  --pgn-spacing-data-table-padding-cell-x: 0.5rem;
+  --pgn-spacing-data-table-padding-cell-y: 0.75rem;
+  --pgn-spacing-data-table-footer-position: center;
+  --pgn-spacing-dropdown-spacer: 0.125rem;
+  --pgn-spacing-dropdown-padding-x-base: 0;
+  --pgn-spacing-dropdown-padding-x-item: 1rem;
+  --pgn-spacing-dropdown-padding-y-base: 0.5rem;
+  --pgn-spacing-dropdown-padding-y-item: 0.25rem;
+  --pgn-spacing-dropdown-padding-header-y: 0.5rem;
+  --pgn-spacing-dropdown-close-container-top: 0.625rem;
+  --pgn-spacing-dropzone-padding: 1.5rem;
+  --pgn-spacing-dropzone-border-base: 1px;
+  --pgn-spacing-form-input-check-gutter: 1.25rem;
+  --pgn-spacing-form-input-check-margin-x-base: 0.25rem;
+  --pgn-spacing-form-input-check-margin-x-inline: 0.3125rem;
+  --pgn-spacing-form-input-check-margin-y: 0.3rem;
+  --pgn-spacing-form-text-margin-top: 0.25rem;
+  --pgn-spacing-form-check-inline-margin-x: 0.75rem;
+  --pgn-spacing-form-check-position-axis: 0.375rem;
+  --pgn-spacing-form-group-margin-bottom: 1rem;
+  --pgn-spacing-form-control-gutter: 0.5rem;
+  --pgn-spacing-form-control-spacer-x: 1rem;
+  --pgn-spacing-form-control-select-indicator-padding: 1rem;
+  --pgn-spacing-form-control-select-feedback-icon-position-position-y: center;
+  --pgn-spacing-form-control-select-feedback-icon-position-position-x: right;
+  --pgn-spacing-form-control-select-feedback-icon-position-offset-y: 0;
+  --pgn-spacing-form-control-select-feedback-tooltip-padding-y: 0.25rem;
+  --pgn-spacing-form-control-select-feedback-tooltip-padding-x: 0.5rem;
+  --pgn-spacing-form-control-select-icon-padding: 0.5625rem;
+  --pgn-spacing-image-thumbnail-padding: 0.25rem;
+  --pgn-spacing-menu-item-icon-margin-left: 0.25em;
+  --pgn-spacing-modal-inner-padding-base: 1.5rem;
+  --pgn-spacing-modal-inner-padding-bottom: 0.7rem;
+  --pgn-spacing-modal-footer-padding-base-x: 1.5rem;
+  --pgn-spacing-modal-footer-padding-y: 1rem;
+  --pgn-spacing-modal-header-padding-base-x: 1.5rem;
+  --pgn-spacing-modal-header-padding-y: 1rem;
+  --pgn-spacing-modal-dialog-margin: 1.5rem;
+  --pgn-spacing-nav-link-padding-y: 0.5rem;
+  --pgn-spacing-nav-link-padding-x: 1rem;
+  --pgn-spacing-nav-link-distance-to-border: 4px;
+  --pgn-spacing-navbar-padding-x-nav-link: 0.5rem;
+  --pgn-spacing-navbar-toggler-padding-y: 0.25rem;
+  --pgn-spacing-navbar-toggler-padding-x: 0.75rem;
+  --pgn-spacing-pagination-padding-y-base: 0.625rem;
+  --pgn-spacing-pagination-padding-y-sm: 0.8rem;
+  --pgn-spacing-pagination-padding-y-lg: 0.75rem;
+  --pgn-spacing-pagination-padding-x-base: 1rem;
+  --pgn-spacing-pagination-padding-x-sm: 0.6rem;
+  --pgn-spacing-pagination-padding-x-lg: 1.5rem;
+  --pgn-spacing-popover-header-padding-y: 0.5rem;
+  --pgn-spacing-popover-header-padding-x: 1rem;
+  --pgn-spacing-popover-icon-margin-right: 0.5rem;
+  --pgn-spacing-progress-bar-hint-annotation-gap: 0.5rem;
+  --pgn-spacing-search-field-margin-button: 0.5rem;
+  --pgn-spacing-selectable-box-padding: 1rem;
+  --pgn-spacing-selectable-box-border-radius: 0.25rem;
+  --pgn-spacing-selectable-box-box-space: 0.75rem;
+  --pgn-spacing-vertical-align: 0.125em;
+  --pgn-spacing-stepper-header-padding-y: 0.75rem;
+  --pgn-spacing-stepper-header-step-padding: 0.25rem;
+  --pgn-spacing-stepper-header-step-list-padding-y: 0.25rem;
+  --pgn-spacing-stepper-header-step-list-padding-x: 0;
+  --pgn-spacing-stepper-header-step-list-margin: 0;
+  --pgn-spacing-sticky-offset: 0;
+  --pgn-spacing-tab-more-link-dropdown-toggle-padding-x: 0.7rem;
+  --pgn-spacing-tab-inverse-pills-link-dropdown-toggle-padding-x: 0.625rem;
+  --pgn-spacing-tab-inverse-tabs-link-dropdown-toggle-padding-x: 0.625rem;
+  --pgn-spacing-tab-inverse-tabs-link-dropdown-toggle-distance: 5px;
+  --pgn-spacing-toast-padding-x: 0.75rem;
+  --pgn-spacing-toast-padding-y: 0.25rem;
+  --pgn-spacing-toast-container-gutter-lg: 1.25rem;
+  --pgn-spacing-toast-container-gutter-sm: 0.625rem;
+  --pgn-spacing-tooltip-padding-y: 0.5rem;
+  --pgn-spacing-tooltip-padding-x: 0.5rem;
+  --pgn-spacing-tooltip-margin: 0;
+  --pgn-spacing-caret-base: 0.255em;
+  --pgn-spacing-caret-vertical-align: 0.255em;
+  --pgn-spacing-headings-margin-bottom: 0.5rem;
+  --pgn-spacing-input-btn-padding-y: 0.5625rem;
+  --pgn-spacing-input-btn-padding-x: 1rem;
+  --pgn-spacing-input-btn-padding-sm-y: 0.4375rem;
+  --pgn-spacing-input-btn-padding-sm-x: 0.75rem;
+  --pgn-spacing-input-btn-padding-lg-y: 0.6875rem;
+  --pgn-spacing-input-btn-padding-lg-x: 1.25rem;
+  --pgn-spacing-list-inline-padding: 0.5rem;
+  --pgn-spacing-list-group-item-padding-y: 0.75rem;
+  --pgn-spacing-list-group-item-padding-x: 1.25rem;
+  --pgn-spacing-paragraph-margin-bottom: 1rem;
+  --pgn-spacing-mark-padding: 0.2em;
+  --pgn-spacing-spacer-0: 0; /* Space value of level 0 */
+  --pgn-spacing-spacer-base: 1rem; /* Basic space value */
+  --pgn-spacing-label-margin-bottom: 0.5rem; /* Margin bottom for label. */
+  --pgn-spacing-table-cell-padding-base: 0.75rem; /* Padding for tables. */
+  --pgn-spacing-table-cell-padding-sm: 0.3rem; /* Padding sm for tables. */
+  --pgn-spacing-grid-gutter-width: 24px; /* Grid gutter width value. */
+  --pgn-typography-alert-font-size: 0.875rem;
+  --pgn-typography-alert-line-height: 1.5rem;
+  --pgn-typography-badge-font-size: 75%;
+  --pgn-typography-dropdown-item-text-decoration: none;
+  --pgn-typography-image-figure-caption-font-size: 90%;
+  --pgn-typography-menu-select-btn-link-text-decoration-line: underline;
+  --pgn-typography-menu-select-btn-link-text-decoration-thickness: 0.125rem;
+  --pgn-typography-nav-link-font-weight: 500;
+  --pgn-typography-nav-link-text-decoration: none;
+  --pgn-typography-pagination-font-size-sm: 0.875rem;
+  --pgn-typography-pagination-line-height: 1.5rem;
+  --pgn-typography-spacer-line-height: 1px;
+  --pgn-typography-toast-font-size: 0.875rem;
+  --pgn-typography-headings-font-family: inherit;
+  --pgn-typography-headings-line-height: 1.25;
+  --pgn-typography-input-btn-font-family: inherit;
+  --pgn-typography-input-btn-font-size-base: 1.125rem;
+  --pgn-typography-input-btn-font-size-sm: 0.875rem;
+  --pgn-typography-input-btn-font-size-lg: 1.325rem;
+  --pgn-typography-input-btn-line-height-base: 1.3333;
+  --pgn-typography-input-btn-line-height-sm: 1.4286;
+  --pgn-typography-link-decoration-base: none;
+  --pgn-typography-link-decoration-hover: underline;
+  --pgn-typography-link-decoration-inline-base: underline;
+  --pgn-typography-link-decoration-inline-hover: underline;
+  --pgn-typography-link-decoration-muted-base: none;
+  --pgn-typography-link-decoration-muted-hover: underline;
+  --pgn-typography-link-decoration-muted-inline-base: underline;
+  --pgn-typography-link-decoration-muted-inline-hover: underline;
+  --pgn-typography-link-decoration-brand-base: none;
+  --pgn-typography-link-decoration-brand-hover: underline;
+  --pgn-typography-link-decoration-brand-inline-base: underline;
+  --pgn-typography-link-decoration-brand-inline-hover: underline;
+  --pgn-typography-font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; /* Sans-serif font family. */
+  --pgn-typography-font-family-serif: serif; /* Serif font family. */
+  --pgn-typography-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; /* Monospace font family. */
+  --pgn-typography-font-size-base: 1.125rem; /* Base font size. */
+  --pgn-typography-font-size-sm: 87.5%; /* Small font size. */
+  --pgn-typography-font-size-xs: 75%; /* X-small font size. */
+  --pgn-typography-font-size-micro: 0.688rem; /* Micro utils text font size. */
+  --pgn-typography-font-size-h1-base: 2.5rem; /* Base font size of heading level 1. */
+  --pgn-typography-font-size-h1-mobile: 2.25rem; /* Mobile font size of heading level 1. */
+  --pgn-typography-font-size-h2-base: 2rem; /* Font size of heading level 2. */
+  --pgn-typography-font-size-h3-base: 1.375rem; /* Font size of heading level 3. */
+  --pgn-typography-font-size-h4-base: 1.125rem; /* Font size of heading level 4. */
+  --pgn-typography-font-size-h5-base: 0.875rem; /* Font size of heading level 5. */
+  --pgn-typography-font-size-h6-base: 0.75rem; /* Font size of heading level 6. */
+  --pgn-typography-font-size-display-1: 3.75rem; /* Font size for heading of level 1. */
+  --pgn-typography-font-size-display-2: 4.875rem; /* Font size for heading of level 2. */
+  --pgn-typography-font-size-display-3: 5.625rem; /* Font size for heading of level 3. */
+  --pgn-typography-font-size-display-4: 7.5rem; /* Font size for heading of level 4. */
+  --pgn-typography-font-size-display-mobile-1: 3.25rem; /* Mobile font size for heading of level 1. */
+  --pgn-typography-font-weight-lighter: lighter; /* Lighter font weight. */
+  --pgn-typography-font-weight-light: 300; /* Light font weight. */
+  --pgn-typography-font-weight-normal: 400; /* Normal font weight. */
+  --pgn-typography-font-weight-semi-bold: 500; /* Semi-bold font weight. */
+  --pgn-typography-font-weight-bold: 700; /* Bold font weight. */
+  --pgn-typography-font-weight-bolder: bolder; /* Bolder font weight. */
+  --pgn-typography-font-weight-lead: inherit; /* Lead text font weight. */
+  --pgn-typography-font-weight-table-th: 700; /* Table th font weight. */
+  --pgn-typography-line-height-base: 1.5556; /* Basic line height. */
+  --pgn-typography-line-height-lg: 1.5; /* Large line height. */
+  --pgn-typography-line-height-sm: 1.5; /* Small line height. */
+  --pgn-typography-line-height-micro: 0.938rem; /* Micro utils line height. */
+  --pgn-typography-line-height-display-base: 1; /* Standard display line height. */
+  --pgn-typography-line-height-display-mobile: 3.5rem; /* Mobile display line height. */
+  --pgn-transition-badge: none;
+  --pgn-transition-btn: none;
+  --pgn-transition-carousel-base-property: transform;
+  --pgn-transition-carousel-base-timing-function: ease-in-out;
+  --pgn-transition-carousel-base-delay: 0ms;
+  --pgn-transition-carousel-base-behavior: normal;
+  --pgn-transition-carousel-duration: 0.6s;
+  --pgn-transition-carousel-indicator-property: opacity;
+  --pgn-transition-carousel-indicator-timing-function: ease;
+  --pgn-transition-carousel-indicator-delay: 0ms;
+  --pgn-transition-carousel-indicator-behavior: normal;
+  --pgn-transition-carousel-control-property: opacity;
+  --pgn-transition-carousel-control-duration: 0.15s;
+  --pgn-transition-carousel-control-timing-function: ease;
+  --pgn-transition-carousel-control-delay: 0ms;
+  --pgn-transition-carousel-control-behavior: normal;
+  --pgn-transition-form-input-1-property: border-color;
+  --pgn-transition-form-input-1-duration: 0.15s;
+  --pgn-transition-form-input-1-timing-function: ease-in-out;
+  --pgn-transition-form-input-1-delay: 0s;
+  --pgn-transition-form-input-1-behavior: normal;
+  --pgn-transition-form-input-2-property: box-shadow;
+  --pgn-transition-form-input-2-duration: 0.15s;
+  --pgn-transition-form-input-2-timing-function: ease-in-out;
+  --pgn-transition-form-input-2-delay: 0s;
+  --pgn-transition-form-input-2-behavior: normal;
+  --pgn-transition-form-control-1-property: background-color;
+  --pgn-transition-form-control-1-duration: 0.15s;
+  --pgn-transition-form-control-1-timing-function: ease-in-out;
+  --pgn-transition-form-control-1-delay: 0s;
+  --pgn-transition-form-control-1-behavior: normal;
+  --pgn-transition-form-control-2-property: border-color;
+  --pgn-transition-form-control-2-duration: 0.15s;
+  --pgn-transition-form-control-2-timing-function: ease-in-out;
+  --pgn-transition-form-control-2-delay: 0s;
+  --pgn-transition-form-control-2-behavior: normal;
+  --pgn-transition-form-control-3-property: box-shadow;
+  --pgn-transition-form-control-3-duration: 0.15s;
+  --pgn-transition-form-control-3-timing-function: ease-in-out;
+  --pgn-transition-form-control-3-delay: 0s;
+  --pgn-transition-form-control-3-behavior: normal;
+  --pgn-transition-progress-bar-animation-timing-duration: 1s;
+  --pgn-transition-progress-bar-animation-timing-timing-function: linear;
+  --pgn-transition-progress-bar-animation-timing-delay: 0s;
+  --pgn-transition-progress-bar-animation-timing-iteration-count: infinite;
+  --pgn-transition-progress-bar-transition-property: width;
+  --pgn-transition-progress-bar-transition-duration: 0.6s;
+  --pgn-transition-progress-bar-transition-timing-function: ease;
+  --pgn-transition-progress-bar-transition-delay: 0s;
+  --pgn-transition-progress-bar-transition-behavior: normal;
+  --pgn-transition-base-property: all; /* Generic transition for any property change */
+  --pgn-transition-base-duration: 0.2s; /* Generic transition for any property change */
+  --pgn-transition-base-timing-function: ease-in-out; /* Generic transition for any property change */
+  --pgn-transition-base-delay: 0s; /* Generic transition for any property change */
+  --pgn-transition-base-behavior: normal; /* Generic transition for any property change */
+  --pgn-transition-fade-property: opacity; /* Opacity transition that takes 150ms */
+  --pgn-transition-fade-duration: 0.15s; /* Opacity transition that takes 150ms */
+  --pgn-transition-fade-timing-function: linear; /* Opacity transition that takes 150ms */
+  --pgn-transition-fade-delay: 0s; /* Opacity transition that takes 150ms */
+  --pgn-transition-fade-behavior: normal; /* Opacity transition that takes 150ms */
+  --pgn-transition-collapse-height-property: height; /* Collapse transition for height that takes 350ms */
+  --pgn-transition-collapse-height-duration: 0.35s; /* Collapse transition for height that takes 350ms */
+  --pgn-transition-collapse-height-timing-function: ease; /* Collapse transition for height that takes 350ms */
+  --pgn-transition-collapse-height-delay: 0s; /* Collapse transition for height that takes 350ms */
+  --pgn-transition-collapse-height-behavior: normal; /* Collapse transition for height that takes 350ms */
+  --pgn-transition-collapse-width-property: width; /* Collapse transition for width that takes 350ms */
+  --pgn-transition-collapse-width-duration: 0.35s; /* Collapse transition for width that takes 350ms */
+  --pgn-transition-collapse-width-timing-function: ease; /* Collapse transition for width that takes 350ms */
+  --pgn-transition-collapse-width-delay: 0s; /* Collapse transition for width that takes 350ms */
+  --pgn-transition-collapse-width-behavior: normal; /* Collapse transition for width that takes 350ms */
+  --pgn-elevation-dropdown-zindex: 1000;
+  --pgn-elevation-modal-backdrop-zindex: 1040;
+  --pgn-elevation-modal-zindex: 1050;
+  --pgn-elevation-popover-zindex: 1060;
+  --pgn-elevation-product-tour-checkpoint-zindex: 1060;
+  --pgn-elevation-sheet-zindex-backdrop: 1031;
+  --pgn-elevation-sheet-zindex-main: 1032;
+  --pgn-elevation-tooltip-zindex: 1070;
+  --pgn-elevation-zindex-0: 0; /* z-index of level 0. */
+  --pgn-elevation-zindex-200: 200; /* z-index of level 200. */
+  --pgn-elevation-zindex-400: 400; /* z-index of level 400. */
+  --pgn-elevation-zindex-600: 600; /* z-index of level 600. */
+  --pgn-elevation-zindex-800: 800; /* z-index of level 800. */
+  --pgn-elevation-zindex-1000: 1000; /* z-index of level 1000. */
+  --pgn-elevation-zindex-1200: 1200; /* z-index of level 1200. */
+  --pgn-elevation-zindex-1400: 1400; /* z-index of level 1400. */
+  --pgn-elevation-zindex-1600: 1600; /* z-index of level 1600. */
+  --pgn-elevation-zindex-1800: 1800; /* z-index of level 1800. */
+  --pgn-elevation-zindex-2000: 2000; /* z-index of level 2000. */
+  --pgn-elevation-zindex-sticky: 1020; /* z-index for sticky element. */
+  --pgn-elevation-zindex-fixed: 1030; /* z-index of for fixed element. */
+  --pgn-other-form-control-cursor: auto;
+  --pgn-other-form-control-range-track-cursor: pointer;
+  --pgn-other-form-control-custom-file-lang: en;
+  --pgn-other-form-control-custom-file-content: Browse;
+  --pgn-theme-interval: 8%;
+  --pgn-print-page-size: a3;
+  --pgn-size-alert-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-size-badge-focus-width: var(--pgn-size-input-btn-focus-width);
+  --pgn-size-btn-border-radius-base: var(--pgn-size-border-radius-base);
+  --pgn-size-btn-border-radius-lg: var(--pgn-size-border-radius-lg);
+  --pgn-size-btn-border-radius-sm: var(--pgn-size-border-radius-sm);
+  --pgn-size-card-border-width: var(--pgn-size-border-width);
+  --pgn-size-card-border-radius-base: var(--pgn-size-border-radius-base);
+  --pgn-size-card-focus-border-radius: calc(var(--pgn-spacing-card-focus-border-offset) + var(--pgn-size-card-border-radius-base));
+  --pgn-size-card-image-horizontal-width-min: var(--pgn-size-card-image-horizontal-width-max);
+  --pgn-size-dropdown-border-width: var(--pgn-size-border-width);
+  --pgn-size-dropdown-border-radius-base: var(--pgn-size-border-radius-base);
+  --pgn-size-form-input-radius-border-base: var(--pgn-size-border-radius-base);
+  --pgn-size-form-input-radius-border-lg: var(--pgn-size-border-radius-lg);
+  --pgn-size-form-input-radius-border-sm: var(--pgn-size-border-radius-sm);
+  --pgn-size-form-control-switch-width: calc(var(--pgn-size-form-control-indicator-base) * 1.75);
+  --pgn-size-form-control-switch-indicator-base: calc(var(--pgn-size-form-control-indicator-base) - var(--pgn-size-form-control-indicator-border-width) * 4);
+  --pgn-size-form-control-switch-indicator-border-radius: calc(var(--pgn-size-form-control-indicator-base) / 2);
+  --pgn-size-form-control-select-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-size-form-control-range-thumb-height: var(--pgn-size-form-control-range-thumb-width);
+  --pgn-size-form-control-range-thumb-focus-width: var(--pgn-size-form-input-width-focus);
+  --pgn-size-form-autosuggest-icon-height: var(--pgn-size-form-autosuggest-icon-width);
+  --pgn-size-form-autosuggest-spinner-height: var(--pgn-size-form-autosuggest-spinner-width);
+  --pgn-size-form-feedback-tooltip-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-size-icon-button-diameter-inline: calc(var(--pgn-typography-line-height-base) * 1em + .1em);
+  --pgn-size-image-thumbnail-border-width: var(--pgn-size-border-width);
+  --pgn-size-image-thumbnail-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-size-modal-content-border-radius: var(--pgn-size-border-radius-lg);
+  --pgn-size-nav-pills-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-size-nav-pills-inverse-link-border-width: var(--pgn-size-nav-pills-link-border-width);
+  --pgn-size-nav-tabs-inverse-link-active-border-bottom-width: var(--pgn-size-nav-tabs-link-border-bottom-width);
+  --pgn-size-pagination-border-width: var(--pgn-size-border-width);
+  --pgn-size-pagination-border-radius-sm: var(--pgn-size-border-radius-sm);
+  --pgn-size-pagination-border-radius-lg: var(--pgn-size-border-radius-lg);
+  --pgn-size-popover-border-width: var(--pgn-size-border-width);
+  --pgn-size-popover-border-radius: var(--pgn-size-border-radius-sm);
+  --pgn-size-product-tour-checkpoint-arrow-top: var(--pgn-size-product-tour-checkpoint-width-arrow);
+  --pgn-size-product-tour-checkpoint-arrow-transparent: var(--pgn-size-product-tour-checkpoint-width-arrow);
+  --pgn-size-spinner-base-height: var(--pgn-size-spinner-base-width);
+  --pgn-size-spinner-sm-height: var(--pgn-size-spinner-sm-width);
+  --pgn-size-tooltip-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-size-hr-border-width: var(--pgn-size-border-width);
+  --pgn-size-hr-border-margin-y: var(--pgn-spacing-spacer-base);
+  --pgn-size-input-btn-border-width: var(--pgn-size-border-width);
+  --pgn-size-list-group-border-width: var(--pgn-size-border-width);
+  --pgn-size-list-group-border-radius: var(--pgn-size-border-radius-base);
+  --pgn-spacing-btn-padding-y-base: var(--pgn-spacing-input-btn-padding-y);
+  --pgn-spacing-btn-padding-y-lg: var(--pgn-spacing-input-btn-padding-lg-y);
+  --pgn-spacing-btn-padding-y-sm: var(--pgn-spacing-input-btn-padding-sm-y);
+  --pgn-spacing-btn-padding-x-base: var(--pgn-spacing-input-btn-padding-x);
+  --pgn-spacing-btn-padding-x-lg: var(--pgn-spacing-input-btn-padding-lg-x);
+  --pgn-spacing-btn-padding-x-sm: var(--pgn-spacing-input-btn-padding-sm-x);
+  --pgn-spacing-btn-focus-gap: var(--pgn-size-btn-focus-width);
+  --pgn-spacing-btn-focus-border-gap: calc(var(--pgn-size-btn-focus-width) + var(--pgn-spacing-btn-focus-gap));
+  --pgn-spacing-card-margin-deck: var(--pgn-spacing-card-margin-group);
+  --pgn-spacing-card-margin-grid: var(--pgn-spacing-card-margin-group);
+  --pgn-spacing-card-columns-margin: var(--pgn-spacing-card-spacer-y);
+  --pgn-spacing-collapsible-card-spacer-y-lg: var(--pgn-spacing-card-spacer-y);
+  --pgn-spacing-collapsible-card-spacer-x-lg: var(--pgn-spacing-card-spacer-x);
+  --pgn-spacing-dropdown-padding-header-x: var(--pgn-spacing-dropdown-padding-x-item);
+  --pgn-spacing-dropdown-divider-margin-y: calc(var(--pgn-spacing-spacer-base) / 2);
+  --pgn-spacing-form-input-padding-y-base: var(--pgn-spacing-input-btn-padding-y);
+  --pgn-spacing-form-input-padding-y-sm: var(--pgn-spacing-input-btn-padding-sm-y);
+  --pgn-spacing-form-input-padding-y-lg: var(--pgn-spacing-input-btn-padding-lg-y);
+  --pgn-spacing-form-input-padding-x-base: var(--pgn-spacing-input-btn-padding-x);
+  --pgn-spacing-form-input-padding-x-sm: var(--pgn-spacing-input-btn-padding-sm-x);
+  --pgn-spacing-form-input-padding-x-lg: var(--pgn-spacing-input-btn-padding-lg-x);
+  --pgn-spacing-form-control-select-feedback-margin-top: var(--pgn-spacing-form-text-margin-top);
+  --pgn-spacing-menu-item-icon-margin-right: var(--pgn-spacing-menu-item-icon-margin-left);
+  --pgn-spacing-modal-footer-padding-base-y: var(--pgn-spacing-modal-footer-padding-y);
+  --pgn-spacing-modal-header-padding-base-y: var(--pgn-spacing-modal-header-padding-y);
+  --pgn-spacing-navbar-padding-y: calc(var(--pgn-spacing-spacer-base) / 2);
+  --pgn-spacing-navbar-padding-x-base: var(--pgn-spacing-spacer-base);
+  --pgn-spacing-popover-body-padding-y: var(--pgn-spacing-popover-header-padding-y);
+  --pgn-spacing-popover-body-padding-x: var(--pgn-spacing-popover-header-padding-x);
+  --pgn-spacing-stepper-header-padding-x: var(--pgn-spacing-spacer-base);
+  --pgn-spacing-tab-more-link-dropdown-toggle-padding-y: var(--pgn-spacing-spacer-base);
+  --pgn-spacing-tab-inverse-pills-link-dropdown-toggle-padding-y: var(--pgn-spacing-spacer-base);
+  --pgn-spacing-tab-inverse-tabs-link-dropdown-toggle-padding-y: var(--pgn-spacing-spacer-base);
+  --pgn-spacing-spacer-1: calc(var(--pgn-spacing-spacer-base) * .25); /* Space value of level 1 */
+  --pgn-spacing-spacer-2: calc(var(--pgn-spacing-spacer-base) * .5); /* Space value of level 2 */
+  --pgn-spacing-spacer-3: var(--pgn-spacing-spacer-base); /* Space value of level 3 */
+  --pgn-spacing-spacer-4: calc(var(--pgn-spacing-spacer-base) * 1.5); /* Space value of level 4 */
+  --pgn-spacing-spacer-5: calc(var(--pgn-spacing-spacer-base) * 3); /* Space value of level 5 */
+  --pgn-spacing-spacer-6: calc(var(--pgn-spacing-spacer-base) * 5); /* Space value of level 6 */
+  --pgn-spacing-spacer-1-5: calc(var(--pgn-spacing-spacer-base) * .375); /* Space value of level 1.5 */
+  --pgn-spacing-spacer-2-5: calc(var(--pgn-spacing-spacer-base) * .75); /* Space value of level 2.5 */
+  --pgn-spacing-spacer-3-5: calc(var(--pgn-spacing-spacer-base) * 1.25); /* Space value of level 3.5 */
+  --pgn-spacing-spacer-4-5: calc(var(--pgn-spacing-spacer-base) * 2); /* Space value of level 4.5 */
+  --pgn-spacing-spacer-5-5: calc(var(--pgn-spacing-spacer-base) * 4); /* Space value of level 5.5 */
+  --pgn-typography-alert-font-weight-link: var(--pgn-typography-font-weight-normal);
+  --pgn-typography-annotation-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-annotation-line-height: var(--pgn-typography-line-height-sm);
+  --pgn-typography-badge-font-weight: var(--pgn-typography-font-weight-bold);
+  --pgn-typography-btn-font-family: var(--pgn-typography-input-btn-font-family);
+  --pgn-typography-btn-font-size-base: var(--pgn-typography-input-btn-font-size-base);
+  --pgn-typography-btn-font-size-sm: var(--pgn-typography-input-btn-font-size-sm);
+  --pgn-typography-btn-font-size-lg: var(--pgn-typography-input-btn-font-size-lg);
+  --pgn-typography-btn-font-weight: var(--pgn-typography-font-weight-normal);
+  --pgn-typography-btn-line-height-base: var(--pgn-typography-input-btn-line-height-base);
+  --pgn-typography-btn-line-height-sm: var(--pgn-typography-input-btn-line-height-sm);
+  --pgn-typography-footer-text-font-size: var(--pgn-typography-font-size-xs);
+  --pgn-typography-close-button-font-size: calc(var(--pgn-typography-font-size-base) * 1.5);
+  --pgn-typography-close-button-font-weight: var(--pgn-typography-font-weight-bold);
+  --pgn-typography-code-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-code-kbd-nested-font-weight: var(--pgn-typography-font-weight-bold);
+  --pgn-typography-dropdown-font-size: var(--pgn-typography-font-size-base);
+  --pgn-typography-dropzone-restriction-msg-font-size: var(--pgn-typography-font-size-xs);
+  --pgn-typography-form-input-font-family: var(--pgn-typography-input-btn-font-family);
+  --pgn-typography-form-input-font-size-base: var(--pgn-typography-input-btn-font-size-base);
+  --pgn-typography-form-input-font-size-sm: var(--pgn-typography-input-btn-font-size-sm);
+  --pgn-typography-form-input-font-size-lg: var(--pgn-typography-input-btn-font-size-lg);
+  --pgn-typography-form-input-line-height-base: var(--pgn-typography-input-btn-line-height-base);
+  --pgn-typography-form-input-line-height-sm: var(--pgn-typography-input-btn-line-height-sm);
+  --pgn-typography-form-feedback-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-form-feedback-tooltip-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-form-feedback-tooltip-line-height: var(--pgn-typography-line-height-base);
+  --pgn-typography-navbar-nav-link-height: calc(var(--pgn-typography-font-size-base) * var(--pgn-typography-line-height-base) + .5rem * 2);
+  --pgn-typography-popover-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-progress-bar-font-size: calc(var(--pgn-typography-font-size-base) * .75);
+  --pgn-typography-tabs-notification-font-size: var(--pgn-typography-font-size-xs);
+  --pgn-typography-tooltip-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-headings-font-weight: var(--pgn-typography-font-weight-bold);
+  --pgn-typography-input-btn-line-height-lg: var(--pgn-typography-line-height-lg);
+  --pgn-typography-dt-font-weight: var(--pgn-typography-font-weight-bold);
+  --pgn-typography-blockquote-small-font-size: var(--pgn-typography-font-size-sm);
+  --pgn-typography-blockquote-font-size: calc(var(--pgn-typography-font-size-base) * 1.25);
+  --pgn-typography-font-family-base: var(--pgn-typography-font-family-sans-serif); /* Basic font family. */
+  --pgn-typography-font-size-lg: calc(var(--pgn-typography-font-size-base) * 1.25); /* Lead text font size. */
+  --pgn-typography-font-size-h2-mobile: var(--pgn-typography-font-size-h2-base); /* Mobile font size of heading level 2. */
+  --pgn-typography-font-size-h3-mobile: var(--pgn-typography-font-size-h3-base); /* Mobile font size of heading level 3. */
+  --pgn-typography-font-size-h4-mobile: var(--pgn-typography-font-size-h4-base); /* Mobile font size of heading level 4. */
+  --pgn-typography-font-size-h5-mobile: var(--pgn-typography-font-size-h5-base); /* Mobile font size of heading level 5. */
+  --pgn-typography-font-size-h6-mobile: var(--pgn-typography-font-size-h6-base); /* Mobile font size of heading level 6. */
+  --pgn-typography-font-size-display-mobile-2: var(--pgn-typography-font-size-display-mobile-1); /* Mobile font size for heading of level 2. */
+  --pgn-typography-font-size-display-mobile-3: var(--pgn-typography-font-size-display-mobile-1); /* Mobile font size for heading of level 3. */
+  --pgn-typography-font-size-display-mobile-4: var(--pgn-typography-font-size-display-mobile-1); /* Mobile font size for heading of level 4. */
+  --pgn-typography-font-weight-base: var(--pgn-typography-font-weight-normal); /* Basic font weight. */
+  --pgn-typography-font-weight-display-1: var(--pgn-typography-font-weight-bold); /* Font weight of display level 1. */
+  --pgn-typography-font-weight-display-2: var(--pgn-typography-font-weight-bold); /* Font weight of display level 2. */
+  --pgn-typography-font-weight-display-3: var(--pgn-typography-font-weight-bold); /* Font weight of display level 3. */
+  --pgn-typography-font-weight-display-4: var(--pgn-typography-font-weight-bold); /* Font weight of display level 4. */
+  --pgn-transition-carousel-base-duration: var(--pgn-transition-carousel-duration);
+  --pgn-transition-carousel-indicator-duration: var(--pgn-transition-carousel-duration);
+  --pgn-size-btn-border-width: var(--pgn-size-input-btn-border-width);
+  --pgn-size-btn-focus-border-radius-base: calc(var(--pgn-size-btn-border-radius-base) + var(--pgn-spacing-btn-focus-border-gap));
+  --pgn-size-btn-focus-border-radius-sm: var(--pgn-size-btn-border-radius-base);
+  --pgn-size-card-border-radius-inner: calc(var(--pgn-size-card-border-radius-base) - var(--pgn-size-card-border-width));
+  --pgn-size-card-image-border-radius: var(--pgn-size-card-border-radius-base);
+  --pgn-size-dropdown-border-radius-inner: calc(var(--pgn-size-dropdown-border-radius-base) - var(--pgn-size-dropdown-border-width));
+  --pgn-size-form-input-height-base: calc(var(--pgn-typography-form-input-line-height-base) * 1em + var(--pgn-spacing-form-input-padding-y-base) * 2 + var(--pgn-size-form-input-height-border));
+  --pgn-size-form-input-height-sm: calc(var(--pgn-typography-form-input-line-height-sm) * 1em + var(--pgn-spacing-input-btn-padding-sm-y) * 2 + var(--pgn-size-form-input-height-border));
+  --pgn-size-form-input-height-inner-base: calc(var(--pgn-typography-form-input-line-height-base) * 1em + var(--pgn-spacing-form-input-padding-y-base) * 2);
+  --pgn-size-form-input-height-inner-half: calc(var(--pgn-typography-form-input-line-height-base) * .5em + var(--pgn-spacing-form-input-padding-y-base));
+  --pgn-size-form-input-height-inner-quarter: calc(var(--pgn-typography-form-input-line-height-base) * .25em + calc(var(--pgn-spacing-form-input-padding-y-base) / 2));
+  --pgn-size-form-input-width-border: var(--pgn-size-input-btn-border-width);
+  --pgn-size-form-control-file-border-radius: var(--pgn-size-form-input-radius-border-base);
+  --pgn-size-navbar-toggler-border-radius: var(--pgn-size-btn-border-radius-base);
+  --pgn-size-search-field-search-input-height: calc(var(--pgn-typography-form-input-line-height-base) * 1em + var(--pgn-spacing-form-input-padding-y-base) * 2);
+  --pgn-spacing-alert-actions-gap: var(--pgn-spacing-spacer-3);
+  --pgn-spacing-btn-focus-distance-to-border: calc(var(--pgn-spacing-btn-focus-border-gap) + var(--pgn-size-btn-border-width));
+  --pgn-spacing-card-margin-deck-bottom: var(--pgn-spacing-spacer-3);
+  --pgn-spacing-card-margin-grid-bottom: var(--pgn-spacing-spacer-3);
+  --pgn-spacing-form-control-select-padding-y-base: var(--pgn-spacing-form-input-padding-y-base);
+  --pgn-spacing-form-control-select-padding-y-sm: var(--pgn-spacing-form-input-padding-y-sm);
+  --pgn-spacing-form-control-select-padding-y-lg: var(--pgn-spacing-form-input-padding-y-lg);
+  --pgn-spacing-form-control-select-padding-x-base: var(--pgn-spacing-form-input-padding-x-base);
+  --pgn-spacing-form-control-select-padding-x-sm: var(--pgn-spacing-form-input-padding-x-sm);
+  --pgn-spacing-form-control-select-padding-x-lg: var(--pgn-spacing-form-input-padding-x-lg);
+  --pgn-spacing-form-control-file-padding-y: var(--pgn-spacing-form-input-padding-y-base);
+  --pgn-spacing-form-control-file-padding-x: var(--pgn-spacing-form-input-padding-x-base);
+  --pgn-spacing-menu-item-padding-x: var(--pgn-spacing-btn-padding-x-base);
+  --pgn-spacing-menu-item-padding-y: var(--pgn-spacing-btn-padding-y-base);
+  --pgn-spacing-navbar-brand-padding-y: calc((var(--pgn-typography-navbar-nav-link-height) - var(--pgn-size-navbar-brand-height)) / 2);
+  --pgn-typography-btn-line-height-lg: var(--pgn-typography-input-btn-line-height-lg);
+  --pgn-typography-code-kbd-font-size: var(--pgn-typography-code-font-size);
+  --pgn-typography-form-input-font-weight: var(--pgn-typography-font-weight-base);
+  --pgn-typography-form-input-line-height-lg: var(--pgn-typography-input-btn-line-height-lg);
+  --pgn-typography-form-control-select-font-family: var(--pgn-typography-form-input-font-family);
+  --pgn-typography-form-control-select-font-size-base: var(--pgn-typography-form-input-font-size-base);
+  --pgn-typography-form-control-select-font-size-sm: var(--pgn-typography-form-input-font-size-sm);
+  --pgn-typography-form-control-select-font-size-lg: var(--pgn-typography-form-input-font-size-lg);
+  --pgn-typography-form-control-select-line-height: var(--pgn-typography-form-input-line-height-base);
+  --pgn-typography-form-control-file-line-height: var(--pgn-typography-form-input-line-height-base);
+  --pgn-typography-form-control-file-font-family: var(--pgn-typography-form-input-font-family);
+  --pgn-typography-navbar-brand-font-size: var(--pgn-typography-font-size-lg);
+  --pgn-typography-navbar-toggler-font-size: var(--pgn-typography-font-size-lg);
+  --pgn-size-btn-focus-border-radius-lg: var(--pgn-size-btn-focus-border-radius-base);
+  --pgn-size-form-input-height-border: calc(var(--pgn-size-form-input-width-border) * 2);
+  --pgn-size-form-input-height-lg: calc(var(--pgn-typography-form-input-line-height-lg) * 1em + var(--pgn-spacing-input-btn-padding-lg-y) * 2 + var(--pgn-size-form-input-height-border));
+  --pgn-size-form-control-select-height-base: var(--pgn-size-form-input-height-base);
+  --pgn-size-form-control-select-height-sm: var(--pgn-size-form-input-height-sm);
+  --pgn-size-form-control-select-feedback-icon: var(--pgn-size-form-input-height-inner-half) var(--pgn-size-form-input-height-inner-half);
+  --pgn-size-form-control-select-border-width-base: var(--pgn-size-form-input-width-border);
+  --pgn-size-form-control-file-width: var(--pgn-size-form-input-width-border);
+  --pgn-size-form-control-file-height-base: var(--pgn-size-form-input-height-base);
+  --pgn-size-form-control-file-height-inner: var(--pgn-size-form-input-height-inner-base);
+  --pgn-size-menu-item-border-width: var(--pgn-size-btn-border-width);
+  --pgn-size-navbar-brand-height: calc(var(--pgn-typography-navbar-brand-font-size) * var(--pgn-typography-line-height-base));
+  --pgn-spacing-form-control-select-feedback-icon-padding-right: calc((1em + 2 * var(--pgn-spacing-form-control-select-padding-y-base)) * 3 / 4 + var(--pgn-spacing-form-control-select-padding-x-base) + var(--pgn-spacing-form-control-select-indicator-padding));
+  --pgn-spacing-form-control-select-feedback-icon-position-offset-x: calc(var(--pgn-spacing-form-control-select-padding-x-base) + var(--pgn-spacing-form-control-select-indicator-padding));
+  --pgn-typography-form-control-select-font-weight: var(--pgn-typography-form-input-font-weight);
+  --pgn-typography-form-control-file-font-weight: var(--pgn-typography-form-input-font-weight);
+  --pgn-size-form-control-select-height-lg: var(--pgn-size-form-input-height-lg);
 }

--- a/styles/css/core/variables.css
+++ b/styles/css/core/variables.css
@@ -4,6 +4,7 @@
  */
 
 :root {
+  --pgn-print-page-size: a3;
   --pgn-theme-interval: 8%;
   --pgn-other-form-control-custom-file-content: Browse;
   --pgn-other-form-control-custom-file-lang: en;
@@ -102,7 +103,6 @@
   --pgn-transition-carousel-base-property: transform;
   --pgn-transition-btn: none;
   --pgn-transition-badge: none;
-  --pgn-typography-print-page-size: a3;
   --pgn-typography-line-height-display-mobile: 3.5rem; /* Mobile display line height. */
   --pgn-typography-line-height-display-base: 1; /* Standard display line height. */
   --pgn-typography-line-height-micro: 0.938rem; /* Micro utils line height. */

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -4,2060 +4,2060 @@
  */
 
 :root {
-  --pgn-border-color-nav-tabs-link-border-focus: var(--pgn-color-nav-tabs-base-link-active-text);
-  --pgn-border-color-nav-tabs-link-border-hover-left: transparent;
-  --pgn-border-color-nav-tabs-link-border-hover-bottom: var(--pgn-color-nav-tabs-base-border-base);
-  --pgn-border-color-nav-tabs-link-border-hover-right: transparent;
-  --pgn-border-color-nav-tabs-link-border-hover-top: transparent;
-  --pgn-border-color-nav-tabs-link-border-active: var(--pgn-color-primary-500);
-  --pgn-content-navbar-toggler-light-icon-bg: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%2300000080' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-  --pgn-content-navbar-toggler-dark-icon-bg: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%23FFFFFF80' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-  --pgn-content-carousel-control-bg-next-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e");
-  --pgn-content-carousel-control-bg-prev-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e");
-  --pgn-color-action-default-accent-b: #FFE755FF;
-  --pgn-color-action-default-accent-a: #0095C6FF;
-  --pgn-color-action-default-dark-base: #142018FF;
-  --pgn-color-action-default-dark-900: #080C09FF;
-  --pgn-color-action-default-dark-800: #0A0F0CFF;
-  --pgn-color-action-default-dark-700: #0B130EFF;
-  --pgn-color-action-default-dark-600: #101913FF;
-  --pgn-color-action-default-dark-500: #142018FF;
-  --pgn-color-action-default-dark-400: #46534AFF;
-  --pgn-color-action-default-dark-300: #78877DFF;
-  --pgn-color-action-default-dark-200: #AEB7B1FF;
-  --pgn-color-action-default-dark-100: #D7DBDBFF;
-  --pgn-color-action-default-light-base: #CAC3BFFF;
-  --pgn-color-action-default-light-900: #85817FFF;
-  --pgn-color-action-default-light-800: #908C8AFF;
-  --pgn-color-action-default-light-700: #9B9795FF;
-  --pgn-color-action-default-light-600: #B3ADAAFF;
-  --pgn-color-action-default-light-500: #CAC3BFFF;
-  --pgn-color-action-default-light-400: #D2CCC8FF;
-  --pgn-color-action-default-light-300: #D9D4D1FF;
-  --pgn-color-action-default-light-200: #E2DED9FF;
-  --pgn-color-action-default-light-100: #E4E4E4FF;
-  --pgn-color-action-default-danger-base: #9A232EFF;
-  --pgn-color-action-default-danger-900: #60161DFF;
-  --pgn-color-action-default-danger-800: #691820FF;
-  --pgn-color-action-default-danger-700: #731A22FF;
-  --pgn-color-action-default-danger-600: #871F28FF;
-  --pgn-color-action-default-danger-500: #9A232EFF;
-  --pgn-color-action-default-danger-400: #C73A46FF;
-  --pgn-color-action-default-danger-300: #D66E78FF;
-  --pgn-color-action-default-danger-200: #E5A3A9FF;
-  --pgn-color-action-default-danger-100: #EFCBCFFF;
-  --pgn-color-action-default-warning-base: #CCAE00FF;
-  --pgn-color-action-default-warning-900: #806D00FF;
-  --pgn-color-action-default-warning-800: #8C7700FF;
-  --pgn-color-action-default-warning-700: #998300FF;
-  --pgn-color-action-default-warning-600: #B39800FF;
-  --pgn-color-action-default-warning-500: #CCAE00FF;
-  --pgn-color-action-default-warning-400: #FFDC0DFF;
-  --pgn-color-action-default-warning-300: #FFE44DFF;
-  --pgn-color-action-default-warning-200: #FFEF8CFF;
-  --pgn-color-action-default-warning-100: #FFF6BDFF;
-  --pgn-color-action-default-info-base: #004C77FF;
-  --pgn-color-action-default-info-900: #002B44FF;
-  --pgn-color-action-default-info-800: #00314DFF;
-  --pgn-color-action-default-info-700: #003655FF;
-  --pgn-color-action-default-info-600: #004166FF;
-  --pgn-color-action-default-info-500: #004C77FF;
-  --pgn-color-action-default-info-400: #337599FF;
-  --pgn-color-action-default-info-300: #5AA0C8FF;
-  --pgn-color-action-default-info-200: #99C5DDFF;
-  --pgn-color-action-default-info-100: #CADFEDFF;
-  --pgn-color-action-default-success-base: #0F5737FF;
-  --pgn-color-action-default-success-900: #08301EFF;
-  --pgn-color-action-default-success-800: #093723FF;
-  --pgn-color-action-default-success-700: #0A3D26FF;
-  --pgn-color-action-default-success-600: #0D4A2FFF;
-  --pgn-color-action-default-success-500: #0F5737FF;
-  --pgn-color-action-default-success-400: #407F63FF;
-  --pgn-color-action-default-success-300: #6AAF90FF;
-  --pgn-color-action-default-success-200: #A4CEBBFF;
-  --pgn-color-action-default-success-100: #CFE7DDFF;
-  --pgn-color-action-default-brand-base: #6A0039FF;
-  --pgn-color-action-default-brand-900: #3B0020FF;
-  --pgn-color-action-default-brand-800: #430024FF;
-  --pgn-color-action-default-brand-700: #4B0028FF;
-  --pgn-color-action-default-brand-600: #5A0031FF;
-  --pgn-color-action-default-brand-500: #6A0039FF;
-  --pgn-color-action-default-brand-400: #903365FF;
-  --pgn-color-action-default-brand-300: #C05B91FF;
-  --pgn-color-action-default-brand-200: #D99ABBFF;
-  --pgn-color-action-default-brand-100: #EACCDDFF;
-  --pgn-color-action-default-secondary-base: #2B2B2BFF;
-  --pgn-color-action-default-secondary-900: #161616FF;
-  --pgn-color-action-default-secondary-800: #1A1A1AFF;
-  --pgn-color-action-default-secondary-700: #1E1E1EFF;
-  --pgn-color-action-default-secondary-600: #252525FF;
-  --pgn-color-action-default-secondary-500: #2B2B2BFF;
-  --pgn-color-action-default-secondary-400: #5A5A5AFF;
-  --pgn-color-action-default-secondary-300: #898989FF;
-  --pgn-color-action-default-secondary-200: #B8B8B8FF;
-  --pgn-color-action-default-secondary-100: #DBDBDBFF;
-  --pgn-color-action-default-primary-base: #051627FF;
-  --pgn-color-action-default-primary-900: #02080EFF;
-  --pgn-color-action-default-primary-800: #020A13FF;
-  --pgn-color-action-default-primary-700: #030C16FF;
-  --pgn-color-action-default-primary-600: #04111FFF;
-  --pgn-color-action-default-primary-500: #051627FF;
-  --pgn-color-action-default-primary-400: #354A5FFF;
-  --pgn-color-action-default-primary-300: #677F95FF;
-  --pgn-color-action-default-primary-200: #A4B1C0FF;
-  --pgn-color-action-default-primary-100: #D1DBE1FF;
-  --pgn-color-action-default-gray-base: #575757FF;
-  --pgn-color-action-default-gray-900: #0A0C0DFF;
-  --pgn-color-action-default-gray-800: #1A1A1AFF;
-  --pgn-color-action-default-gray-700: #2B2B2BFF;
-  --pgn-color-action-default-gray-600: #424242FF;
-  --pgn-color-action-default-gray-500: #575757FF;
-  --pgn-color-action-default-gray-400: #767676FF;
-  --pgn-color-action-default-gray-300: #949494FF;
-  --pgn-color-action-default-gray-200: #B3B3B3FF;
-  --pgn-color-action-default-gray-100: #D2D2D2FF;
-  --pgn-color-dark-base: #273F2FFF; /* Basic dark color. */
-  --pgn-color-dark-900: #1B2C21FF; /* Dark color of level 900. */
-  --pgn-color-dark-800: #1D2F23FF; /* Dark color of level 800. */
-  --pgn-color-dark-700: #1F3226FF; /* Info color of level 700. */
-  --pgn-color-dark-600: #23392AFF; /* Dark color of level 600. */
-  --pgn-color-dark-500: var(--pgn-color-dark-base); /* Dark color of level 500. */
-  --pgn-color-dark-400: #5D6F63FF; /* Dark color of level 400. */
-  --pgn-color-dark-300: #939F97FF; /* Dark color of level 300. */
-  --pgn-color-dark-200: #C9CFCBFF; /* Dark color of level 200. */
-  --pgn-color-dark-100: #F2F3F3FF; /* Dark color of level 100. */
-  --pgn-color-light-base: #E1DDDBFF; /* Basic light color. */
-  --pgn-color-light-900: #9E9B99FF; /* Light color of level 900. */
-  --pgn-color-light-800: #A9A6A4FF; /* Light color of level 800. */
-  --pgn-color-light-700: #B4B1AFFF; /* Light color of level 700. */
-  --pgn-color-light-600: #CBC7C5FF; /* Light color of level 600. */
-  --pgn-color-light-500: var(--pgn-color-light-base); /* Light color of level 500. */
-  --pgn-color-light-400: #E9E6E4FF; /* Light color of level 400. */
-  --pgn-color-light-300: #F0EEEDFF; /* Light color of level 300. */
-  --pgn-color-light-200: #F8F7F6FF; /* Light color of level 200. */
-  --pgn-color-light-100: #FDFDFDFF; /* Light color of level 100. */
-  --pgn-color-danger-base: var(--pgn-color-red); /* Basic danger color. */
-  --pgn-color-danger-900: #892029FF; /* Danger color of level 900. */
-  --pgn-color-danger-800: #92222CFF; /* Danger color of level 800. */
-  --pgn-color-danger-700: #9C242EFF; /* Danger color of level 700. */
-  --pgn-color-danger-600: #B02934FF; /* Danger color of level 600. */
-  --pgn-color-danger-500: var(--pgn-color-danger-base); /* Danger color of level 500. */
-  --pgn-color-danger-400: #D2626BFF; /* Danger color of level 400. */
-  --pgn-color-danger-300: #E1969DFF; /* Danger color of level 300. */
-  --pgn-color-danger-200: #F0CBCEFF; /* Danger color of level 200. */
-  --pgn-color-danger-100: #FBF2F3FF; /* Danger color of level 100. */
-  --pgn-color-warning-base: var(--pgn-color-yellow); /* Basic warning color. */
-  --pgn-color-warning-900: #B39800FF; /* Warning color of level 900. */
-  --pgn-color-warning-800: #BFA300FF; /* Warning color of level 800. */
-  --pgn-color-warning-700: #CCAE00FF; /* Warning color of level 700. */
-  --pgn-color-warning-600: #E6C300FF; /* Warning color of level 600. */
-  --pgn-color-warning-500: var(--pgn-color-warning-base); /* Warning color of level 500. */
-  --pgn-color-warning-400: #FFE340FF; /* Warning color of level 400. */
-  --pgn-color-warning-300: #FFEC80FF; /* Warning color of level 300. */
-  --pgn-color-warning-200: #FFF6BFFF; /* Warning color of level 200. */
-  --pgn-color-warning-100: #FFFDF0FF; /* Warning color of level 100. */
-  --pgn-color-info-base: var(--pgn-color-teal); /* Basic info color. */
-  --pgn-color-info-900: #004C77FF; /* Info color of level 900. */
-  --pgn-color-info-800: #005280FF; /* Info color of level 800. */
-  --pgn-color-info-700: #005788FF; /* Info color of level 700. */
-  --pgn-color-info-600: #006299FF; /* Info color of level 600. */
-  --pgn-color-info-500: var(--pgn-color-info-base); /* Info color of level 500. */
-  --pgn-color-info-400: #4092BFFF; /* Info color of level 400. */
-  --pgn-color-info-300: #80B6D5FF; /* Info color of level 300. */
-  --pgn-color-info-200: #BFDBEAFF; /* Info color of level 200. */
-  --pgn-color-info-100: #F0F6FAFF; /* Info color of level 100. */
-  --pgn-color-success-base: var(--pgn-color-green); /* Basic success color. */
-  --pgn-color-success-900: #105B3AFF; /* Success color of level 900. */
-  --pgn-color-success-800: #11623EFF; /* Success color of level 800. */
-  --pgn-color-success-700: #126842FF; /* Success color of level 700. */
-  --pgn-color-success-600: #15754BFF; /* Success color of level 600. */
-  --pgn-color-success-500: var(--pgn-color-success-base); /* Success color of level 500. */
-  --pgn-color-success-400: #51A17EFF; /* Success color of level 400. */
-  --pgn-color-success-300: #8BC1A9FF; /* Success color of level 300. */
-  --pgn-color-success-200: #C5E0D4FF; /* Success color of level 200. */
-  --pgn-color-success-100: #F1F8F5FF; /* Success color of level 100. */
-  --pgn-color-brand-base: #9D0054FF; /* Basic brand color. */
-  --pgn-color-brand-900: #6E003BFF; /* Brand color of level 900. */
-  --pgn-color-brand-800: #76003FFF; /* Brand color of level 800. */
-  --pgn-color-brand-700: #7E0043FF; /* Brand color of level 700. */
-  --pgn-color-brand-600: #8D004CFF; /* Brand color of level 600. */
-  --pgn-color-brand-500: var(--pgn-color-brand-base); /* Brand color of level 500. */
-  --pgn-color-brand-400: #B6407FFF; /* Brand color of level 400. */
-  --pgn-color-brand-300: #CE80AAFF; /* Brand color of level 300. */
-  --pgn-color-brand-200: #E7BFD4FF; /* Brand color of level 200. */
-  --pgn-color-brand-100: #F9F0F5FF; /* Brand color of level 100. */
-  --pgn-color-secondary-base: var(--pgn-color-gray-700); /* Basic secondary color. */
-  --pgn-color-secondary-900: #303030FF; /* Secondary color of level 900. */
-  --pgn-color-secondary-800: #343434FF; /* Secondary color of level 800. */
-  --pgn-color-secondary-700: #373737FF; /* Secondary color of level 700. */
-  --pgn-color-secondary-600: #3E3E3EFF; /* Secondary color of level 600. */
-  --pgn-color-secondary-500: var(--pgn-color-secondary-base); /* Secondary color of level 500. */
-  --pgn-color-secondary-400: #747474FF; /* Secondary color of level 400. */
-  --pgn-color-secondary-300: #A2A2A2FF; /* Secondary color of level 300. */
-  --pgn-color-secondary-200: #D1D1D1FF; /* Secondary color of level 200. */
-  --pgn-color-secondary-100: #F4F4F4FF; /* Secondary color of level 100. */
-  --pgn-color-primary-base: #0A3055FF; /* Basic primary color. */
-  --pgn-color-primary-900: #07223CFF; /* Primary color of level 900. */
-  --pgn-color-primary-800: #082440FF; /* Primary color of level 800. */
-  --pgn-color-primary-700: #082644FF; /* Primary color of level 700. */
-  --pgn-color-primary-600: #092B4DFF; /* Primary color of level 600. */
-  --pgn-color-primary-500: var(--pgn-color-primary-base); /* Primary color of level 500. */
-  --pgn-color-primary-400: #476480FF; /* Primary color of level 400. */
-  --pgn-color-primary-300: #8598AAFF; /* Primary color of level 300. */
-  --pgn-color-primary-200: #C2CBD5FF; /* Primary color of level 200. */
-  --pgn-color-primary-100: #F0F3F5FF; /* Primary color of level 100. */
-  --pgn-color-gray-base: #707070FF; /* Basic gray color. */
-  --pgn-color-gray-900: #212529FF; /* Gray color of level 900. */
-  --pgn-color-gray-800: #333333FF; /* Gray color of level 800. */
-  --pgn-color-gray-700: #454545FF; /* Gray color of level 700. */
-  --pgn-color-gray-600: #5C5C5CFF; /* Gray color of level 600. */
-  --pgn-color-gray-500: var(--pgn-color-gray-base); /* Gray color of level 500. */
-  --pgn-color-gray-400: #8F8F8FFF; /* Gray color of level 400. */
-  --pgn-color-gray-300: #ADADADFF; /* Gray color of level 300. */
-  --pgn-color-gray-200: #CCCCCCFF; /* Gray color of level 200. */
-  --pgn-color-gray-100: #EBEBEBFF; /* Gray color of level 100. */
-  --pgn-color-accent-b: #FFEE88FF; /* Accent-B color. */
-  --pgn-color-accent-a: #00BBF9FF; /* Accent-A color. */
-  --pgn-color-teal: #006DAAFF; /* Teal color. */
-  --pgn-color-yellow: #FFD900FF; /* Yellow color. */
-  --pgn-color-green: #178253FF; /* Green color. */
-  --pgn-color-red: #C32D3AFF; /* Red color. */
-  --pgn-color-blue: #23419FFF; /* Blue color. */
-  --pgn-color-black: #000000FF; /* Black color. */
-  --pgn-color-white: #FFFFFFFF; /* White color. */
-  --pgn-color-yiq-light: var(--pgn-color-white);
-  --pgn-color-blockquote-small: var(--pgn-color-gray-500);
-  --pgn-color-mark-bg: #FFF243FF;
-  --pgn-color-text-muted: var(--pgn-color-gray-500);
-  --pgn-color-list-group-action-active-bg: var(--pgn-color-gray-200);
-  --pgn-color-list-group-action-active-base: var(--pgn-color-body-base);
-  --pgn-color-list-group-action-hover: var(--pgn-color-list-group-action-base);
-  --pgn-color-list-group-action-base: var(--pgn-color-gray-700);
-  --pgn-color-list-group-disabled-bg: var(--pgn-color-list-group-bg-base);
-  --pgn-color-list-group-disabled-base: var(--pgn-color-gray-600);
-  --pgn-color-list-group-active-bg: var(--pgn-color-bg-active);
-  --pgn-color-list-group-active-border: var(--pgn-color-list-group-active-bg);
-  --pgn-color-list-group-active-base: var(--pgn-color-active);
-  --pgn-color-list-group-border: #00000020;
-  --pgn-color-list-group-bg-hover: var(--pgn-color-gray-100);
-  --pgn-color-list-group-bg-base: var(--pgn-color-white);
-  --pgn-color-list-group-base: inherit;
-  --pgn-color-link-brand-inline-hover-decoration: #51002BFF;
-  --pgn-color-link-brand-inline-hover-base: #51002BFF;
-  --pgn-color-link-brand-inline-decoration: #9D00544D;
-  --pgn-color-link-brand-inline-base: var(--pgn-color-brand-500);
-  --pgn-color-link-brand-hover: #51002BFF;
-  --pgn-color-link-brand-base: var(--pgn-color-brand-500);
-  --pgn-color-link-muted-inline-hover-decoration: #020911FF;
-  --pgn-color-link-muted-inline-hover-base: #020911FF;
-  --pgn-color-link-muted-inline-decoration: #0A30554D;
-  --pgn-color-link-muted-inline-base: var(--pgn-color-primary-500);
-  --pgn-color-link-muted-hover: #020911FF;
-  --pgn-color-link-muted-base: var(--pgn-color-primary-500);
-  --pgn-color-link-inline-hover-decoration: #003C5EFF;
-  --pgn-color-link-inline-hover-base: #003C5EFF;
-  --pgn-color-link-inline-decoration: #006DAA4D;
-  --pgn-color-link-inline-base: var(--pgn-color-info-500);
-  --pgn-color-link-hover: #003C5EFF;
-  --pgn-color-link-base: var(--pgn-color-info-500);
-  --pgn-color-hr-border: #0000001A;
-  --pgn-color-headings-base: var(--pgn-color-black);
-  --pgn-color-body-bg: var(--pgn-color-bg-base);
-  --pgn-color-body-base: var(--pgn-color-gray-700);
-  --pgn-color-tooltip-arrow-light: var(--pgn-color-white);
-  --pgn-color-tooltip-arrow-base: var(--pgn-color-tooltip-bg-base);
-  --pgn-color-tooltip-bg-light: var(--pgn-color-white);
-  --pgn-color-tooltip-bg-base: var(--pgn-color-black);
-  --pgn-color-tooltip-light: var(--pgn-color-black);
-  --pgn-color-tooltip-text: var(--pgn-color-white);
-  --pgn-color-toast-header-border: #00000080;
-  --pgn-color-toast-header-bg: var(--pgn-color-gray-700);
-  --pgn-color-toast-header-text: var(--pgn-color-white);
-  --pgn-color-toast-border: #0000001A;
-  --pgn-color-toast-bg: var(--pgn-color-gray-700);
-  --pgn-color-toast-base: inherit;
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-border-focus: var(--pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-focus);
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-active-hover: var(--pgn-color-primary-300);
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-hover: #00000000;
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-focus: var(--pgn-color-white);
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-text-active-hover: var(--pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-focus);
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-text-active: var(--pgn-color-tab-inverse-pills-link-dropdown-toggle-text-focus);
-  --pgn-color-tab-inverse-pills-link-dropdown-toggle-text-focus: var(--pgn-color-primary-500);
-  --pgn-color-tab-more-link-dropdown-toggle-border-focus: var(--pgn-color-tab-more-link-dropdown-toggle-bg-focus);
-  --pgn-color-tab-more-link-dropdown-toggle-bg-focus: var(--pgn-color-primary-500);
-  --pgn-color-tab-more-link-dropdown-toggle-text-hover: var(--pgn-color-tab-more-link-dropdown-toggle-bg-focus);
-  --pgn-color-tab-more-link-dropdown-toggle-text-active: var(--pgn-color-tab-more-link-dropdown-toggle-text-focus);
-  --pgn-color-tab-more-link-dropdown-toggle-text-focus: var(--pgn-color-white);
-  --pgn-color-tab-more-link-dropdown-toggle-btn-border-focus: var(--pgn-color-tab-more-link-dropdown-toggle-bg-focus);
-  --pgn-color-tab-more-link-dropdown-toggle-btn-text-focus: var(--pgn-color-tab-more-link-dropdown-toggle-text-focus);
-  --pgn-color-stepper-header-step-description-error: var(--pgn-color-stepper-header-step-bubble-error);
-  --pgn-color-stepper-header-step-bubble-error: var(--pgn-color-danger-base);
-  --pgn-color-stepper-header-step-border: none;
-  --pgn-color-stepper-header-step-bg-active: var(--pgn-color-gray-500);
-  --pgn-color-stepper-header-step-bg-base: var(--pgn-color-stepper-header-bg-base);
-  --pgn-color-stepper-header-step-base: var(--pgn-color-primary-base);
-  --pgn-color-stepper-header-bg-line: var(--pgn-color-light-base);
-  --pgn-color-stepper-header-bg-base: #00000000;
-  --pgn-color-sheet-skrim-component-box-shadow: #00000026;
-  --pgn-color-sheet-skrim-bg: #ADADAD80;
-  --pgn-color-search-field-form-bg: var(--pgn-color-white);
-  --pgn-color-search-field-button-bg-brand: var(--pgn-color-brand-500);
-  --pgn-color-search-field-button-bg-primary: var(--pgn-color-primary-500);
-  --pgn-color-search-field-border-focus: var(--pgn-color-black);
-  --pgn-color-search-field-border-interaction: var(--pgn-color-black);
-  --pgn-color-search-field-border-base: var(--pgn-color-gray-500);
-  --pgn-color-progress-bg: #00000000;
-  --pgn-color-progress-bar-border: var(--pgn-color-gray-500);
-  --pgn-color-progress-bar-bg-annotated: var(--pgn-color-dark-500);
-  --pgn-color-progress-bar-bg-base: var(--pgn-color-accent-a);
-  --pgn-color-progress-bar-base: var(--pgn-color-white);
-  --pgn-color-product-tour-checkpoint-arrow-border-transparent: #00000000;
-  --pgn-color-product-tour-checkpoint-arrow-border-top: var(--pgn-color-product-tour-checkpoint-bg);
-  --pgn-color-product-tour-checkpoint-box-shadow: #0000004D;
-  --pgn-color-product-tour-checkpoint-breadcrumb: var(--pgn-color-primary-base);
-  --pgn-color-product-tour-checkpoint-border: var(--pgn-color-brand-base);
-  --pgn-color-product-tour-checkpoint-body: var(--pgn-color-gray-700);
-  --pgn-color-product-tour-checkpoint-bg: var(--pgn-color-light-300);
-  --pgn-color-popover-danger-icon: var(--pgn-color-danger-500);
-  --pgn-color-popover-danger-bg: var(--pgn-color-danger-100);
-  --pgn-color-popover-warning-icon: var(--pgn-color-warning-500);
-  --pgn-color-popover-warning-bg: var(--pgn-color-warning-100);
-  --pgn-color-popover-success-icon: var(--pgn-color-success-500);
-  --pgn-color-popover-success-bg: var(--pgn-color-success-100);
-  --pgn-color-popover-arrow-outer: #0000000D;
-  --pgn-color-popover-arrow-base: var(--pgn-color-popover-bg);
-  --pgn-color-popover-body: var(--pgn-color-body-base);
-  --pgn-color-popover-header-border-bottom-dark: #F2F2F2FF;
-  --pgn-color-popover-header-bg-dark: #808080FF;
-  --pgn-color-popover-header-bg: var(--pgn-color-white);
-  --pgn-color-popover-header-text: var(--pgn-color-headings-base);
-  --pgn-color-popover-border: #00000033;
-  --pgn-color-popover-bg: var(--pgn-color-bg-base);
-  --pgn-color-pagination-dropdown-text-inverse: var(--pgn-color-white);
-  --pgn-color-pagination-focus-text: var(--pgn-color-black);
-  --pgn-color-pagination-focus-base: var(--pgn-color-primary-500);
-  --pgn-color-pagination-border-disabled: var(--pgn-color-gray-100);
-  --pgn-color-pagination-border-active: var(--pgn-color-pagination-bg-active);
-  --pgn-color-pagination-border-hover: var(--pgn-color-gray-200);
-  --pgn-color-pagination-border-base: var(--pgn-color-gray-200);
-  --pgn-color-pagination-bg-disabled: var(--pgn-color-white);
-  --pgn-color-pagination-bg-active: var(--pgn-color-bg-active);
-  --pgn-color-pagination-bg-hover: var(--pgn-color-gray-100);
-  --pgn-color-pagination-bg-base: var(--pgn-color-bg-base);
-  --pgn-color-pagination-text-disabled: var(--pgn-color-disabled);
-  --pgn-color-pagination-text-active: var(--pgn-color-active);
-  --pgn-color-pagination-text-hover: var(--pgn-color-link-hover);
-  --pgn-color-pagination-text-inverse: var(--pgn-color-white);
-  --pgn-color-pagination-text-base: var(--pgn-color-link-base);
-  --pgn-color-page-banner-text-warning: var(--pgn-color-black);
-  --pgn-color-page-banner-text-accent-b: var(--pgn-color-black);
-  --pgn-color-page-banner-text-accent-a: var(--pgn-color-black);
-  --pgn-color-page-banner-text-light: var(--pgn-color-black);
-  --pgn-color-page-banner-text-dark: var(--pgn-color-white);
-  --pgn-color-page-banner-bg-warning: var(--pgn-color-warning-100);
-  --pgn-color-page-banner-bg-accent-b: var(--pgn-color-accent-b);
-  --pgn-color-page-banner-bg-accent-a: var(--pgn-color-accent-a);
-  --pgn-color-page-banner-bg-light: var(--pgn-color-light-400);
-  --pgn-color-page-banner-bg-dark: var(--pgn-color-dark-500);
-  --pgn-color-overflow-scroll-opacity-mask-transparent: #00000066;
-  --pgn-color-navbar-light-brand-hover: var(--pgn-color-navbar-light-active);
-  --pgn-color-navbar-light-brand-text: var(--pgn-color-navbar-light-active);
-  --pgn-color-navbar-light-toggler-border: #0000001A;
-  --pgn-color-navbar-light-disabled: #0000004D;
-  --pgn-color-navbar-light-active: #000000E6;
-  --pgn-color-navbar-light-hover: #000000B3;
-  --pgn-color-navbar-light-text: #00000080;
-  --pgn-color-navbar-dark-brand-hover: var(--pgn-color-navbar-dark-active);
-  --pgn-color-navbar-dark-brand-text: var(--pgn-color-navbar-dark-active);
-  --pgn-color-navbar-dark-toggler-border: #FFFFFF1A;
-  --pgn-color-navbar-dark-disabled: #FFFFFF40;
-  --pgn-color-navbar-dark-active: var(--pgn-color-active);
-  --pgn-color-navbar-dark-hover: #FFFFFFBF;
-  --pgn-color-navbar-dark-text: #FFFFFF80;
-  --pgn-color-nav-light: #00000080;
-  --pgn-color-nav-dark: #FFFFFF80;
-  --pgn-color-nav-divider: var(--pgn-color-gray-100);
-  --pgn-color-nav-pills-inverse-tab-content-color: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-bg-active-focus-hover: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-bg-active-hover: var(--pgn-color-nav-pills-inverse-link-border-base);
-  --pgn-color-nav-pills-inverse-link-bg-active: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-bg-hover: var(--pgn-color-nav-pills-inverse-link-border-base);
-  --pgn-color-nav-pills-inverse-link-border-focus-hover: var(--pgn-color-nav-pills-inverse-link-border-active-focus);
-  --pgn-color-nav-pills-inverse-link-border-active-focus: var(--pgn-color-primary-base);
-  --pgn-color-nav-pills-inverse-link-border-active-hover: var(--pgn-color-nav-pills-inverse-link-border-base);
-  --pgn-color-nav-pills-inverse-link-border-active: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-border-base: var(--pgn-color-dark-300);
-  --pgn-color-nav-pills-inverse-link-text-active-hover: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-text-active-focus: var(--pgn-color-nav-pills-inverse-link-text-active);
-  --pgn-color-nav-pills-inverse-link-text-hover: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-text-active: var(--pgn-color-primary-500);
-  --pgn-color-nav-pills-inverse-link-text-focus: var(--pgn-color-nav-pills-inverse-link-text-base);
-  --pgn-color-nav-pills-inverse-link-text-base: var(--pgn-color-white);
-  --pgn-color-nav-pills-base-link-border: var(--pgn-color-nav-tabs-base-border-base);
-  --pgn-color-nav-pills-base-link-active-border: var(--pgn-color-white);
-  --pgn-color-nav-pills-base-link-active-bg: var(--pgn-color-bg-active);
-  --pgn-color-nav-pills-base-link-active-text: var(--pgn-color-active);
-  --pgn-color-nav-tabs-inverse-dropdown-border: var(--pgn-color-nav-tabs-inverse-link-bg-active-hover);
-  --pgn-color-nav-tabs-inverse-link-tab-content-color: var(--pgn-color-nav-tabs-inverse-link-text-base);
-  --pgn-color-nav-tabs-inverse-link-bg-active-hover: #00000000;
-  --pgn-color-nav-tabs-inverse-link-bg-focus: var(--pgn-color-nav-tabs-inverse-link-text-base);
-  --pgn-color-nav-tabs-inverse-link-bg-active: var(--pgn-color-nav-tabs-inverse-link-bg-hover);
-  --pgn-color-nav-tabs-inverse-link-bg-hover: var(--pgn-color-nav-tabs-inverse-link-border-bottom);
-  --pgn-color-nav-tabs-inverse-link-border-active: var(--pgn-color-nav-tabs-inverse-link-text-base);
-  --pgn-color-nav-tabs-inverse-link-border-bottom: var(--pgn-color-dark-300);
-  --pgn-color-nav-tabs-inverse-link-text-base: var(--pgn-color-white);
-  --pgn-color-nav-tabs-base-link-disabled-border: var(--pgn-color-nav-link-border);
-  --pgn-color-nav-tabs-base-link-active-bg: #00000000;
-  --pgn-color-nav-tabs-base-link-active-text: var(--pgn-color-primary-500);
-  --pgn-color-nav-tabs-base-link-hover-bg: var(--pgn-color-light-400);
-  --pgn-color-nav-tabs-base-border-focus: var(--pgn-color-nav-tabs-base-bg-hover);
-  --pgn-color-nav-tabs-base-border-base: var(--pgn-color-light-400);
-  --pgn-color-nav-tabs-base-bg-hover: #00000000;
-  --pgn-color-nav-tabs-base-text-disabled: var(--pgn-color-nav-tabs-base-bg-hover);
-  --pgn-color-nav-link-border: #00000000;
-  --pgn-color-nav-link-text-disabled: var(--pgn-color-gray-300);
-  --pgn-color-nav-link-text-base: var(--pgn-color-gray-700);
-  --pgn-color-modal-backdrop-bg: var(--pgn-color-black);
-  --pgn-color-modal-content-border: #00000033;
-  --pgn-color-modal-content-bg: var(--pgn-color-bg-base);
-  --pgn-color-menu-select-btn-link-color: var(--pgn-color-primary-500);
-  --pgn-color-menu-item-focus-bg: var(--pgn-color-btn-active-bg-tertiary);
-  --pgn-color-menu-item-hover-border: var(--pgn-color-menu-item-bg);
-  --pgn-color-menu-item-hover-bg: var(--pgn-color-btn-hover-bg-tertiary);
-  --pgn-color-menu-item-hover-color: var(--pgn-color-btn-text-tertiary);
-  --pgn-color-menu-item-border: var(--pgn-color-menu-item-bg);
-  --pgn-color-menu-item-bg: #00000000;
-  --pgn-color-menu-item-color: var(--pgn-color-body-base);
-  --pgn-color-menu-bg: var(--pgn-color-white);
-  --pgn-color-image-thumbnail-border: var(--pgn-color-gray-200);
-  --pgn-color-image-thumbnail-bg: var(--pgn-color-body-bg);
-  --pgn-color-image-figure-caption: var(--pgn-color-gray-500);
-  --pgn-color-icon-button-black: var(--pgn-color-black);
-  --pgn-color-icon-button-accent: var(--pgn-color-white);
-  --pgn-color-icon-button-text-black-inverse-active-focus: var(--pgn-color-icon-button-text-black-inverse-active-base);
-  --pgn-color-icon-button-text-black-inverse-active-hover: var(--pgn-color-icon-button-text-black-inverse-active-base);
-  --pgn-color-icon-button-text-black-inverse-active-base: var(--pgn-color-black);
-  --pgn-color-icon-button-text-black-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-black-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-black-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-black-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-black-inverse-hover: var(--pgn-color-black);
-  --pgn-color-icon-button-text-black-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-black-focus: var(--pgn-color-icon-button-text-black-base);
-  --pgn-color-icon-button-text-black-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-black-base: var(--pgn-color-black);
-  --pgn-color-icon-button-text-dark-inverse-active-focus: var(--pgn-color-icon-button-text-dark-inverse-active-base);
-  --pgn-color-icon-button-text-dark-inverse-active-hover: var(--pgn-color-icon-button-text-dark-inverse-active-base);
-  --pgn-color-icon-button-text-dark-inverse-active-base: var(--pgn-color-dark-base);
-  --pgn-color-icon-button-text-dark-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-dark-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-dark-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-dark-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-dark-inverse-hover: var(--pgn-color-dark-base);
-  --pgn-color-icon-button-text-dark-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-dark-focus: var(--pgn-color-icon-button-text-dark-base);
-  --pgn-color-icon-button-text-dark-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-dark-base: var(--pgn-color-dark-base);
-  --pgn-color-icon-button-text-light-inverse-active-focus: var(--pgn-color-icon-button-text-light-inverse-active-base);
-  --pgn-color-icon-button-text-light-inverse-active-hover: var(--pgn-color-icon-button-text-light-inverse-active-base);
-  --pgn-color-icon-button-text-light-inverse-active-base: var(--pgn-color-light-base);
-  --pgn-color-icon-button-text-light-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-light-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-light-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-light-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-light-inverse-hover: var(--pgn-color-light-base);
-  --pgn-color-icon-button-text-light-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-light-focus: var(--pgn-color-icon-button-text-light-base);
-  --pgn-color-icon-button-text-light-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-light-base: var(--pgn-color-light-base);
-  --pgn-color-icon-button-text-danger-inverse-active-focus: var(--pgn-color-icon-button-text-danger-inverse-active-base);
-  --pgn-color-icon-button-text-danger-inverse-active-hover: var(--pgn-color-icon-button-text-danger-inverse-active-base);
-  --pgn-color-icon-button-text-danger-inverse-active-base: var(--pgn-color-danger-base);
-  --pgn-color-icon-button-text-danger-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-danger-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-danger-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-danger-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-danger-inverse-hover: var(--pgn-color-danger-base);
-  --pgn-color-icon-button-text-danger-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-danger-focus: var(--pgn-color-icon-button-text-danger-base);
-  --pgn-color-icon-button-text-danger-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-danger-base: var(--pgn-color-danger-base);
-  --pgn-color-icon-button-text-warning-inverse-active-focus: var(--pgn-color-icon-button-text-warning-inverse-active-base);
-  --pgn-color-icon-button-text-warning-inverse-active-hover: var(--pgn-color-icon-button-text-warning-inverse-active-base);
-  --pgn-color-icon-button-text-warning-inverse-active-base: var(--pgn-color-warning-base);
-  --pgn-color-icon-button-text-warning-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-warning-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-warning-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-warning-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-warning-inverse-hover: var(--pgn-color-warning-base);
-  --pgn-color-icon-button-text-warning-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-warning-focus: var(--pgn-color-icon-button-text-warning-base);
-  --pgn-color-icon-button-text-warning-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-warning-base: var(--pgn-color-warning-base);
-  --pgn-color-icon-button-text-success-inverse-active-focus: var(--pgn-color-icon-button-text-success-inverse-active-base);
-  --pgn-color-icon-button-text-success-inverse-active-hover: var(--pgn-color-icon-button-text-success-inverse-active-base);
-  --pgn-color-icon-button-text-success-inverse-active-base: var(--pgn-color-success-base);
-  --pgn-color-icon-button-text-success-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-success-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-success-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-success-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-success-inverse-hover: var(--pgn-color-success-base);
-  --pgn-color-icon-button-text-success-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-success-focus: var(--pgn-color-icon-button-text-success-base);
-  --pgn-color-icon-button-text-success-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-success-base: var(--pgn-color-success-base);
-  --pgn-color-icon-button-text-brand-inverse-active-focus: var(--pgn-color-icon-button-text-brand-inverse-active-base);
-  --pgn-color-icon-button-text-brand-inverse-active-hover: var(--pgn-color-icon-button-text-brand-inverse-active-base);
-  --pgn-color-icon-button-text-brand-inverse-active-base: var(--pgn-color-brand-base);
-  --pgn-color-icon-button-text-brand-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-brand-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-brand-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-brand-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-brand-inverse-hover: var(--pgn-color-brand-base);
-  --pgn-color-icon-button-text-brand-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-brand-focus: var(--pgn-color-icon-button-text-brand-base);
-  --pgn-color-icon-button-text-brand-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-brand-base: var(--pgn-color-brand-base);
-  --pgn-color-icon-button-text-secondary-inverse-active-focus: var(--pgn-color-icon-button-text-secondary-inverse-active-base);
-  --pgn-color-icon-button-text-secondary-inverse-active-hover: var(--pgn-color-icon-button-text-secondary-inverse-active-base);
-  --pgn-color-icon-button-text-secondary-inverse-active-base: var(--pgn-color-secondary-base);
-  --pgn-color-icon-button-text-secondary-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-secondary-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-secondary-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-secondary-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-secondary-inverse-hover: var(--pgn-color-secondary-base);
-  --pgn-color-icon-button-text-secondary-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-secondary-focus: var(--pgn-color-icon-button-text-secondary-base);
-  --pgn-color-icon-button-text-secondary-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-secondary-base: var(--pgn-color-secondary-base);
-  --pgn-color-icon-button-text-primary-inverse-active-focus: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-text-primary-inverse-active-hover: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-text-primary-inverse-active-base: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-text-primary-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-primary-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-primary-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-primary-inverse-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-primary-inverse-hover: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-text-primary-inverse-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-primary-focus: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-text-primary-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-text-primary-base: var(--pgn-color-primary-base);
-  --pgn-color-icon-button-bg-black-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-black-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-black-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-black-active-focus: var(--pgn-color-icon-button-bg-black-active-base);
-  --pgn-color-icon-button-bg-black-active-hover: var(--pgn-color-icon-button-bg-black-active-base);
-  --pgn-color-icon-button-bg-black-active-base: var(--pgn-color-black);
-  --pgn-color-icon-button-bg-black-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-black-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-black-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-black-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-black-hover: var(--pgn-color-black);
-  --pgn-color-icon-button-bg-black-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-dark-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-dark-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-dark-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-dark-active-focus: var(--pgn-color-icon-button-bg-dark-active-base);
-  --pgn-color-icon-button-bg-dark-active-hover: var(--pgn-color-icon-button-bg-dark-active-base);
-  --pgn-color-icon-button-bg-dark-active-base: var(--pgn-color-dark-base);
-  --pgn-color-icon-button-bg-dark-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-dark-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-dark-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-dark-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-dark-hover: var(--pgn-color-dark-base);
-  --pgn-color-icon-button-bg-dark-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-light-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-light-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-light-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-light-active-focus: var(--pgn-color-icon-button-bg-light-active-base);
-  --pgn-color-icon-button-bg-light-active-hover: var(--pgn-color-icon-button-bg-light-active-base);
-  --pgn-color-icon-button-bg-light-active-base: var(--pgn-color-light-base);
-  --pgn-color-icon-button-bg-light-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-light-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-light-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-light-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-light-hover: var(--pgn-color-light-base);
-  --pgn-color-icon-button-bg-light-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-danger-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-danger-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-danger-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-danger-active-focus: var(--pgn-color-icon-button-bg-danger-active-base);
-  --pgn-color-icon-button-bg-danger-active-hover: var(--pgn-color-icon-button-bg-danger-active-base);
-  --pgn-color-icon-button-bg-danger-active-base: var(--pgn-color-danger-base);
-  --pgn-color-icon-button-bg-danger-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-danger-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-danger-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-danger-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-danger-hover: var(--pgn-color-danger-base);
-  --pgn-color-icon-button-bg-danger-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-warning-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-warning-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-warning-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-warning-active-focus: var(--pgn-color-icon-button-bg-warning-active-base);
-  --pgn-color-icon-button-bg-warning-active-hover: var(--pgn-color-icon-button-bg-warning-active-base);
-  --pgn-color-icon-button-bg-warning-active-base: var(--pgn-color-warning-base);
-  --pgn-color-icon-button-bg-warning-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-warning-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-warning-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-warning-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-warning-hover: var(--pgn-color-warning-base);
-  --pgn-color-icon-button-bg-warning-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-success-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-success-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-success-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-success-active-focus: var(--pgn-color-icon-button-bg-success-active-base);
-  --pgn-color-icon-button-bg-success-active-hover: var(--pgn-color-icon-button-bg-success-active-base);
-  --pgn-color-icon-button-bg-success-active-base: var(--pgn-color-success-base);
-  --pgn-color-icon-button-bg-success-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-success-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-success-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-success-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-success-hover: var(--pgn-color-success-base);
-  --pgn-color-icon-button-bg-success-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-brand-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-brand-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-brand-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-brand-active-focus: var(--pgn-color-icon-button-bg-brand-active-base);
-  --pgn-color-icon-button-bg-brand-active-hover: var(--pgn-color-icon-button-bg-brand-active-base);
-  --pgn-color-icon-button-bg-brand-active-base: var(--pgn-color-brand-base);
-  --pgn-color-icon-button-bg-brand-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-brand-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-brand-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-brand-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-brand-hover: var(--pgn-color-brand-base);
-  --pgn-color-icon-button-bg-brand-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-secondary-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-secondary-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-secondary-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-secondary-active-focus: var(--pgn-color-icon-button-bg-secondary-active-base);
-  --pgn-color-icon-button-bg-secondary-active-hover: var(--pgn-color-icon-button-bg-secondary-active-base);
-  --pgn-color-icon-button-bg-secondary-active-base: var(--pgn-color-secondary-base);
-  --pgn-color-icon-button-bg-secondary-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-secondary-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-secondary-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-secondary-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-secondary-hover: var(--pgn-color-secondary-base);
-  --pgn-color-icon-button-bg-secondary-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-primary-inverse-active-focus: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-primary-inverse-active-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-primary-inverse-active-base: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-primary-active-focus: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-bg-primary-active-hover: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-bg-primary-active-base: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-bg-primary-inverse-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-primary-inverse-hover: var(--pgn-color-icon-button-accent);
-  --pgn-color-icon-button-bg-primary-inverse-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-primary-focus: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-primary-hover: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-color-icon-button-bg-primary-base: var(--pgn-color-icon-button-bg-base);
-  --pgn-color-icon-button-bg-base: #00000000;
-  --pgn-color-form-feedback-checked-invalid: #D64D59FF;
-  --pgn-color-form-feedback-checked-valid: #1FAD6FFF;
-  --pgn-color-form-feedback-tooltip-box-shadow-focus-invalid: #C32D3A40;
-  --pgn-color-form-feedback-tooltip-box-shadow-focus-valid: #17825340;
-  --pgn-color-form-feedback-tooltip-bg-invalid: #C32D3AE6;
-  --pgn-color-form-feedback-tooltip-bg-valid: #178253E6;
-  --pgn-color-form-feedback-tooltip-valid: #FFFFFFFF;
-  --pgn-color-form-feedback-icon-invalid: var(--pgn-color-form-feedback-invalid);
-  --pgn-color-form-feedback-icon-valid: var(--pgn-color-form-feedback-valid);
-  --pgn-color-form-feedback-invalid: var(--pgn-color-danger-base);
-  --pgn-color-form-feedback-valid: var(--pgn-color-success-base);
-  --pgn-color-form-control-file-border-focus: var(--pgn-color-form-input-focus-border);
-  --pgn-color-form-control-file-border-base: var(--pgn-color-form-input-border);
-  --pgn-color-form-control-file-button-bg: var(--pgn-color-form-input-group-addon-bg);
-  --pgn-color-form-control-file-button-base: var(--pgn-color-form-control-file-base);
-  --pgn-color-form-control-file-bg-disabled: var(--pgn-color-form-input-bg-disabled);
-  --pgn-color-form-control-file-bg-base: var(--pgn-color-form-input-bg-base);
-  --pgn-color-form-control-file-base: var(--pgn-color-form-input-base);
-  --pgn-color-form-control-range-thumb-bg-active: #000000FF;
-  --pgn-color-form-control-range-thumb-bg-disabled: var(--pgn-color-disabled);
-  --pgn-color-form-control-range-thumb-bg-base: var(--pgn-color-bg-active);
-  --pgn-color-form-control-range-track-bg: var(--pgn-color-gray-300);
-  --pgn-color-form-control-select-border-focus: var(--pgn-color-form-input-focus-border);
-  --pgn-color-form-control-select-border-base: var(--pgn-color-form-input-border);
-  --pgn-color-form-control-select-bg-size: var(--pgn-color-gray-100);
-  --pgn-color-form-control-select-bg-disabled: var(--pgn-color-gray-100);
-  --pgn-color-form-control-select-bg-base: var(--pgn-color-form-input-bg-base);
-  --pgn-color-form-control-select-indicator-base: var(--pgn-color-theme-hover-gray);
-  --pgn-color-form-control-select-disabled: var(--pgn-color-disabled);
-  --pgn-color-form-control-select-base: var(--pgn-color-form-input-base);
-  --pgn-color-form-control-switch-indicator-checked-bg: var(--pgn-color-success-base);
-  --pgn-color-form-control-checkbox-indicator-indeterminate-border: var(--pgn-color-form-control-checkbox-indicator-indeterminate-bg);
-  --pgn-color-form-control-checkbox-indicator-indeterminate-bg: var(--pgn-color-bg-active);
-  --pgn-color-form-control-checkbox-indicator-indeterminate-base: var(--pgn-color-form-control-indicator-checked-base);
-  --pgn-color-form-control-label-floating-text: #FFFFFF1A;
-  --pgn-color-form-control-label-disabled: var(--pgn-color-disabled);
-  --pgn-color-form-control-label-base: inherit;
-  --pgn-color-form-control-indicator-active-border: var(--pgn-color-form-control-indicator-active-bg);
-  --pgn-color-form-control-indicator-active-bg: var(--pgn-color-bg-active);
-  --pgn-color-form-control-indicator-active-base: var(--pgn-color-active);
-  --pgn-color-form-control-indicator-checked-border-focus: var(--pgn-color-form-input-focus-border);
-  --pgn-color-form-control-indicator-checked-border-base: var(--pgn-color-form-control-indicator-checked-base);
-  --pgn-color-form-control-indicator-checked-bg-disabled: #0A305580;
-  --pgn-color-form-control-indicator-checked-bg-base: var(--pgn-color-bg-active);
-  --pgn-color-form-control-indicator-checked-invalid: var(--pgn-color-danger-base);
-  --pgn-color-form-control-indicator-checked-valid: var(--pgn-color-success-base);
-  --pgn-color-form-control-indicator-checked-base: var(--pgn-color-bg-active);
-  --pgn-color-form-control-indicator-bg-disabled: var(--pgn-color-form-input-bg-disabled);
-  --pgn-color-form-control-indicator-bg-base: var(--pgn-color-form-input-bg-base);
-  --pgn-color-form-control-indicator-border: var(--pgn-color-gray-700);
-  --pgn-color-form-input-focus-bg: var(--pgn-color-form-input-bg-base);
-  --pgn-color-form-input-focus-border: var(--pgn-color-input-focus);
-  --pgn-color-form-input-focus-base: var(--pgn-color-form-input-base);
-  --pgn-color-form-input-group-addon-bg: var(--pgn-color-gray-100);
-  --pgn-color-form-input-group-addon-border: var(--pgn-color-form-input-border);
-  --pgn-color-form-input-group-addon-base: var(--pgn-color-form-input-base);
-  --pgn-color-form-input-bg-disabled: var(--pgn-color-gray-100);
-  --pgn-color-form-input-bg-base: var(--pgn-color-bg-base);
-  --pgn-color-form-input-border: var(--pgn-color-gray-500);
-  --pgn-color-form-input-plaintext: var(--pgn-color-body-base);
-  --pgn-color-form-input-placeholder: var(--pgn-color-gray-500);
-  --pgn-color-form-input-base: var(--pgn-color-gray-700);
-  --pgn-color-dropzone-border-base: var(--pgn-color-gray-500);
-  --pgn-color-dropzone-restriction-msg: var(--pgn-color-gray-500);
-  --pgn-color-dropzone-error-wrapper: var(--pgn-color-danger-500);
-  --pgn-color-dropdown-link-disabled: var(--pgn-color-disabled);
-  --pgn-color-dropdown-link-active-bg: var(--pgn-color-bg-active);
-  --pgn-color-dropdown-link-active-base: var(--pgn-color-active);
-  --pgn-color-dropdown-link-hover-bg: var(--pgn-color-light-300);
-  --pgn-color-dropdown-link-hover-base: #000000FF;
-  --pgn-color-dropdown-link-base: var(--pgn-color-gray-900);
-  --pgn-color-dropdown-divider-bg: var(--pgn-color-gray-100);
-  --pgn-color-dropdown-border: #00000026;
-  --pgn-color-dropdown-bg: var(--pgn-color-bg-base);
-  --pgn-color-dropdown-header: var(--pgn-color-gray-500);
-  --pgn-color-dropdown-text: var(--pgn-color-body-base);
-  --pgn-color-data-table-border: var(--pgn-color-light-300);
-  --pgn-color-data-table-bg-is-loading: #FFFFFFB3;
-  --pgn-color-data-table-bg-base: var(--pgn-color-bg-base);
-  --pgn-color-code-pre: var(--pgn-color-gray-900);
-  --pgn-color-code-kbd-bg: var(--pgn-color-gray-700);
-  --pgn-color-code-kbd-base: var(--pgn-color-white);
-  --pgn-color-code-base: #E83E8CFF;
-  --pgn-color-close-button: var(--pgn-color-black);
-  --pgn-color-chip-outline-light: var(--pgn-color-chip-label-base);
-  --pgn-color-chip-outline-dark: var(--pgn-color-white);
-  --pgn-color-chip-label-dark: var(--pgn-color-chip-outline-dark);
-  --pgn-color-chip-label-base: var(--pgn-color-primary-700);
-  --pgn-color-chip-border-focus-selected-light: var(--pgn-color-dark-500);
-  --pgn-color-chip-border-focus-selected-dark: var(--pgn-color-chip-outline-dark);
-  --pgn-color-chip-border-base: var(--pgn-color-light-800);
-  --pgn-color-chip-bg-dark: var(--pgn-color-primary-300);
-  --pgn-color-chip-bg-light: var(--pgn-color-white);
-  --pgn-color-chip-text-dark: var(--pgn-color-white);
-  --pgn-color-chip-text-light: var(--pgn-color-black);
-  --pgn-color-carousel-caption: var(--pgn-color-white);
-  --pgn-color-carousel-indicator-active-bg: var(--pgn-color-white);
-  --pgn-color-carousel-control-base: var(--pgn-color-white);
-  --pgn-color-card-divider-bg: var(--pgn-color-light-400);
-  --pgn-color-card-border-focus-dark: var(--pgn-color-theme-focus-primary);
-  --pgn-color-card-border-focus-base: var(--pgn-color-primary-500);
-  --pgn-color-card-border-base: #00000020;
-  --pgn-color-card-bg-muted: var(--pgn-color-light-200);
-  --pgn-color-card-bg-dark: var(--pgn-color-primary-500);
-  --pgn-color-card-bg-base: var(--pgn-color-bg-base);
-  --pgn-color-card-base: inherit;
-  --pgn-color-btn-disabled-link: var(--pgn-color-disabled);
-  --pgn-color-btn-disabled-border-inverse-outline-warning: var(--pgn-color-btn-border-inverse-outline-warning);
-  --pgn-color-btn-disabled-border-inverse-warning: #00000000;
-  --pgn-color-btn-disabled-border-outline-warning: var(--pgn-color-btn-border-outline-warning);
-  --pgn-color-btn-disabled-border-warning: var(--pgn-color-btn-border-warning);
-  --pgn-color-btn-disabled-border-inverse-tertiary: var(--pgn-color-btn-border-inverse-tertiary);
-  --pgn-color-btn-disabled-border-tertiary: var(--pgn-color-btn-border-tertiary);
-  --pgn-color-btn-disabled-border-inverse-outline-success: inherit;
-  --pgn-color-btn-disabled-border-inverse-success: #00000000;
-  --pgn-color-btn-disabled-border-outline-success: var(--pgn-color-btn-border-outline-success);
-  --pgn-color-btn-disabled-border-success: var(--pgn-color-btn-border-success);
-  --pgn-color-btn-disabled-border-inverse-outline-secondary: var(--pgn-color-btn-border-inverse-outline-secondary);
-  --pgn-color-btn-disabled-border-inverse-secondary: var(--pgn-color-btn-border-inverse-secondary);
-  --pgn-color-btn-disabled-border-outline-secondary: var(--pgn-color-secondary-base);
-  --pgn-color-btn-disabled-border-secondary: inherit;
-  --pgn-color-btn-disabled-border-inverse-outline-primary: var(--pgn-color-btn-text-inverse-outline-primary);
-  --pgn-color-btn-disabled-border-outline-primary: var(--pgn-color-btn-hover-text-outline-primary);
-  --pgn-color-btn-disabled-border-inverse-primary: #00000000;
-  --pgn-color-btn-disabled-border-primary: var(--pgn-color-btn-border-primary);
-  --pgn-color-btn-disabled-border-inverse-outline-light: var(--pgn-color-btn-border-inverse-outline-light);
-  --pgn-color-btn-disabled-border-inverse-light: #00000000;
-  --pgn-color-btn-disabled-border-outline-light: var(--pgn-color-btn-hover-text-outline-light);
-  --pgn-color-btn-disabled-border-light: var(--pgn-color-btn-border-light);
-  --pgn-color-btn-disabled-border-inverse-outline-info: var(--pgn-color-btn-border-inverse-outline-info);
-  --pgn-color-btn-disabled-border-inverse-info: #00000000;
-  --pgn-color-btn-disabled-border-outline-info: var(--pgn-color-btn-border-outline-info);
-  --pgn-color-btn-disabled-border-info: var(--pgn-color-btn-bg-info);
-  --pgn-color-btn-disabled-border-inverse-outline-dark: var(--pgn-color-btn-focus-border-inverse-outline-dark);
-  --pgn-color-btn-disabled-border-inverse-dark: #00000000;
-  --pgn-color-btn-disabled-border-outline-dark: var(--pgn-color-btn-hover-text-outline-dark);
-  --pgn-color-btn-disabled-border-dark: var(--pgn-color-btn-border-dark);
-  --pgn-color-btn-disabled-border-inverse-outline-danger: var(--pgn-color-btn-border-inverse-outline-danger);
-  --pgn-color-btn-disabled-border-inverse-danger: #00000000;
-  --pgn-color-btn-disabled-border-outline-danger: var(--pgn-color-btn-border-outline-danger);
-  --pgn-color-btn-disabled-border-danger: var(--pgn-color-btn-border-danger);
-  --pgn-color-btn-disabled-border-inverse-outline-brand: var(--pgn-color-btn-text-inverse-outline-brand);
-  --pgn-color-btn-disabled-border-inverse-brand: var(--pgn-color-btn-disabled-bg-inverse-brand);
-  --pgn-color-btn-disabled-border-outline-brand: var(--pgn-color-btn-border-outline-brand);
-  --pgn-color-btn-disabled-border-brand: var(--pgn-color-btn-border-brand);
-  --pgn-color-btn-disabled-bg-inverse-outline-warning: inherit;
-  --pgn-color-btn-disabled-bg-inverse-warning: inherit;
-  --pgn-color-btn-disabled-bg-outline-warning: inherit;
-  --pgn-color-btn-disabled-bg-warning: var(--pgn-color-btn-bg-warning);
-  --pgn-color-btn-disabled-bg-inverse-tertiary: inherit;
-  --pgn-color-btn-disabled-bg-tertiary: inherit;
-  --pgn-color-btn-disabled-bg-inverse-outline-success: inherit;
-  --pgn-color-btn-disabled-bg-inverse-success: inherit;
-  --pgn-color-btn-disabled-bg-outline-success: inherit;
-  --pgn-color-btn-disabled-bg-success: var(--pgn-color-btn-bg-success);
-  --pgn-color-btn-disabled-bg-inverse-outline-secondary: inherit;
-  --pgn-color-btn-disabled-bg-inverse-secondary: inherit;
-  --pgn-color-btn-disabled-bg-outline-secondary: inherit;
-  --pgn-color-btn-disabled-bg-secondary: var(--pgn-color-btn-bg-secondary);
-  --pgn-color-btn-disabled-bg-inverse-outline-primary: inherit;
-  --pgn-color-btn-disabled-bg-outline-primary: inherit;
-  --pgn-color-btn-disabled-bg-inverse-primary: var(--pgn-color-white);
-  --pgn-color-btn-disabled-bg-primary: var(--pgn-color-btn-bg-primary);
-  --pgn-color-btn-disabled-bg-inverse-outline-light: inherit;
-  --pgn-color-btn-disabled-bg-inverse-light: inherit;
-  --pgn-color-btn-disabled-bg-outline-light: inherit;
-  --pgn-color-btn-disabled-bg-light: var(--pgn-color-btn-bg-light);
-  --pgn-color-btn-disabled-bg-inverse-outline-info: inherit;
-  --pgn-color-btn-disabled-bg-inverse-info: inherit;
-  --pgn-color-btn-disabled-bg-outline-info: inherit;
-  --pgn-color-btn-disabled-bg-info: var(--pgn-color-btn-bg-info);
-  --pgn-color-btn-disabled-bg-inverse-outline-dark: inherit;
-  --pgn-color-btn-disabled-bg-inverse-dark: inherit;
-  --pgn-color-btn-disabled-bg-outline-dark: inherit;
-  --pgn-color-btn-disabled-bg-dark: var(--pgn-color-btn-bg-dark);
-  --pgn-color-btn-disabled-bg-inverse-outline-danger: inherit;
-  --pgn-color-btn-disabled-bg-inverse-danger: #00000000;
-  --pgn-color-btn-disabled-bg-outline-danger: inherit;
-  --pgn-color-btn-disabled-bg-danger: var(--pgn-color-btn-bg-danger);
-  --pgn-color-btn-disabled-bg-inverse-outline-brand: var(--pgn-color-btn-bg-inverse-outline-brand);
-  --pgn-color-btn-disabled-bg-inverse-brand: var(--pgn-color-white);
-  --pgn-color-btn-disabled-bg-outline-brand: inherit;
-  --pgn-color-btn-disabled-bg-brand: var(--pgn-color-btn-bg-brand);
-  --pgn-color-btn-disabled-text-inverse-outline-warning: var(--pgn-color-btn-text-inverse-outline-warning);
-  --pgn-color-btn-disabled-text-inverse-warning: var(--pgn-color-warning-base);
-  --pgn-color-btn-disabled-text-outline-warning: var(--pgn-color-btn-text-outline-warning);
-  --pgn-color-btn-disabled-text-warning: var(--pgn-color-btn-text-warning);
-  --pgn-color-btn-disabled-text-inverse-tertiary: var(--pgn-color-btn-text-inverse-tertiary);
-  --pgn-color-btn-disabled-text-tertiary: var(--pgn-color-btn-text-tertiary);
-  --pgn-color-btn-disabled-text-inverse-outline-success: var(--pgn-color-btn-text-inverse-outline-success);
-  --pgn-color-btn-disabled-text-inverse-success: var(--pgn-color-success-base);
-  --pgn-color-btn-disabled-text-outline-success: var(--pgn-color-btn-text-outline-success);
-  --pgn-color-btn-disabled-text-success: var(--pgn-color-btn-text-success);
-  --pgn-color-btn-disabled-text-inverse-outline-secondary: var(--pgn-color-btn-text-inverse-outline-secondary);
-  --pgn-color-btn-disabled-text-inverse-secondary: inherit;
-  --pgn-color-btn-disabled-text-outline-secondary: inherit;
-  --pgn-color-btn-disabled-text-secondary: var(--pgn-color-btn-text-secondary);
-  --pgn-color-btn-disabled-text-inverse-outline-primary: var(--pgn-color-btn-text-inverse-outline-primary);
-  --pgn-color-btn-disabled-text-outline-primary: var(--pgn-color-btn-hover-text-outline-primary);
-  --pgn-color-btn-disabled-text-inverse-primary: var(--pgn-color-primary-500);
-  --pgn-color-btn-disabled-text-primary: var(--pgn-color-btn-text-primary);
-  --pgn-color-btn-disabled-text-inverse-outline-light: var(--pgn-color-btn-text-inverse-outline-light);
-  --pgn-color-btn-disabled-text-inverse-light: var(--pgn-color-btn-text-inverse-light);
-  --pgn-color-btn-disabled-text-outline-light: var(--pgn-color-btn-hover-text-outline-light);
-  --pgn-color-btn-disabled-text-light: var(--pgn-color-btn-text-light);
-  --pgn-color-btn-disabled-text-inverse-outline-info: var(--pgn-color-btn-text-inverse-outline-info);
-  --pgn-color-btn-disabled-text-inverse-info: var(--pgn-color-info-base);
-  --pgn-color-btn-disabled-text-outline-info: var(--pgn-color-btn-text-outline-info);
-  --pgn-color-btn-disabled-text-info: var(--pgn-color-btn-text-info);
-  --pgn-color-btn-disabled-text-inverse-outline-dark: var(--pgn-color-btn-text-inverse-outline-dark);
-  --pgn-color-btn-disabled-text-inverse-dark: var(--pgn-color-btn-text-inverse-dark);
-  --pgn-color-btn-disabled-text-outline-dark: inherit;
-  --pgn-color-btn-disabled-text-dark: var(--pgn-color-btn-text-dark);
-  --pgn-color-btn-disabled-text-inverse-outline-danger: var(--pgn-color-btn-text-inverse-outline-danger);
-  --pgn-color-btn-disabled-text-inverse-danger: var(--pgn-color-danger-base);
-  --pgn-color-btn-disabled-text-outline-danger: var(--pgn-color-btn-hover-text-outline-danger);
-  --pgn-color-btn-disabled-text-danger: var(--pgn-color-btn-text-danger);
-  --pgn-color-btn-disabled-text-inverse-outline-brand: var(--pgn-color-btn-text-inverse-outline-brand);
-  --pgn-color-btn-disabled-text-outline-brand: var(--pgn-color-btn-hover-text-outline-brand);
-  --pgn-color-btn-disabled-text-inverse-brand: var(--pgn-color-brand-500);
-  --pgn-color-btn-disabled-text-brand: var(--pgn-color-btn-text-brand);
-  --pgn-color-btn-focus-outline-inverse-outline-warning: inherit;
-  --pgn-color-btn-focus-outline-inverse-warning: var(--pgn-color-white);
-  --pgn-color-btn-focus-outline-outline-warning: var(--pgn-color-theme-focus-warning);
-  --pgn-color-btn-focus-outline-warning: var(--pgn-color-theme-focus-warning);
-  --pgn-color-btn-focus-outline-inverse-tertiary: var(--pgn-color-white);
-  --pgn-color-btn-focus-outline-tertiary: var(--pgn-color-theme-focus-primary);
-  --pgn-color-btn-focus-outline-inverse-outline-success: var(--pgn-color-btn-focus-border-inverse-outline-success);
-  --pgn-color-btn-focus-outline-inverse-success: var(--pgn-color-btn-focus-border-inverse-success);
-  --pgn-color-btn-focus-outline-outline-success: var(--pgn-color-theme-focus-success);
-  --pgn-color-btn-focus-outline-success: var(--pgn-color-theme-focus-success);
-  --pgn-color-btn-focus-outline-inverse-outline-secondary: var(--pgn-color-btn-border-inverse-outline-secondary);
-  --pgn-color-btn-focus-outline-inverse-secondary: var(--pgn-color-white);
-  --pgn-color-btn-focus-outline-outline-secondary: var(--pgn-color-theme-focus-secondary);
-  --pgn-color-btn-focus-outline-secondary: var(--pgn-color-theme-focus-secondary);
-  --pgn-color-btn-focus-outline-inverse-outline-primary: var(--pgn-color-btn-border-inverse-outline-primary);
-  --pgn-color-btn-focus-outline-inverse-primary: var(--pgn-color-btn-focus-border-inverse-primary);
-  --pgn-color-btn-focus-outline-outline-primary: var(--pgn-color-theme-focus-primary);
-  --pgn-color-btn-focus-outline-primary: var(--pgn-color-theme-focus-primary);
-  --pgn-color-btn-focus-outline-inverse-outline-light: var(--pgn-color-btn-focus-border-inverse-outline-light);
-  --pgn-color-btn-focus-outline-inverse-light: var(--pgn-color-white);
-  --pgn-color-btn-focus-outline-outline-light: var(--pgn-color-theme-focus-light);
-  --pgn-color-btn-focus-outline-light: var(--pgn-color-primary-300);
-  --pgn-color-btn-focus-outline-inverse-outline-info: var(--pgn-color-btn-focus-border-inverse-outline-info);
-  --pgn-color-btn-focus-outline-inverse-info: var(--pgn-color-btn-focus-border-inverse-info);
-  --pgn-color-btn-focus-outline-outline-info: var(--pgn-color-theme-focus-info);
-  --pgn-color-btn-focus-outline-info: var(--pgn-color-theme-focus-info);
-  --pgn-color-btn-focus-outline-inverse-outline-dark: var(--pgn-color-btn-focus-border-inverse-outline-dark);
-  --pgn-color-btn-focus-outline-inverse-dark: var(--pgn-color-btn-focus-border-inverse-dark);
-  --pgn-color-btn-focus-outline-outline-dark: var(--pgn-color-theme-focus-dark);
-  --pgn-color-btn-focus-outline-dark: var(--pgn-color-theme-focus-dark);
-  --pgn-color-btn-focus-outline-inverse-outline-danger: var(--pgn-color-btn-focus-border-inverse-danger);
-  --pgn-color-btn-focus-outline-inverse-danger: var(--pgn-color-btn-focus-border-inverse-danger);
-  --pgn-color-btn-focus-outline-outline-danger: var(--pgn-color-theme-focus-danger);
-  --pgn-color-btn-focus-outline-danger: var(--pgn-color-theme-focus-danger);
-  --pgn-color-btn-focus-outline-inverse-outline-brand: var(--pgn-color-btn-focus-border-inverse-outline-brand);
-  --pgn-color-btn-focus-outline-inverse-brand: var(--pgn-color-btn-focus-border-inverse-brand);
-  --pgn-color-btn-focus-outline-outline-brand: var(--pgn-color-theme-focus-brand);
-  --pgn-color-btn-focus-outline-brand: var(--pgn-color-theme-focus-brand);
-  --pgn-color-btn-focus-bg-inverse-outline-warning: inherit;
-  --pgn-color-btn-focus-bg-inverse-warning: var(--pgn-color-btn-bg-inverse-warning);
-  --pgn-color-btn-focus-bg-outline-warning: inherit;
-  --pgn-color-btn-focus-bg-warning: var(--pgn-color-btn-bg-warning);
-  --pgn-color-btn-focus-bg-inverse-tertiary: inherit;
-  --pgn-color-btn-focus-bg-tertiary: inherit;
-  --pgn-color-btn-focus-bg-inverse-outline-success: inherit;
-  --pgn-color-btn-focus-bg-inverse-success: var(--pgn-color-btn-bg-inverse-success);
-  --pgn-color-btn-focus-bg-outline-success: inherit;
-  --pgn-color-btn-focus-bg-success: var(--pgn-color-btn-bg-success);
-  --pgn-color-btn-focus-bg-inverse-outline-secondary: inherit;
-  --pgn-color-btn-focus-bg-inverse-secondary: var(--pgn-color-btn-bg-inverse-secondary);
-  --pgn-color-btn-focus-bg-outline-secondary: #00000000;
-  --pgn-color-btn-focus-bg-secondary: var(--pgn-color-btn-bg-secondary);
-  --pgn-color-btn-focus-bg-inverse-outline-primary: inherit;
-  --pgn-color-btn-focus-bg-inverse-primary: var(--pgn-color-btn-bg-inverse-primary);
-  --pgn-color-btn-focus-bg-outline-primary: inherit;
-  --pgn-color-btn-focus-bg-primary: var(--pgn-color-btn-bg-primary);
-  --pgn-color-btn-focus-bg-inverse-outline-light: inherit;
-  --pgn-color-btn-focus-bg-inverse-light: var(--pgn-color-btn-bg-inverse-light);
-  --pgn-color-btn-focus-bg-outline-light: #00000000;
-  --pgn-color-btn-focus-bg-light: var(--pgn-color-btn-bg-light);
-  --pgn-color-btn-focus-bg-inverse-outline-info: inherit;
-  --pgn-color-btn-focus-bg-inverse-info: var(--pgn-color-btn-bg-inverse-info);
-  --pgn-color-btn-focus-bg-outline-info: inherit;
-  --pgn-color-btn-focus-bg-info: var(--pgn-color-btn-bg-info);
-  --pgn-color-btn-focus-bg-inverse-outline-dark: inherit;
-  --pgn-color-btn-focus-bg-inverse-dark: var(--pgn-color-btn-bg-inverse-dark);
-  --pgn-color-btn-focus-bg-outline-dark: inherit;
-  --pgn-color-btn-focus-bg-dark: var(--pgn-color-btn-bg-dark);
-  --pgn-color-btn-focus-bg-inverse-outline-danger: inherit;
-  --pgn-color-btn-focus-bg-inverse-danger: var(--pgn-color-btn-bg-inverse-danger);
-  --pgn-color-btn-focus-bg-outline-danger: inherit;
-  --pgn-color-btn-focus-bg-danger: var(--pgn-color-btn-bg-danger);
-  --pgn-color-btn-focus-bg-inverse-outline-brand: inherit;
-  --pgn-color-btn-focus-bg-outline-brand: inherit;
-  --pgn-color-btn-focus-bg-inverse-brand: var(--pgn-color-btn-bg-inverse-brand);
-  --pgn-color-btn-focus-bg-brand: var(--pgn-color-btn-bg-brand);
-  --pgn-color-btn-focus-border-inverse-outline-warning: var(--pgn-color-btn-border-inverse-outline-warning);
-  --pgn-color-btn-focus-border-inverse-warning: var(--pgn-color-btn-border-inverse-warning);
-  --pgn-color-btn-focus-border-outline-warning: var(--pgn-color-btn-border-outline-warning);
-  --pgn-color-btn-focus-border-warning: var(--pgn-color-btn-border-warning);
-  --pgn-color-btn-focus-border-inverse-tertiary: #00000000;
-  --pgn-color-btn-focus-border-tertiary: var(--pgn-color-btn-border-tertiary);
-  --pgn-color-btn-focus-border-inverse-outline-success: var(--pgn-color-btn-border-inverse-outline-success);
-  --pgn-color-btn-focus-border-inverse-success: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-success: var(--pgn-color-btn-border-outline-success);
-  --pgn-color-btn-focus-border-success: var(--pgn-color-btn-border-success);
-  --pgn-color-btn-focus-border-inverse-outline-secondary: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-inverse-secondary: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-secondary: var(--pgn-color-btn-border-outline-secondary);
-  --pgn-color-btn-focus-border-secondary: var(--pgn-color-btn-bg-secondary);
-  --pgn-color-btn-focus-border-inverse-outline-primary: var(--pgn-color-btn-border-inverse-outline-primary);
-  --pgn-color-btn-focus-border-inverse-primary: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-primary: var(--pgn-color-btn-border-outline-primary);
-  --pgn-color-btn-focus-border-primary: var(--pgn-color-btn-border-primary);
-  --pgn-color-btn-focus-border-inverse-outline-light: var(--pgn-color-btn-border-inverse-outline-light);
-  --pgn-color-btn-focus-border-inverse-light: var(--pgn-color-btn-border-inverse-light);
-  --pgn-color-btn-focus-border-outline-light: var(--pgn-color-btn-border-outline-light);
-  --pgn-color-btn-focus-border-light: var(--pgn-color-btn-border-light);
-  --pgn-color-btn-focus-border-inverse-outline-info: var(--pgn-color-btn-border-inverse-outline-info);
-  --pgn-color-btn-focus-border-inverse-info: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-info: var(--pgn-color-btn-border-outline-info);
-  --pgn-color-btn-focus-border-info: var(--pgn-color-btn-border-info);
-  --pgn-color-btn-focus-border-inverse-outline-dark: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-inverse-dark: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-dark: var(--pgn-color-btn-border-outline-dark);
-  --pgn-color-btn-focus-border-dark: var(--pgn-color-btn-focus-bg-dark);
-  --pgn-color-btn-focus-border-inverse-outline-danger: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-inverse-danger: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-danger: var(--pgn-color-btn-border-outline-danger);
-  --pgn-color-btn-focus-border-danger: var(--pgn-color-btn-focus-bg-danger);
-  --pgn-color-btn-focus-border-inverse-outline-brand: var(--pgn-color-btn-border-inverse-outline-brand);
-  --pgn-color-btn-focus-border-inverse-brand: var(--pgn-color-white);
-  --pgn-color-btn-focus-border-outline-brand: var(--pgn-color-btn-border-outline-brand);
-  --pgn-color-btn-focus-border-brand: var(--pgn-color-btn-border-brand);
-  --pgn-color-btn-focus-text-inverse-outline-warning: var(--pgn-color-btn-text-inverse-outline-warning);
-  --pgn-color-btn-focus-text-inverse-warning: var(--pgn-color-btn-text-inverse-warning);
-  --pgn-color-btn-focus-text-outline-warning: var(--pgn-color-btn-text-outline-warning);
-  --pgn-color-btn-focus-text-warning: var(--pgn-color-btn-text-warning);
-  --pgn-color-btn-focus-text-inverse-tertiary: var(--pgn-color-btn-text-inverse-tertiary);
-  --pgn-color-btn-focus-text-tertiary: var(--pgn-color-btn-text-tertiary);
-  --pgn-color-btn-focus-text-inverse-outline-success: var(--pgn-color-btn-text-inverse-outline-success);
-  --pgn-color-btn-focus-text-inverse-success: var(--pgn-color-btn-text-inverse-success);
-  --pgn-color-btn-focus-text-outline-success: var(--pgn-color-btn-text-outline-success);
-  --pgn-color-btn-focus-text-success: var(--pgn-color-btn-text-success);
-  --pgn-color-btn-focus-text-inverse-outline-secondary: var(--pgn-color-btn-text-inverse-outline-secondary);
-  --pgn-color-btn-focus-text-outline-secondary: var(--pgn-color-btn-text-outline-secondary);
-  --pgn-color-btn-focus-text-inverse-secondary: inherit;
-  --pgn-color-btn-focus-text-secondary: var(--pgn-color-btn-text-secondary);
-  --pgn-color-btn-focus-text-inverse-outline-primary: var(--pgn-color-btn-text-inverse-outline-primary);
-  --pgn-color-btn-focus-text-inverse-primary: var(--pgn-color-btn-text-inverse-primary);
-  --pgn-color-btn-focus-text-outline-primary: var(--pgn-color-btn-text-outline-primary);
-  --pgn-color-btn-focus-text-primary: var(--pgn-color-btn-text-primary);
-  --pgn-color-btn-focus-text-inverse-outline-light: var(--pgn-color-btn-text-inverse-outline-light);
-  --pgn-color-btn-focus-text-inverse-light: var(--pgn-color-btn-text-inverse-light);
-  --pgn-color-btn-focus-text-outline-light: var(--pgn-color-btn-text-outline-light);
-  --pgn-color-btn-focus-text-light: var(--pgn-color-btn-text-light);
-  --pgn-color-btn-focus-text-inverse-outline-info: var(--pgn-color-btn-text-inverse-outline-info);
-  --pgn-color-btn-focus-text-inverse-info: var(--pgn-color-btn-text-inverse-info);
-  --pgn-color-btn-focus-text-outline-info: var(--pgn-color-btn-text-outline-info);
-  --pgn-color-btn-focus-text-info: var(--pgn-color-btn-text-info);
-  --pgn-color-btn-focus-text-inverse-outline-dark: var(--pgn-color-btn-text-inverse-outline-dark);
-  --pgn-color-btn-focus-text-outline-dark: inherit;
-  --pgn-color-btn-focus-text-inverse-dark: var(--pgn-color-btn-text-inverse-dark);
-  --pgn-color-btn-focus-text-dark: var(--pgn-color-btn-text-dark);
-  --pgn-color-btn-focus-text-inverse-outline-danger: var(--pgn-color-btn-text-inverse-outline-danger);
-  --pgn-color-btn-focus-text-outline-danger: var(--pgn-color-btn-text-outline-danger);
-  --pgn-color-btn-focus-text-inverse-danger: var(--pgn-color-btn-text-inverse-danger);
-  --pgn-color-btn-focus-text-danger: var(--pgn-color-btn-text-danger);
-  --pgn-color-btn-focus-text-inverse-outline-brand: var(--pgn-color-btn-text-inverse-outline-brand);
-  --pgn-color-btn-focus-text-outline-brand: var(--pgn-color-btn-text-outline-brand);
-  --pgn-color-btn-focus-text-inverse-brand: var(--pgn-color-btn-text-inverse-brand);
-  --pgn-color-btn-focus-text-brand: var(--pgn-color-btn-text-brand);
-  --pgn-color-btn-active-border-inverse-outline-warning: #00000000;
-  --pgn-color-btn-active-border-outline-warning: var(--pgn-color-theme-active-warning);
-  --pgn-color-btn-active-border-inverse-warning: inherit;
-  --pgn-color-btn-active-border-warning: var(--pgn-color-theme-active-warning);
-  --pgn-color-btn-active-border-inverse-tertiary: #00000000;
-  --pgn-color-btn-active-border-tertiary: #00000000;
-  --pgn-color-btn-active-border-inverse-outline-success: #00000000;
-  --pgn-color-btn-active-border-inverse-success: inherit;
-  --pgn-color-btn-active-border-outline-success: var(--pgn-color-theme-active-success);
-  --pgn-color-btn-active-border-success: var(--pgn-color-theme-active-success);
-  --pgn-color-btn-active-border-inverse-secondary: #00000000;
-  --pgn-color-btn-active-border-inverse-outline-secondary: #00000000;
-  --pgn-color-btn-active-border-outline-secondary: var(--pgn-color-theme-active-secondary);
-  --pgn-color-btn-active-border-secondary: var(--pgn-color-theme-active-secondary);
-  --pgn-color-btn-active-border-inverse-primary: #00000000;
-  --pgn-color-btn-active-border-inverse-outline-primary: #00000000;
-  --pgn-color-btn-active-border-outline-primary: var(--pgn-color-theme-active-primary);
-  --pgn-color-btn-active-border-primary: var(--pgn-color-theme-active-primary);
-  --pgn-color-btn-active-border-inverse-outline-light: #00000000;
-  --pgn-color-btn-active-border-inverse-light: inherit;
-  --pgn-color-btn-active-border-outline-light: var(--pgn-color-theme-active-light);
-  --pgn-color-btn-active-border-light: var(--pgn-color-theme-active-light);
-  --pgn-color-btn-active-border-inverse-outline-info: #00000000;
-  --pgn-color-btn-active-border-inverse-info: #00000000;
-  --pgn-color-btn-active-border-outline-info: var(--pgn-color-theme-active-info);
-  --pgn-color-btn-active-border-info: var(--pgn-color-theme-active-info);
-  --pgn-color-btn-active-border-inverse-outline-dark: #00000000;
-  --pgn-color-btn-active-border-inverse-dark: #00000000;
-  --pgn-color-btn-active-border-outline-dark: var(--pgn-color-theme-active-dark);
-  --pgn-color-btn-active-border-dark: var(--pgn-color-theme-active-dark);
-  --pgn-color-btn-active-border-inverse-outline-danger: #00000000;
-  --pgn-color-btn-active-border-inverse-danger: #00000000;
-  --pgn-color-btn-active-border-outline-danger: var(--pgn-color-theme-active-danger);
-  --pgn-color-btn-active-border-danger: var(--pgn-color-theme-active-danger);
-  --pgn-color-btn-active-border-inverse-outline-brand: #00000000;
-  --pgn-color-btn-active-border-inverse-brand: #00000000;
-  --pgn-color-btn-active-border-outline-brand: var(--pgn-color-theme-active-brand);
-  --pgn-color-btn-active-border-brand: var(--pgn-color-theme-active-brand);
-  --pgn-color-btn-active-bg-inverse-outline-warning: var(--pgn-color-theme-bg-warning);
-  --pgn-color-btn-active-bg-inverse-warning: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-outline-warning: var(--pgn-color-theme-bg-warning);
-  --pgn-color-btn-active-bg-warning: var(--pgn-color-theme-active-warning);
-  --pgn-color-btn-active-bg-inverse-tertiary: var(--pgn-color-btn-hover-bg-inverse-tertiary);
-  --pgn-color-btn-active-bg-tertiary: var(--pgn-color-light-500);
-  --pgn-color-btn-active-bg-inverse-outline-success: var(--pgn-color-theme-bg-success);
-  --pgn-color-btn-active-bg-inverse-success: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-outline-success: var(--pgn-color-theme-bg-success);
-  --pgn-color-btn-active-bg-success: var(--pgn-color-theme-active-success);
-  --pgn-color-btn-active-bg-inverse-secondary: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-inverse-outline-secondary: var(--pgn-color-theme-bg-secondary);
-  --pgn-color-btn-active-bg-outline-secondary: var(--pgn-color-theme-bg-secondary);
-  --pgn-color-btn-active-bg-secondary: var(--pgn-color-theme-active-secondary);
-  --pgn-color-btn-active-bg-inverse-primary: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-inverse-outline-primary: var(--pgn-color-theme-bg-primary);
-  --pgn-color-btn-active-bg-outline-primary: var(--pgn-color-theme-bg-primary);
-  --pgn-color-btn-active-bg-primary: var(--pgn-color-theme-active-primary);
-  --pgn-color-btn-active-bg-inverse-outline-light: var(--pgn-color-theme-bg-light);
-  --pgn-color-btn-active-bg-inverse-light: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-outline-light: var(--pgn-color-theme-bg-light);
-  --pgn-color-btn-active-bg-light: var(--pgn-color-theme-active-light);
-  --pgn-color-btn-active-bg-inverse-outline-info: var(--pgn-color-theme-bg-info);
-  --pgn-color-btn-active-bg-inverse-info: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-outline-info: var(--pgn-color-theme-bg-info);
-  --pgn-color-btn-active-bg-info: var(--pgn-color-theme-active-info);
-  --pgn-color-btn-active-bg-inverse-outline-dark: var(--pgn-color-theme-bg-dark);
-  --pgn-color-btn-active-bg-inverse-dark: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-outline-dark: var(--pgn-color-theme-bg-dark);
-  --pgn-color-btn-active-bg-dark: var(--pgn-color-theme-active-dark);
-  --pgn-color-btn-active-bg-inverse-outline-danger: var(--pgn-color-theme-bg-danger);
-  --pgn-color-btn-active-bg-inverse-danger: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-outline-danger: var(--pgn-color-theme-bg-danger);
-  --pgn-color-btn-active-bg-danger: var(--pgn-color-theme-active-danger);
-  --pgn-color-btn-active-bg-inverse-brand: var(--pgn-color-gray-100);
-  --pgn-color-btn-active-bg-inverse-outline-brand: var(--pgn-color-theme-bg-brand);
-  --pgn-color-btn-active-bg-outline-brand: var(--pgn-color-theme-bg-brand);
-  --pgn-color-btn-active-bg-brand: var(--pgn-color-theme-active-brand);
-  --pgn-color-btn-active-text-inverse-outline-warning: #454545FF;
-  --pgn-color-btn-active-text-inverse-warning: #CCAE00FF;
-  --pgn-color-btn-active-text-outline-warning: #454545FF;
-  --pgn-color-btn-active-text-warning: #313131FF;
-  --pgn-color-btn-active-text-inverse-tertiary: var(--pgn-color-white);
-  --pgn-color-btn-active-text-tertiary: var(--pgn-color-gray-700);
-  --pgn-color-btn-active-text-inverse-outline-success: #454545FF;
-  --pgn-color-btn-active-text-inverse-success: #0F5737FF;
-  --pgn-color-btn-active-text-outline-success: #454545FF;
-  --pgn-color-btn-active-text-success: #FFFFFFFF;
-  --pgn-color-btn-active-text-inverse-outline-secondary: #454545FF;
-  --pgn-color-btn-active-text-inverse-secondary: #2B2B2BFF;
-  --pgn-color-btn-active-text-outline-secondary: #454545FF;
-  --pgn-color-btn-active-text-secondary: #FFFFFFFF;
-  --pgn-color-btn-active-text-inverse-outline-primary: #454545FF;
-  --pgn-color-btn-active-text-inverse-primary: #051627FF;
-  --pgn-color-btn-active-text-outline-primary: #454545FF;
-  --pgn-color-btn-active-text-primary: #FFFFFFFF;
-  --pgn-color-btn-active-text-inverse-outline-light: #454545FF;
-  --pgn-color-btn-active-text-inverse-light: #CAC3BFFF;
-  --pgn-color-btn-active-text-outline-light: #454545FF;
-  --pgn-color-btn-active-text-light: #313131FF;
-  --pgn-color-btn-active-text-inverse-outline-info: #454545FF;
-  --pgn-color-btn-active-text-inverse-info: #004C77FF;
-  --pgn-color-btn-active-text-outline-info: #454545FF;
-  --pgn-color-btn-active-text-info: #FFFFFFFF;
-  --pgn-color-btn-active-text-inverse-outline-dark: #454545FF;
-  --pgn-color-btn-active-text-inverse-dark: #142018FF;
-  --pgn-color-btn-active-text-outline-dark: #454545FF;
-  --pgn-color-btn-active-text-dark: #FFFFFFFF;
-  --pgn-color-btn-active-text-inverse-outline-danger: #454545FF;
-  --pgn-color-btn-active-text-inverse-danger: #9A232EFF;
-  --pgn-color-btn-active-text-outline-danger: #454545FF;
-  --pgn-color-btn-active-text-danger: #FFFFFFFF;
-  --pgn-color-btn-active-text-inverse-outline-brand: #454545FF;
-  --pgn-color-btn-active-text-inverse-brand: #6A0039FF;
-  --pgn-color-btn-active-text-outline-brand: #454545FF;
-  --pgn-color-btn-active-text-brand: #FFFFFFFF;
-  --pgn-color-btn-hover-border-inverse-outline-warning: #00000000;
-  --pgn-color-btn-hover-border-inverse-warning: #00000000;
-  --pgn-color-btn-hover-border-outline-warning: var(--pgn-color-warning-900);
-  --pgn-color-btn-hover-border-warning: var(--pgn-color-theme-hover-warning);
-  --pgn-color-btn-hover-border-inverse-tertiary: #00000000;
-  --pgn-color-btn-hover-border-tertiary: #00000000;
-  --pgn-color-btn-hover-border-inverse-outline-success: #00000000;
-  --pgn-color-btn-hover-border-inverse-success: #00000000;
-  --pgn-color-btn-hover-border-outline-success: var(--pgn-color-success-900);
-  --pgn-color-btn-hover-border-success: var(--pgn-color-theme-hover-success);
-  --pgn-color-btn-hover-border-inverse-secondary: #00000000;
-  --pgn-color-btn-hover-border-inverse-outline-secondary: #00000000;
-  --pgn-color-btn-hover-border-outline-secondary: var(--pgn-color-secondary-900);
-  --pgn-color-btn-hover-border-secondary: var(--pgn-color-theme-hover-secondary);
-  --pgn-color-btn-hover-border-inverse-primary: #00000000;
-  --pgn-color-btn-hover-border-inverse-outline-primary: #00000000;
-  --pgn-color-btn-hover-border-outline-primary: var(--pgn-color-primary-900);
-  --pgn-color-btn-hover-border-primary: var(--pgn-color-theme-hover-primary);
-  --pgn-color-btn-hover-border-inverse-outline-light: #00000000;
-  --pgn-color-btn-hover-border-inverse-light: #00000000;
-  --pgn-color-btn-hover-border-outline-light: var(--pgn-color-light-900);
-  --pgn-color-btn-hover-border-light: var(--pgn-color-theme-hover-light);
-  --pgn-color-btn-hover-border-inverse-outline-info: #00000000;
-  --pgn-color-btn-hover-border-inverse-info: #00000000;
-  --pgn-color-btn-hover-border-outline-info: var(--pgn-color-info-900);
-  --pgn-color-btn-hover-border-info: var(--pgn-color-theme-hover-info);
-  --pgn-color-btn-hover-border-inverse-outline-dark: #00000000;
-  --pgn-color-btn-hover-border-inverse-dark: #00000000;
-  --pgn-color-btn-hover-border-outline-dark: var(--pgn-color-dark-900);
-  --pgn-color-btn-hover-border-dark: var(--pgn-color-theme-hover-dark);
-  --pgn-color-btn-hover-border-inverse-outline-danger: #00000000;
-  --pgn-color-btn-hover-border-inverse-danger: #00000000;
-  --pgn-color-btn-hover-border-outline-danger: var(--pgn-color-danger-900);
-  --pgn-color-btn-hover-border-danger: var(--pgn-color-theme-hover-danger);
-  --pgn-color-btn-hover-border-inverse-brand: #00000000;
-  --pgn-color-btn-hover-border-inverse-outline-brand: #00000000;
-  --pgn-color-btn-hover-border-outline-brand: var(--pgn-color-brand-900);
-  --pgn-color-btn-hover-border-brand: var(--pgn-color-theme-hover-brand);
-  --pgn-color-btn-hover-bg-inverse-outline-warning: var(--pgn-color-warning-100);
-  --pgn-color-btn-hover-bg-inverse-warning: #323232FF;
-  --pgn-color-btn-hover-bg-outline-warning: var(--pgn-color-warning-100);
-  --pgn-color-btn-hover-bg-warning: var(--pgn-color-theme-hover-warning);
-  --pgn-color-btn-hover-bg-inverse-tertiary: #FFFFFF1A;
-  --pgn-color-btn-hover-bg-tertiary: var(--pgn-color-light-500);
-  --pgn-color-btn-hover-bg-inverse-outline-success: var(--pgn-color-success-100);
-  --pgn-color-btn-hover-bg-inverse-success: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-success: var(--pgn-color-success-100);
-  --pgn-color-btn-hover-bg-success: var(--pgn-color-theme-hover-success);
-  --pgn-color-btn-hover-bg-inverse-outline-secondary: var(--pgn-color-secondary-100);
-  --pgn-color-btn-hover-bg-inverse-secondary: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-secondary: var(--pgn-color-secondary-100);
-  --pgn-color-btn-hover-bg-secondary: var(--pgn-color-theme-hover-secondary);
-  --pgn-color-btn-hover-bg-inverse-outline-primary: var(--pgn-color-primary-100);
-  --pgn-color-btn-hover-bg-inverse-primary: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-primary: var(--pgn-color-primary-100);
-  --pgn-color-btn-hover-bg-primary: var(--pgn-color-theme-hover-primary);
-  --pgn-color-btn-hover-bg-inverse-outline-light: var(--pgn-color-light-100);
-  --pgn-color-btn-hover-bg-inverse-light: #323232FF;
-  --pgn-color-btn-hover-bg-outline-light: var(--pgn-color-light-100);
-  --pgn-color-btn-hover-bg-light: var(--pgn-color-theme-hover-light);
-  --pgn-color-btn-hover-bg-inverse-outline-info: var(--pgn-color-info-100);
-  --pgn-color-btn-hover-bg-inverse-info: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-info: var(--pgn-color-info-100);
-  --pgn-color-btn-hover-bg-info: var(--pgn-color-theme-hover-info);
-  --pgn-color-btn-hover-bg-inverse-outline-dark: var(--pgn-color-dark-100);
-  --pgn-color-btn-hover-bg-inverse-dark: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-dark: var(--pgn-color-dark-100);
-  --pgn-color-btn-hover-bg-dark: var(--pgn-color-theme-hover-dark);
-  --pgn-color-btn-hover-bg-inverse-outline-danger: var(--pgn-color-danger-100);
-  --pgn-color-btn-hover-bg-inverse-danger: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-danger: var(--pgn-color-danger-100);
-  --pgn-color-btn-hover-bg-danger: var(--pgn-color-theme-hover-danger);
-  --pgn-color-btn-hover-bg-inverse-outline-brand: var(--pgn-color-brand-100);
-  --pgn-color-btn-hover-bg-inverse-brand: #ECECECFF;
-  --pgn-color-btn-hover-bg-outline-brand: var(--pgn-color-brand-100);
-  --pgn-color-btn-hover-bg-brand: var(--pgn-color-theme-hover-brand);
-  --pgn-color-btn-hover-text-inverse-outline-warning: var(--pgn-color-theme-hover-warning);
-  --pgn-color-btn-hover-text-inverse-warning: #D9B800FF;
-  --pgn-color-btn-hover-text-outline-warning: var(--pgn-color-theme-hover-warning);
-  --pgn-color-btn-hover-text-warning: #414141FF;
-  --pgn-color-btn-hover-text-inverse-tertiary: var(--pgn-color-white);
-  --pgn-color-btn-hover-text-tertiary: var(--pgn-color-gray-700);
-  --pgn-color-btn-hover-text-inverse-outline-success: var(--pgn-color-theme-hover-success);
-  --pgn-color-btn-hover-text-inverse-success: #11623EFF;
-  --pgn-color-btn-hover-text-outline-success: var(--pgn-color-theme-hover-success);
-  --pgn-color-btn-hover-text-success: #FFFFFFFF;
-  --pgn-color-btn-hover-text-inverse-outline-secondary: var(--pgn-color-theme-hover-secondary);
-  --pgn-color-btn-hover-text-inverse-secondary: #323232FF;
-  --pgn-color-btn-hover-text-outline-secondary: var(--pgn-color-theme-hover-secondary);
-  --pgn-color-btn-hover-text-secondary: #FFFFFFFF;
-  --pgn-color-btn-hover-text-inverse-outline-primary: var(--pgn-color-theme-hover-primary);
-  --pgn-color-btn-hover-text-inverse-primary: #061D33FF;
-  --pgn-color-btn-hover-text-outline-primary: var(--pgn-color-theme-hover-primary);
-  --pgn-color-btn-hover-text-primary: #FFFFFFFF;
-  --pgn-color-btn-hover-text-inverse-outline-light: var(--pgn-color-theme-hover-light);
-  --pgn-color-btn-hover-text-inverse-light: #D0C9C6FF;
-  --pgn-color-btn-hover-text-outline-light: var(--pgn-color-theme-hover-light);
-  --pgn-color-btn-hover-text-light: #414141FF;
-  --pgn-color-btn-hover-text-inverse-outline-info: var(--pgn-color-theme-hover-info);
-  --pgn-color-btn-hover-text-inverse-info: #005484FF;
-  --pgn-color-btn-hover-text-outline-info: var(--pgn-color-theme-hover-info);
-  --pgn-color-btn-hover-text-info: #FFFFFFFF;
-  --pgn-color-btn-hover-text-inverse-outline-dark: var(--pgn-color-theme-hover-dark);
-  --pgn-color-btn-hover-text-inverse-dark: #18271DFF;
-  --pgn-color-btn-hover-text-outline-dark: var(--pgn-color-theme-hover-dark);
-  --pgn-color-btn-hover-text-dark: #FFFFFFFF;
-  --pgn-color-btn-hover-text-inverse-outline-danger: var(--pgn-color-theme-hover-danger);
-  --pgn-color-btn-hover-text-inverse-danger: #A42631FF;
-  --pgn-color-btn-hover-text-outline-danger: var(--pgn-color-theme-hover-danger);
-  --pgn-color-btn-hover-text-danger: #FFFFFFFF;
-  --pgn-color-btn-hover-text-inverse-outline-brand: var(--pgn-color-theme-hover-brand);
-  --pgn-color-btn-hover-text-inverse-brand: #770040FF;
-  --pgn-color-btn-hover-text-outline-brand: var(--pgn-color-theme-hover-brand);
-  --pgn-color-btn-hover-text-brand: #FFFFFFFF;
-  --pgn-color-btn-border-inverse-outline-warning: var(--pgn-color-white);
-  --pgn-color-btn-border-inverse-warning: #00000000;
-  --pgn-color-btn-border-outline-warning: var(--pgn-color-warning-base);
-  --pgn-color-btn-border-warning: var(--pgn-color-btn-bg-warning);
-  --pgn-color-btn-border-inverse-tertiary: #00000000;
-  --pgn-color-btn-border-tertiary: #00000000;
-  --pgn-color-btn-border-inverse-outline-success: var(--pgn-color-white);
-  --pgn-color-btn-border-inverse-success: #00000000;
-  --pgn-color-btn-border-outline-success: var(--pgn-color-success-base);
-  --pgn-color-btn-border-success: var(--pgn-color-btn-bg-success);
-  --pgn-color-btn-border-inverse-secondary: #00000000;
-  --pgn-color-btn-border-inverse-outline-secondary: var(--pgn-color-white);
-  --pgn-color-btn-border-outline-secondary: var(--pgn-color-secondary-base);
-  --pgn-color-btn-border-secondary: var(--pgn-color-btn-bg-secondary);
-  --pgn-color-btn-border-inverse-primary: #00000000;
-  --pgn-color-btn-border-inverse-outline-primary: var(--pgn-color-white);
-  --pgn-color-btn-border-outline-primary: var(--pgn-color-primary-base);
-  --pgn-color-btn-border-primary: var(--pgn-color-btn-bg-primary);
-  --pgn-color-btn-border-inverse-outline-light: var(--pgn-color-white);
-  --pgn-color-btn-border-inverse-light: #00000000;
-  --pgn-color-btn-border-outline-light: var(--pgn-color-light-base);
-  --pgn-color-btn-border-light: var(--pgn-color-btn-bg-light);
-  --pgn-color-btn-border-inverse-outline-info: var(--pgn-color-white);
-  --pgn-color-btn-border-inverse-info: #00000000;
-  --pgn-color-btn-border-outline-info: var(--pgn-color-info-base);
-  --pgn-color-btn-border-info: var(--pgn-color-btn-bg-info);
-  --pgn-color-btn-border-inverse-outline-dark: var(--pgn-color-white);
-  --pgn-color-btn-border-inverse-dark: #00000000;
-  --pgn-color-btn-border-outline-dark: var(--pgn-color-dark-base);
-  --pgn-color-btn-border-dark: var(--pgn-color-btn-bg-dark);
-  --pgn-color-btn-border-inverse-outline-danger: var(--pgn-color-white);
-  --pgn-color-btn-border-inverse-danger: #00000000;
-  --pgn-color-btn-border-outline-danger: var(--pgn-color-danger-base);
-  --pgn-color-btn-border-danger: var(--pgn-color-btn-bg-danger);
-  --pgn-color-btn-border-inverse-brand: #00000000;
-  --pgn-color-btn-border-inverse-outline-brand: var(--pgn-color-white);
-  --pgn-color-btn-border-outline-brand: var(--pgn-color-brand-base);
-  --pgn-color-btn-border-brand: var(--pgn-color-btn-bg-brand);
-  --pgn-color-btn-bg-inverse-outline-warning: inherit;
-  --pgn-color-btn-bg-inverse-warning: #454545FF;
-  --pgn-color-btn-bg-outline-warning: inherit;
-  --pgn-color-btn-bg-warning: var(--pgn-color-warning-base);
-  --pgn-color-btn-bg-inverse-tertiary: #00000000;
-  --pgn-color-btn-bg-tertiary: #00000000;
-  --pgn-color-btn-bg-inverse-outline-success: inherit;
-  --pgn-color-btn-bg-inverse-success: #FFFFFFFF;
-  --pgn-color-btn-bg-outline-success: inherit;
-  --pgn-color-btn-bg-success: var(--pgn-color-success-base);
-  --pgn-color-btn-bg-inverse-secondary: #FFFFFFFF;
-  --pgn-color-btn-bg-inverse-outline-secondary: inherit;
-  --pgn-color-btn-bg-outline-secondary: inherit;
-  --pgn-color-btn-bg-secondary: var(--pgn-color-secondary-base);
-  --pgn-color-btn-bg-inverse-primary: #FFFFFFFF;
-  --pgn-color-btn-bg-inverse-outline-primary: #00000000;
-  --pgn-color-btn-bg-outline-primary: #00000000;
-  --pgn-color-btn-bg-primary: var(--pgn-color-primary-base);
-  --pgn-color-btn-bg-inverse-outline-light: inherit;
-  --pgn-color-btn-bg-outline-light: inherit;
-  --pgn-color-btn-bg-inverse-light: #454545FF;
-  --pgn-color-btn-bg-light: var(--pgn-color-light-base);
-  --pgn-color-btn-bg-inverse-outline-info: inherit;
-  --pgn-color-btn-bg-inverse-info: #FFFFFFFF;
-  --pgn-color-btn-bg-outline-info: inherit;
-  --pgn-color-btn-bg-info: var(--pgn-color-info-base);
-  --pgn-color-btn-bg-inverse-outline-dark: #00000000;
-  --pgn-color-btn-bg-inverse-dark: #FFFFFFFF;
-  --pgn-color-btn-bg-outline-dark: inherit;
-  --pgn-color-btn-bg-dark: var(--pgn-color-dark-base);
-  --pgn-color-btn-bg-inverse-outline-danger: #00000000;
-  --pgn-color-btn-bg-inverse-danger: #FFFFFFFF;
-  --pgn-color-btn-bg-outline-danger: inherit;
-  --pgn-color-btn-bg-danger: var(--pgn-color-danger-base);
-  --pgn-color-btn-bg-inverse-outline-brand: #00000000;
-  --pgn-color-btn-bg-inverse-brand: #FFFFFFFF;
-  --pgn-color-btn-bg-outline-brand: inherit;
-  --pgn-color-btn-bg-brand: var(--pgn-color-brand-base);
-  --pgn-color-btn-text-inverse-outline-warning: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-warning: var(--pgn-color-warning-base);
-  --pgn-color-btn-text-outline-warning: var(--pgn-color-warning-base);
-  --pgn-color-btn-text-warning: #454545FF;
-  --pgn-color-btn-text-inverse-tertiary: var(--pgn-color-white);
-  --pgn-color-btn-text-tertiary: var(--pgn-color-gray-700);
-  --pgn-color-btn-text-inverse-outline-success: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-success: var(--pgn-color-success-base);
-  --pgn-color-btn-text-outline-success: var(--pgn-color-success-base);
-  --pgn-color-btn-text-success: #FFFFFFFF;
-  --pgn-color-btn-text-inverse-outline-secondary: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-secondary: var(--pgn-color-secondary-base);
-  --pgn-color-btn-text-outline-secondary: var(--pgn-color-secondary-base);
-  --pgn-color-btn-text-secondary: #FFFFFFFF;
-  --pgn-color-btn-text-inverse-outline-primary: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-primary: var(--pgn-color-primary-base);
-  --pgn-color-btn-text-outline-primary: var(--pgn-color-primary-base);
-  --pgn-color-btn-text-primary: #FFFFFFFF;
-  --pgn-color-btn-text-inverse-outline-light: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-light: var(--pgn-color-light-base);
-  --pgn-color-btn-text-outline-light: var(--pgn-color-light-base);
-  --pgn-color-btn-text-light: #454545FF;
-  --pgn-color-btn-text-inverse-outline-info: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-info: var(--pgn-color-info-base);
-  --pgn-color-btn-text-outline-info: var(--pgn-color-info-base);
-  --pgn-color-btn-text-info: #FFFFFFFF;
-  --pgn-color-btn-text-inverse-outline-dark: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-dark: var(--pgn-color-dark-base);
-  --pgn-color-btn-text-outline-dark: var(--pgn-color-dark-base);
-  --pgn-color-btn-text-dark: #FFFFFFFF;
-  --pgn-color-btn-text-inverse-outline-danger: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-danger: var(--pgn-color-danger-base);
-  --pgn-color-btn-text-outline-danger: var(--pgn-color-danger-base);
-  --pgn-color-btn-text-danger: #FFFFFFFF;
-  --pgn-color-btn-text-inverse-outline-brand: var(--pgn-color-white);
-  --pgn-color-btn-text-inverse-brand: var(--pgn-color-brand-base);
-  --pgn-color-btn-text-outline-brand: var(--pgn-color-brand-base);
-  --pgn-color-btn-text-brand: #FFFFFFFF;
-  --pgn-color-bubble-bg-primary: var(--pgn-color-primary-base);
-  --pgn-color-bubble-bg-error: var(--pgn-color-danger-base);
-  --pgn-color-bubble-bg-warning: var(--pgn-color-warning-base);
-  --pgn-color-bubble-bg-success: var(--pgn-color-success-base);
-  --pgn-color-bubble-text-primary: var(--pgn-color-white);
-  --pgn-color-bubble-text-error: var(--pgn-color-white);
-  --pgn-color-bubble-text-warning: var(--pgn-color-white);
-  --pgn-color-bubble-text-success: var(--pgn-color-white);
-  --pgn-color-breadcrumb-inverse-spacer: var(--pgn-color-light-700);
-  --pgn-color-breadcrumb-inverse-active: var(--pgn-color-light-500);
-  --pgn-color-breadcrumb-inverse-base: var(--pgn-color-white);
-  --pgn-color-breadcrumb-active: var(--pgn-color-gray-500);
-  --pgn-color-breadcrumb-base: var(--pgn-color-primary-500);
-  --pgn-color-badge-focus-box-shadow-dark: #273F2F0D;
-  --pgn-color-badge-focus-box-shadow-light: #E1DDDB0D;
-  --pgn-color-badge-focus-box-shadow-info: #006DAA0D;
-  --pgn-color-badge-focus-box-shadow-warning: #FFD9000D;
-  --pgn-color-badge-focus-box-shadow-danger: #C32D3A0D;
-  --pgn-color-badge-focus-box-shadow-success: #1782530D;
-  --pgn-color-badge-focus-box-shadow-secondary: #4545450D;
-  --pgn-color-badge-focus-box-shadow-primary: #0A30550D;
-  --pgn-color-badge-focus-bg-dark: #142018FF;
-  --pgn-color-badge-focus-bg-light: #CAC3BFFF;
-  --pgn-color-badge-focus-bg-info: #004C77FF;
-  --pgn-color-badge-focus-bg-warning: #CCAE00FF;
-  --pgn-color-badge-focus-bg-danger: #9A232EFF;
-  --pgn-color-badge-focus-bg-success: #0F5737FF;
-  --pgn-color-badge-focus-bg-secondary: #2B2B2BFF;
-  --pgn-color-badge-focus-bg-primary: #051627FF;
-  --pgn-color-badge-focus-dark: var(--pgn-color-badge-text-dark);
-  --pgn-color-badge-focus-light: var(--pgn-color-badge-text-light);
-  --pgn-color-badge-focus-info: var(--pgn-color-badge-text-info);
-  --pgn-color-badge-focus-danger: var(--pgn-color-badge-text-danger);
-  --pgn-color-badge-focus-warning: var(--pgn-color-badge-text-warning);
-  --pgn-color-badge-focus-success: var(--pgn-color-badge-text-success);
-  --pgn-color-badge-focus-secondary: var(--pgn-color-badge-text-secondary);
-  --pgn-color-badge-focus-primary: var(--pgn-color-badge-text-primary);
-  --pgn-color-badge-bg-dark: var(--pgn-color-dark-base);
-  --pgn-color-badge-bg-light: var(--pgn-color-light-base);
-  --pgn-color-badge-bg-info: var(--pgn-color-info-base);
-  --pgn-color-badge-bg-danger: var(--pgn-color-danger-base);
-  --pgn-color-badge-bg-warning: var(--pgn-color-warning-base);
-  --pgn-color-badge-bg-success: var(--pgn-color-success-base);
-  --pgn-color-badge-bg-secondary: var(--pgn-color-secondary-base);
-  --pgn-color-badge-bg-primary: var(--pgn-color-primary-base);
-  --pgn-color-badge-text-dark: #FFFFFFFF;
-  --pgn-color-badge-text-light: #454545FF;
-  --pgn-color-badge-text-info: #FFFFFFFF;
-  --pgn-color-badge-text-warning: #454545FF;
-  --pgn-color-badge-text-danger: #FFFFFFFF;
-  --pgn-color-badge-text-success: #FFFFFFFF;
-  --pgn-color-badge-text-secondary: #FFFFFFFF;
-  --pgn-color-badge-text-primary: #FFFFFFFF;
-  --pgn-color-avatar-border: var(--pgn-color-light-300);
-  --pgn-color-annotation-bg-dark: var(--pgn-color-dark-base);
-  --pgn-color-annotation-bg-light: var(--pgn-color-white);
-  --pgn-color-annotation-bg-error: var(--pgn-color-danger-base);
-  --pgn-color-annotation-bg-warning: var(--pgn-color-accent-b);
-  --pgn-color-annotation-bg-success: var(--pgn-color-success-base);
-  --pgn-color-annotation-text-dark: var(--pgn-color-white);
-  --pgn-color-annotation-text-light: var(--pgn-color-primary-500);
-  --pgn-color-annotation-text-error: var(--pgn-color-white);
-  --pgn-color-annotation-text-warning: var(--pgn-color-black);
-  --pgn-color-annotation-text-success: var(--pgn-color-white);
-  --pgn-color-alert-border-warning: var(--pgn-color-theme-border-warning);
-  --pgn-color-alert-border-danger: var(--pgn-color-theme-border-danger);
-  --pgn-color-alert-border-info: var(--pgn-color-theme-border-info);
-  --pgn-color-alert-border-success: var(--pgn-color-theme-border-success);
-  --pgn-color-alert-bg-warning: var(--pgn-color-theme-bg-warning);
-  --pgn-color-alert-bg-danger: var(--pgn-color-theme-bg-danger);
-  --pgn-color-alert-bg-info: var(--pgn-color-theme-bg-info);
-  --pgn-color-alert-bg-success: var(--pgn-color-theme-bg-success);
-  --pgn-color-alert-icon-warning: var(--pgn-color-theme-default-warning);
-  --pgn-color-alert-icon-danger: var(--pgn-color-theme-default-danger);
-  --pgn-color-alert-icon-info: var(--pgn-color-theme-default-info);
-  --pgn-color-alert-icon-success: var(--pgn-color-theme-default-success);
-  --pgn-color-alert-content: var(--pgn-color-gray-700);
-  --pgn-color-alert-title: var(--pgn-color-black);
-  --pgn-color-theme-active-gray: var(--pgn-color-gray-900); /* Theme-specific gray active color. */
-  --pgn-color-theme-active-dark: var(--pgn-color-dark-900); /* Theme-specific dark active color. */
-  --pgn-color-theme-active-light: var(--pgn-color-light-900); /* Theme-specific light active color. */
-  --pgn-color-theme-active-danger: var(--pgn-color-danger-900); /* Theme-specific danger active color. */
-  --pgn-color-theme-active-warning: var(--pgn-color-warning-900); /* Theme-specific warning active color. */
-  --pgn-color-theme-active-info: var(--pgn-color-info-900); /* Theme-specific info active color. */
-  --pgn-color-theme-active-success: var(--pgn-color-success-900); /* Theme-specific success active color. */
-  --pgn-color-theme-active-brand: var(--pgn-color-brand-900); /* Theme-specific brand active color. */
-  --pgn-color-theme-active-secondary: var(--pgn-color-secondary-900); /* Theme-specific secondary active color. */
-  --pgn-color-theme-active-primary: var(--pgn-color-primary-900); /* Theme-specific primary active color. */
-  --pgn-color-theme-hover-gray: var(--pgn-color-gray-700); /* Theme-specific gray hover color. */
-  --pgn-color-theme-hover-dark: var(--pgn-color-dark-700); /* Theme-specific dark hover color. */
-  --pgn-color-theme-hover-light: var(--pgn-color-light-700); /* Theme-specific light hover color. */
-  --pgn-color-theme-hover-danger: var(--pgn-color-danger-700); /* Theme-specific danger hover color. */
-  --pgn-color-theme-hover-warning: var(--pgn-color-warning-700); /* Theme-specific warning hover color. */
-  --pgn-color-theme-hover-info: var(--pgn-color-info-700); /* Theme-specific info hover color. */
-  --pgn-color-theme-hover-success: var(--pgn-color-success-700); /* Theme-specific success hover color. */
-  --pgn-color-theme-hover-brand: var(--pgn-color-brand-700); /* Theme-specific brand hover color. */
-  --pgn-color-theme-hover-secondary: var(--pgn-color-secondary-700); /* Theme-specific secondary hover color. */
-  --pgn-color-theme-hover-primary: var(--pgn-color-primary-700); /* Theme-specific primary hover color. */
-  --pgn-color-theme-default-gray: var(--pgn-color-gray-500); /* Theme-specific gray default color. */
-  --pgn-color-theme-default-dark: var(--pgn-color-dark-500); /* Theme-specific dark default color. */
-  --pgn-color-theme-default-light: var(--pgn-color-light-500); /* Theme-specific light default color. */
-  --pgn-color-theme-default-danger: var(--pgn-color-danger-500); /* Theme-specific danger default color. */
-  --pgn-color-theme-default-warning: var(--pgn-color-warning-500); /* Theme-specific warning default color. */
-  --pgn-color-theme-default-info: var(--pgn-color-info-500); /* Theme-specific info default color. */
-  --pgn-color-theme-default-success: var(--pgn-color-success-500); /* Theme-specific success default color. */
-  --pgn-color-theme-default-brand: var(--pgn-color-brand-500); /* Theme-specific brand default color. */
-  --pgn-color-theme-default-secondary: var(--pgn-color-secondary-500); /* Theme-specific secondary default color. */
-  --pgn-color-theme-default-primary: var(--pgn-color-primary-500); /* Theme-specific primary default color. */
-  --pgn-color-theme-focus-gray: var(--pgn-color-gray-500); /* Theme-specific gray focus color. */
-  --pgn-color-theme-focus-dark: var(--pgn-color-dark-500); /* Theme-specific dark focus color. */
-  --pgn-color-theme-focus-light: var(--pgn-color-light-500); /* Theme-specific light focus color. */
-  --pgn-color-theme-focus-danger: var(--pgn-color-danger-500); /* Theme-specific danger focus color. */
-  --pgn-color-theme-focus-warning: var(--pgn-color-warning-500); /* Theme-specific warning focus color. */
-  --pgn-color-theme-focus-info: var(--pgn-color-info-500); /* Theme-specific info focus color. */
-  --pgn-color-theme-focus-success: var(--pgn-color-success-500); /* Theme-specific success focus color. */
-  --pgn-color-theme-focus-brand: var(--pgn-color-brand-500); /* Theme-specific brand focus color. */
-  --pgn-color-theme-focus-secondary: var(--pgn-color-secondary-500); /* Theme-specific secondary focus color. */
-  --pgn-color-theme-focus-primary: var(--pgn-color-primary-500); /* Theme-specific primary focus color. */
-  --pgn-color-theme-border-gray: var(--pgn-color-gray-200); /* Theme-specific gray border color. */
-  --pgn-color-theme-border-dark: var(--pgn-color-dark-200); /* Theme-specific dark border color. */
-  --pgn-color-theme-border-light: var(--pgn-color-light-200); /* Theme-specific light border color. */
-  --pgn-color-theme-border-danger: var(--pgn-color-danger-200); /* Theme-specific danger border color. */
-  --pgn-color-theme-border-warning: var(--pgn-color-warning-200); /* Theme-specific warning border color. */
-  --pgn-color-theme-border-info: var(--pgn-color-info-200); /* Theme-specific info border color. */
-  --pgn-color-theme-border-success: var(--pgn-color-success-200); /* Theme-specific success border color. */
-  --pgn-color-theme-border-brand: var(--pgn-color-brand-200); /* Theme-specific brand border color. */
-  --pgn-color-theme-border-secondary: var(--pgn-color-secondary-200); /* Theme-specific secondary border color. */
-  --pgn-color-theme-border-primary: var(--pgn-color-primary-200); /* Theme-specific primary border color. */
-  --pgn-color-theme-bg-gray: var(--pgn-color-gray-100); /* Theme-specific gray background color. */
-  --pgn-color-theme-bg-dark: var(--pgn-color-dark-100); /* Theme-specific dark background color. */
-  --pgn-color-theme-bg-light: var(--pgn-color-light-100); /* Theme-specific light background color. */
-  --pgn-color-theme-bg-danger: var(--pgn-color-danger-100); /* Theme-specific danger background color. */
-  --pgn-color-theme-bg-warning: var(--pgn-color-warning-100); /* Theme-specific warning background color. */
-  --pgn-color-theme-bg-info: var(--pgn-color-info-100); /* Theme-specific info background color. */
-  --pgn-color-theme-bg-success: var(--pgn-color-success-100); /* Theme-specific success background color. */
-  --pgn-color-theme-bg-brand: var(--pgn-color-brand-100); /* Theme-specific brand background color. */
-  --pgn-color-theme-bg-secondary: var(--pgn-color-secondary-100); /* Theme-specific secondary background color. */
-  --pgn-color-theme-bg-primary: var(--pgn-color-primary-100); /* Theme-specific primary background color. */
-  --pgn-color-border: var(--pgn-color-gray-200); /* Border color. */
-  --pgn-color-table-border: var(--pgn-color-border); /* Table border color. */
-  --pgn-color-table-caption: var(--pgn-color-text-muted); /* Table caption color. */
-  --pgn-color-input-btn-focus: var(--pgn-color-bg-active);
-  --pgn-color-input-focus: var(--pgn-color-primary-500); /* Focused input value color. */
-  --pgn-color-disabled: var(--pgn-color-gray-500); /* Color for disabled element. */
-  --pgn-color-active: var(--pgn-color-white); /* Color for active element. */
-  --pgn-color-text-50-white: #FFFFFF80; /* White text color with transparency of 50%. */
-  --pgn-color-text-50-black: #00000080; /* Black text color with transparency of 50%. */
-  --pgn-color-bg-active: var(--pgn-color-primary-500); /* Active background color. */
-  --pgn-color-bg-base: var(--pgn-color-white); /* Basic background color. */
-  --pgn-other-link-emphasized-hover-darken-percentage: 15%;
-  --pgn-other-tooltip-opacity: 1;
-  --pgn-other-search-field-disabled-opacity: .3;
-  --pgn-other-modal-opacity: .5;
-  --pgn-other-content-form-feedback-icon-invalid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23C32D3AFF' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23C32D3AFF' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E");
-  --pgn-other-content-form-feedback-icon-valid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23178253FF' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
-  --pgn-other-content-form-control-select-bg-position-y: center;
-  --pgn-other-content-form-control-select-bg-offset-y: var(--pgn-spacing-form-input-padding-y-base);
-  --pgn-other-content-form-control-select-bg-position-x: right;
-  --pgn-other-content-form-control-select-bg-repeat: no-repeat;
-  --pgn-other-content-form-control-select-bg-image: var(--pgn-other-content-form-control-select-indicator-icon);
-  --pgn-other-content-form-control-select-bg-color: var(--pgn-color-form-control-select-bg-base);
-  --pgn-other-content-form-control-select-indicator-icon: url('data:image/svg+xml,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.58984L12 13.1698L7.41 8.58984L6 9.99984L12 15.9998L18 9.99984L16.59 8.58984Z" fill="%23454545FF"/></svg>');
-  --pgn-other-content-form-control-switch-indicator-icon-on: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23FFFFFFFF'/%3e%3c/svg%3e");
-  --pgn-other-content-form-control-switch-indicator-icon-off: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%230A3055FF'/%3e%3c/svg%3e");
-  --pgn-other-content-form-control-radio-indicator-icon-checked-invalid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23C32D3AFF'/%3e%3c/svg%3e");
-  --pgn-other-content-form-control-radio-indicator-icon-checked-valid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23178253FF'/%3e%3c/svg%3e");
-  --pgn-other-content-form-control-radio-indicator-icon-checked-base: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%230A3055FF'/%3e%3c/svg%3e");
-  --pgn-other-content-form-control-checkbox-indicator-indeterminate-icon: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM17 13H7V11H17V13Z' fill='%230A3055FF'/></svg>");
-  --pgn-other-content-form-control-checkbox-indicator-icon-checked-invalid: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='%23C32D3AFF'/></svg>");
-  --pgn-other-content-form-control-checkbox-indicator-icon-checked-valid: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='%23178253FF'/></svg>");
-  --pgn-other-content-form-control-checkbox-indicator-icon-checked-base: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='%230A3055FF'/></svg>");
-  --pgn-other-chip-opacity-disabled: .3;
-  --pgn-other-carousel-control-opacity-hover: .9;
-  --pgn-other-carousel-control-opacity-base: .5;
-  --pgn-other-btn-disabled-opacity: .65;
-  --pgn-other-form-feedback-tooltip-opacity: .9;
-  --pgn-elevation-box-shadow-centered-5-2-blur: 3rem; /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-2-offset-y: 0rem; /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-2-offset-x: 0rem; /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-1-blur: 2.5rem; /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-1-offset-y: 0rem; /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-1-offset-x: 0rem; /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-5-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 5. */
-  --pgn-elevation-box-shadow-centered-4-2-blur: 1.25rem; /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-2-offset-y: 0rem; /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-2-offset-x: 0rem; /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-1-blur: 1.25rem; /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-1-offset-y: 0rem; /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-1-offset-x: 0rem; /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-4-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 4. */
-  --pgn-elevation-box-shadow-centered-3-2-blur: 1rem; /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-2-offset-y: 0rem; /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-2-offset-x: 0rem; /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-1-blur: 0.625rem; /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-1-offset-y: 0rem; /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-1-offset-x: 0rem; /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-3-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 3. */
-  --pgn-elevation-box-shadow-centered-2-2-blur: 0.5rem; /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-2-offset-y: 0rem; /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-2-offset-x: 0rem; /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-1-blur: 0.25rem; /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-1-offset-y: 0rem; /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-1-offset-x: 0rem; /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-2-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 2. */
-  --pgn-elevation-box-shadow-centered-1-2-blur: 0.25rem; /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-2-offset-y: 0rem; /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-2-offset-x: 0rem; /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-1-blur: 0.125rem; /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-1-offset-y: 0rem; /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-1-offset-x: 0rem; /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-centered-1-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-5-2-blur: 3rem; /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-2-offset-y: 0rem; /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-2-offset-x: 0.5rem; /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-1-blur: 2.5rem; /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-1-offset-y: 0rem; /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-1-offset-x: 1.25rem; /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-5-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 5. */
-  --pgn-elevation-box-shadow-right-4-2-blur: 1.25rem; /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-2-offset-y: 0rem; /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-2-offset-x: 0.5rem; /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-1-blur: 1.25rem; /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-1-offset-y: 0rem; /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-1-offset-x: 0.625rem; /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-4-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 4. */
-  --pgn-elevation-box-shadow-right-3-2-blur: 0.625rem; /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-2-offset-y: 0rem; /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-2-offset-x: 0.25rem; /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-1-blur: 1rem; /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-1-offset-y: 0rem; /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-1-offset-x: 0.5rem; /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-3-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 3. */
-  --pgn-elevation-box-shadow-right-2-2-blur: 0.5rem; /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-2-offset-y: 0rem; /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-2-offset-x: 0.125rem; /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-1-blur: 0.25rem; /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-1-offset-y: 0rem; /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-1-offset-x: 0.125rem; /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-2-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 2. */
-  --pgn-elevation-box-shadow-right-1-2-blur: 0.25rem; /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-2-offset-y: 0rem; /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-2-offset-x: 0.0625rem; /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-1-blur: 0.125rem; /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-1-offset-y: 0rem; /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-1-offset-x: 0.0625rem; /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-right-1-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-5-2-blur: 3rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-2-offset-y: -0.5rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-2-offset-x: 0rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-1-blur: 2.5rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-1-offset-y: -1.25rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-1-offset-x: 0rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-5-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-up-4-2-blur: 1.25rem; /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-2-offset-y: -0.5rem; /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-2-offset-x: 0rem; /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-1-blur: 1.25rem; /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-1-offset-y: -0.625rem; /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-1-offset-x: 0rem; /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-4-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 4. */
-  --pgn-elevation-box-shadow-up-3-2-blur: 0.625rem; /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-2-offset-y: -0.25rem; /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-2-offset-x: 0rem; /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-1-blur: 1rem; /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-1-offset-y: -0.5rem; /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-1-offset-x: 0rem; /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-3-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 3. */
-  --pgn-elevation-box-shadow-up-2-2-blur: 0.5rem; /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-2-offset-y: -0.125rem; /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-2-offset-x: 0rem; /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-1-blur: 0.25rem; /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-1-offset-y: -0.125rem; /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-1-offset-x: 0rem; /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-2-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 2. */
-  --pgn-elevation-box-shadow-up-1-2-blur: 0.25rem; /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-2-offset-y: -0.0625rem; /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-2-offset-x: 0rem; /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-1-blur: 0.125rem; /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-1-offset-y: -0.0625rem; /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-1-offset-x: 0rem; /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-up-1-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-5-2-blur: 3rem; /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-2-offset-y: 0rem; /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-2-offset-x: -0.5rem; /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-1-blur: 2.5rem; /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-1-offset-y: 0rem; /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-1-offset-x: -1.25rem; /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-5-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 5. */
-  --pgn-elevation-box-shadow-left-4-2-blur: 1.25rem; /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-2-offset-y: 0rem; /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-2-offset-x: -0.5rem; /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-1-blur: 1.25rem; /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-1-offset-y: 0rem; /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-1-offset-x: -0.625rem; /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-4-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 4. */
-  --pgn-elevation-box-shadow-left-3-2-blur: 0.625rem; /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-2-offset-y: 0rem; /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-2-offset-x: -0.25rem; /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-1-blur: 1rem; /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-1-offset-y: 0rem; /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-1-offset-x: -0.5rem; /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-3-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 3. */
-  --pgn-elevation-box-shadow-left-2-2-blur: 0.5rem; /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-2-offset-y: 0rem; /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-2-offset-x: -0.125rem; /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-1-blur: 0.25rem; /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-1-offset-y: 0rem; /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-1-offset-x: -0.125rem; /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-2-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 2. */
-  --pgn-elevation-box-shadow-left-1-2-blur: 0.25rem; /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-2-offset-y: 0rem; /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-2-offset-x: -0.0625rem; /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-1-blur: 0.125rem; /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-1-offset-y: 0rem; /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-1-offset-x: -0.0625rem; /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-left-1-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-5-2-blur: 2.5rem; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-2-offset-y: 0.5rem; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-2-offset-x: 0rem; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-1-blur: 2.5rem; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-1-offset-y: 1.25px; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-1-offset-x: 0rem; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-4-2-blur: 1.25rem; /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-2-offset-y: 0.5rem; /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-2-offset-x: 0rem; /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-1-blur: 1.25rem; /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-1-offset-y: 0.625rem; /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-1-offset-x: 0rem; /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-4-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 4. */
-  --pgn-elevation-box-shadow-down-3-2-blur: 0.625rem; /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-2-offset-y: 0.25rem; /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-2-offset-x: 0rem; /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-1-blur: 1rem; /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-1-offset-y: 0.5rem; /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-1-offset-x: 0rem; /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-3-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 3. */
-  --pgn-elevation-box-shadow-down-2-2-blur: 0.5rem; /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-2-offset-y: 0.125rem; /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-2-offset-x: 0rem; /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-1-blur: 0.25rem; /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-1-offset-y: 0.125rem; /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-1-offset-x: 0rem; /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-2-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 2. */
-  --pgn-elevation-box-shadow-down-1-2-blur: 0.25rem; /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-2-offset-y: 0.0625rem; /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-2-offset-x: 0rem; /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-1-blur: 0.125rem; /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-1-offset-y: 0.0625rem; /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-1-offset-x: 0rem; /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-down-1-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 1. */
-  --pgn-elevation-box-shadow-lg-blur: 0.5rem; /* Large box shadow. */
-  --pgn-elevation-box-shadow-lg-offset-y: 0.25rem; /* Large box shadow. */
-  --pgn-elevation-box-shadow-lg-offset-x: 0rem; /* Large box shadow. */
-  --pgn-elevation-box-shadow-lg-color: rgba(0, 0, 0, 0.3); /* Large box shadow. */
-  --pgn-elevation-box-shadow-sm-blur: 0.125rem; /* Small box shadow. */
-  --pgn-elevation-box-shadow-sm-offset-y: 0.0625rem; /* Small box shadow. */
-  --pgn-elevation-box-shadow-sm-offset-x: 0rem; /* Small box shadow. */
-  --pgn-elevation-box-shadow-sm-color: rgba(0, 0, 0, 0.2); /* Small box shadow. */
-  --pgn-elevation-box-shadow-base-blur: 0.25rem; /* Default box shadow. */
-  --pgn-elevation-box-shadow-base-offset-y: 0.125rem; /* Default box shadow. */
-  --pgn-elevation-box-shadow-base-offset-x: 0rem; /* Default box shadow. */
-  --pgn-elevation-box-shadow-base-color: rgba(0, 0, 0, 0.3); /* Default box shadow. */
-  --pgn-elevation-box-shadow-level-5-2-blur: 2.5rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-2-offset-y: 0.5rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-2-offset-x: 0rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-1-blur: 2.5rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-1-offset-y: 1.25px; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-1-offset-x: 0rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-4-2-blur: 1.25rem; /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-2-offset-y: 0.5rem; /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-2-offset-x: 0rem; /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-1-blur: 1.25rem; /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-1-offset-y: 0.625rem; /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-1-offset-x: 0rem; /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-4-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 4. */
-  --pgn-elevation-box-shadow-level-3-2-blur: 1rem; /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-2-offset-y: 0rem; /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-2-offset-x: 0rem; /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-1-blur: 0.625rem; /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-1-offset-y: 0rem; /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-1-offset-x: 0rem; /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-3-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 3. */
-  --pgn-elevation-box-shadow-level-2-2-blur: 0.5rem; /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-2-offset-y: 0.125rem; /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-2-offset-x: 0rem; /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-1-blur: 0.25rem; /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-1-offset-y: 0.125rem; /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-1-offset-x: 0rem; /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-2-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 2. */
-  --pgn-elevation-box-shadow-level-1-2-blur: 0.25rem; /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-2-offset-y: 0.0625rem; /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-2-offset-x: 0rem; /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-1-blur: 0.125rem; /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-1-offset-y: 0.0625rem; /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-1-offset-x: 0rem; /* Basic box shadow of level 1. */
-  --pgn-elevation-box-shadow-level-1-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 1. */
-  --pgn-elevation-input-btn-focus-box-shadow-blur: 0rem;
-  --pgn-elevation-input-btn-focus-box-shadow-offset-y: 0rem;
-  --pgn-elevation-input-btn-focus-box-shadow-offset-x: 0rem;
-  --pgn-elevation-input-btn-focus-box-shadow-spread: var(--pgn-size-input-btn-focus-width);
-  --pgn-elevation-input-btn-focus-box-shadow-color: var(--pgn-color-input-btn-focus);
-  --pgn-elevation-toast-box-shadow-2-blur: 3rem;
-  --pgn-elevation-toast-box-shadow-2-offset-y: 0.5rem;
-  --pgn-elevation-toast-box-shadow-2-offset-x: 0rem;
-  --pgn-elevation-toast-box-shadow-2-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-toast-box-shadow-1-blur: 2.5rem;
-  --pgn-elevation-toast-box-shadow-1-offset-y: 1.25rem;
-  --pgn-elevation-toast-box-shadow-1-offset-x: 0rem;
-  --pgn-elevation-toast-box-shadow-1-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-sticky-shadow-bottom-2-blur: 0.625rem;
-  --pgn-elevation-sticky-shadow-bottom-2-offset-y: 0.25rem;
-  --pgn-elevation-sticky-shadow-bottom-2-offset-x: 0rem;
-  --pgn-elevation-sticky-shadow-bottom-2-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-sticky-shadow-bottom-1-blur: 1rem;
-  --pgn-elevation-sticky-shadow-bottom-1-offset-y: 0.5rem;
-  --pgn-elevation-sticky-shadow-bottom-1-offset-x: 0rem;
-  --pgn-elevation-sticky-shadow-bottom-1-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-sticky-shadow-top-2-blur: 0.625rem;
-  --pgn-elevation-sticky-shadow-top-2-offset-y: -0.25rem;
-  --pgn-elevation-sticky-shadow-top-2-offset-x: 0rem;
-  --pgn-elevation-sticky-shadow-top-2-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-sticky-shadow-top-1-blur: 1rem;
-  --pgn-elevation-sticky-shadow-top-1-offset-y: -0.5rem;
-  --pgn-elevation-sticky-shadow-top-1-offset-x: 0rem;
-  --pgn-elevation-sticky-shadow-top-1-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-scrollable-body-box-shadow: #0000008C;
-  --pgn-elevation-progress-bar-box-shadow: none;
-  --pgn-elevation-pagination-focus-box-shadow-blur: 0rem;
-  --pgn-elevation-pagination-focus-box-shadow-offset-y: 0rem;
-  --pgn-elevation-pagination-focus-box-shadow-offset-x: 0rem;
-  --pgn-elevation-pagination-focus-box-shadow-spread: var(--pgn-size-input-btn-focus-width);
-  --pgn-elevation-pagination-focus-box-shadow-color: var(--pgn-color-input-btn-focus);
-  --pgn-elevation-menu-box-shadow-blur: 0.25rem;
-  --pgn-elevation-menu-box-shadow-offset-y: 0.125rem;
-  --pgn-elevation-menu-box-shadow-offset-x: 0rem;
-  --pgn-elevation-menu-box-shadow-color: rgba(0, 0, 0, 0.3);
-  --pgn-elevation-image-thumbnail-box-shadow: none;
-  --pgn-elevation-icon-button-box-shadow-black-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-black-active: none;
-  --pgn-elevation-icon-button-box-shadow-black-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-black-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-black-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-black-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-black-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-black-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-black-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-black-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-black-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-black-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-black-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-black-base-color: var(--pgn-color-icon-button-text-black-base);
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-dark-active: none;
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-dark-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-dark-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-dark-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-dark-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-dark-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-dark-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-dark-base-color: var(--pgn-color-icon-button-text-dark-base);
-  --pgn-elevation-icon-button-box-shadow-light-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-light-active: none;
-  --pgn-elevation-icon-button-box-shadow-light-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-light-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-light-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-light-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-light-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-light-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-light-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-light-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-light-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-light-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-light-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-light-base-color: var(--pgn-color-icon-button-text-light-base);
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-danger-active: none;
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-danger-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-danger-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-danger-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-danger-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-danger-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-danger-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-danger-base-color: var(--pgn-color-icon-button-text-danger-base);
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-warning-active: none;
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-warning-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-warning-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-warning-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-warning-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-warning-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-warning-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-warning-base-color: var(--pgn-color-icon-button-text-warning-base);
-  --pgn-elevation-icon-button-box-shadow-success-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-success-active: none;
-  --pgn-elevation-icon-button-box-shadow-success-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-success-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-success-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-success-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-success-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-success-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-success-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-success-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-success-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-success-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-success-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-success-base-color: var(--pgn-color-icon-button-text-success-base);
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-brand-active: none;
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-brand-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-brand-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-brand-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-brand-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-brand-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-brand-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-brand-base-color: var(--pgn-color-icon-button-text-brand-base);
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-secondary-active: none;
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-secondary-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-secondary-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-secondary-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-secondary-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-secondary-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-secondary-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-secondary-base-color: var(--pgn-color-icon-button-text-secondary-base);
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-active: none;
-  --pgn-elevation-icon-button-box-shadow-primary-active: none;
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-primary-inverse-color: var(--pgn-color-icon-button-accent);
-  --pgn-elevation-icon-button-box-shadow-primary-base-inset: inset;
-  --pgn-elevation-icon-button-box-shadow-primary-base-blur: 0rem;
-  --pgn-elevation-icon-button-box-shadow-primary-base-offset-y: 0rem;
-  --pgn-elevation-icon-button-box-shadow-primary-base-offset-x: 0rem;
-  --pgn-elevation-icon-button-box-shadow-primary-base-spread: var(--pgn-size-btn-focus-width);
-  --pgn-elevation-icon-button-box-shadow-primary-base-color: var(--pgn-color-icon-button-text-primary-base);
-  --pgn-elevation-form-control-select-border-focus-blur: 0rem;
-  --pgn-elevation-form-control-select-border-focus-offset-y: 0rem;
-  --pgn-elevation-form-control-select-border-focus-offset-x: 0rem;
-  --pgn-elevation-form-control-select-border-focus-spread: var(--pgn-size-input-btn-focus-width);
-  --pgn-elevation-form-control-select-border-focus-color: var(--pgn-color-input-btn-focus);
-  --pgn-elevation-form-control-select-border-base: none;
-  --pgn-elevation-form-control-file-focus-blur: 0rem;
-  --pgn-elevation-form-control-file-focus-offset-y: 0rem;
-  --pgn-elevation-form-control-file-focus-offset-x: 0rem;
-  --pgn-elevation-form-control-file-focus-spread: 1px;
-  --pgn-elevation-form-control-file-focus-color: var(--pgn-color-primary-500);
-  --pgn-elevation-form-control-file-base: var(--pgn-elevation-form-input-base);
-  --pgn-elevation-form-control-range-thumb-focus-blur: 0.25rem;
-  --pgn-elevation-form-control-range-thumb-focus-offset-y: 0.1rem;
-  --pgn-elevation-form-control-range-thumb-focus-offset-x: 0rem;
-  --pgn-elevation-form-control-range-thumb-focus-spread: 0rem;
-  --pgn-elevation-form-control-range-thumb-focus-color: var(--pgn-color-body-bg);
-  --pgn-elevation-form-control-range-thumb-base: none;
-  --pgn-elevation-form-control-range-track: none;
-  --pgn-elevation-form-control-checkbox-indicator-indeterminate: none;
-  --pgn-elevation-form-control-indicator-active: none;
-  --pgn-elevation-form-control-indicator-checked-focus-blur: 0rem;
-  --pgn-elevation-form-control-indicator-checked-focus-offset-y: 0rem;
-  --pgn-elevation-form-control-indicator-checked-focus-offset-x: 0rem;
-  --pgn-elevation-form-control-indicator-checked-focus-spread: 4px;
-  --pgn-elevation-form-control-indicator-checked-focus-color: rgba(0, 0, 0, 0.1);
-  --pgn-elevation-form-control-indicator-checked-base: none;
-  --pgn-elevation-form-control-indicator-base: var(--pgn-elevation-form-input-base);
-  --pgn-elevation-form-input-focus-blur: 0rem;
-  --pgn-elevation-form-input-focus-offset-y: 0rem;
-  --pgn-elevation-form-input-focus-offset-x: 0rem;
-  --pgn-elevation-form-input-focus-spread: 1px;
-  --pgn-elevation-form-input-focus-color: var(--pgn-color-primary-500);
-  --pgn-elevation-form-input-base: none;
-  --pgn-elevation-dropzone-error-inset: inset;
-  --pgn-elevation-dropzone-error-blur: 0rem;
-  --pgn-elevation-dropzone-error-offset-y: 0rem;
-  --pgn-elevation-dropzone-error-offset-x: 0rem;
-  --pgn-elevation-dropzone-error-spread: 2px;
-  --pgn-elevation-dropzone-error-color: var(--pgn-color-danger-300);
-  --pgn-elevation-dropzone-active-inset: inset;
-  --pgn-elevation-dropzone-active-blur: 0rem;
-  --pgn-elevation-dropzone-active-offset-y: 0rem;
-  --pgn-elevation-dropzone-active-offset-x: 0rem;
-  --pgn-elevation-dropzone-active-spread: 2px;
-  --pgn-elevation-dropzone-active-color: var(--pgn-color-primary-500);
-  --pgn-elevation-dropzone-focus-inset: inset;
-  --pgn-elevation-dropzone-focus-blur: 0rem;
-  --pgn-elevation-dropzone-focus-offset-y: 0rem;
-  --pgn-elevation-dropzone-focus-offset-x: 0rem;
-  --pgn-elevation-dropzone-focus-spread: 2px;
-  --pgn-elevation-dropzone-focus-color: var(--pgn-color-info-300);
-  --pgn-elevation-dropzone-hover-inset: inset;
-  --pgn-elevation-dropzone-hover-blur: 0rem;
-  --pgn-elevation-dropzone-hover-offset-y: 0rem;
-  --pgn-elevation-dropzone-hover-offset-x: 0rem;
-  --pgn-elevation-dropzone-hover-spread: 2px;
-  --pgn-elevation-dropzone-hover-color: var(--pgn-color-info-300);
-  --pgn-elevation-data-table-box-shadow-blur: 0.125rem;
-  --pgn-elevation-data-table-box-shadow-offset-y: 0.0625rem;
-  --pgn-elevation-data-table-box-shadow-offset-x: 0rem;
-  --pgn-elevation-data-table-box-shadow-color: rgba(0, 0, 0, 0.2);
-  --pgn-elevation-code-kbd-box-shadow: none;
-  --pgn-elevation-close-button-text-shadow-blur: 0rem;
-  --pgn-elevation-close-button-text-shadow-offset-y: 1px;
-  --pgn-elevation-close-button-text-shadow-offset-x: 0rem;
-  --pgn-elevation-close-button-text-shadow-color: var(--pgn-color-white);
-  --pgn-elevation-btn-box-shadow-active: none;
-  --pgn-elevation-btn-box-shadow-base: none;
-  --pgn-elevation-annotation-box-shadow-2-blur: 8px;
-  --pgn-elevation-annotation-box-shadow-2-offset-y: 2px;
-  --pgn-elevation-annotation-box-shadow-2-offset-x: 0rem;
-  --pgn-elevation-annotation-box-shadow-2-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-annotation-box-shadow-1-blur: 4px;
-  --pgn-elevation-annotation-box-shadow-1-offset-y: 2px;
-  --pgn-elevation-annotation-box-shadow-1-offset-x: 0rem;
-  --pgn-elevation-annotation-box-shadow-1-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-tooltip-box-shadow-2-blur: 8px;
-  --pgn-elevation-tooltip-box-shadow-2-offset-y: 2px;
-  --pgn-elevation-tooltip-box-shadow-2-offset-x: 0rem;
-  --pgn-elevation-tooltip-box-shadow-2-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-tooltip-box-shadow-1-blur: 4px;
-  --pgn-elevation-tooltip-box-shadow-1-offset-y: 2px;
-  --pgn-elevation-tooltip-box-shadow-1-offset-x: 0rem;
-  --pgn-elevation-tooltip-box-shadow-1-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-popover-box-shadow: none;
-  --pgn-elevation-modal-content-box-shadow-sm-up-2-blur: 20px;
-  --pgn-elevation-modal-content-box-shadow-sm-up-2-offset-y: 8px;
-  --pgn-elevation-modal-content-box-shadow-sm-up-2-offset-x: 0rem;
-  --pgn-elevation-modal-content-box-shadow-sm-up-2-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-modal-content-box-shadow-sm-up-1-blur: 20px;
-  --pgn-elevation-modal-content-box-shadow-sm-up-1-offset-y: 10px;
-  --pgn-elevation-modal-content-box-shadow-sm-up-1-offset-x: 0rem;
-  --pgn-elevation-modal-content-box-shadow-sm-up-1-color: rgba(0, 0, 0, 0.15);
-  --pgn-elevation-dropdown-box-shadow: none;
-  --pgn-spacing-input-btn-padding-y: 0.5625rem;
-  --pgn-spacing-form-input-padding-y-base: var(--pgn-spacing-input-btn-padding-y);
-  --pgn-size-input-btn-focus-width: 1px;
   --pgn-size-btn-focus-width: 2px;
+  --pgn-size-input-btn-focus-width: 1px;
+  --pgn-spacing-input-btn-padding-y: 0.5625rem;
+  --pgn-elevation-dropdown-box-shadow: none;
+  --pgn-elevation-modal-content-box-shadow-sm-up-1-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-modal-content-box-shadow-sm-up-1-offset-x: 0;
+  --pgn-elevation-modal-content-box-shadow-sm-up-1-offset-y: 10px;
+  --pgn-elevation-modal-content-box-shadow-sm-up-1-blur: 20px;
+  --pgn-elevation-modal-content-box-shadow-sm-up-2-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-modal-content-box-shadow-sm-up-2-offset-x: 0;
+  --pgn-elevation-modal-content-box-shadow-sm-up-2-offset-y: 8px;
+  --pgn-elevation-modal-content-box-shadow-sm-up-2-blur: 20px;
+  --pgn-elevation-popover-box-shadow: none;
+  --pgn-elevation-tooltip-box-shadow-1-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-tooltip-box-shadow-1-offset-x: 0;
+  --pgn-elevation-tooltip-box-shadow-1-offset-y: 2px;
+  --pgn-elevation-tooltip-box-shadow-1-blur: 4px;
+  --pgn-elevation-tooltip-box-shadow-2-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-tooltip-box-shadow-2-offset-x: 0;
+  --pgn-elevation-tooltip-box-shadow-2-offset-y: 2px;
+  --pgn-elevation-tooltip-box-shadow-2-blur: 8px;
+  --pgn-elevation-annotation-box-shadow-1-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-annotation-box-shadow-1-offset-x: 0;
+  --pgn-elevation-annotation-box-shadow-1-offset-y: 2px;
+  --pgn-elevation-annotation-box-shadow-1-blur: 4px;
+  --pgn-elevation-annotation-box-shadow-2-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-annotation-box-shadow-2-offset-x: 0;
+  --pgn-elevation-annotation-box-shadow-2-offset-y: 2px;
+  --pgn-elevation-annotation-box-shadow-2-blur: 8px;
+  --pgn-elevation-btn-box-shadow-base: none;
+  --pgn-elevation-btn-box-shadow-active: none;
+  --pgn-elevation-close-button-text-shadow-offset-x: 0;
+  --pgn-elevation-close-button-text-shadow-offset-y: 1px;
+  --pgn-elevation-close-button-text-shadow-blur: 0;
+  --pgn-elevation-code-kbd-box-shadow: none;
+  --pgn-elevation-data-table-box-shadow-color: rgba(0, 0, 0, 0.2);
+  --pgn-elevation-data-table-box-shadow-offset-x: 0;
+  --pgn-elevation-data-table-box-shadow-offset-y: 0.0625rem;
+  --pgn-elevation-data-table-box-shadow-blur: 0.125rem;
+  --pgn-elevation-dropzone-hover-spread: 2px;
+  --pgn-elevation-dropzone-hover-offset-x: 0;
+  --pgn-elevation-dropzone-hover-offset-y: 0;
+  --pgn-elevation-dropzone-hover-blur: 0;
+  --pgn-elevation-dropzone-hover-inset: inset;
+  --pgn-elevation-dropzone-focus-spread: 2px;
+  --pgn-elevation-dropzone-focus-offset-x: 0;
+  --pgn-elevation-dropzone-focus-offset-y: 0;
+  --pgn-elevation-dropzone-focus-blur: 0;
+  --pgn-elevation-dropzone-focus-inset: inset;
+  --pgn-elevation-dropzone-active-spread: 2px;
+  --pgn-elevation-dropzone-active-offset-x: 0;
+  --pgn-elevation-dropzone-active-offset-y: 0;
+  --pgn-elevation-dropzone-active-blur: 0;
+  --pgn-elevation-dropzone-active-inset: inset;
+  --pgn-elevation-dropzone-error-spread: 2px;
+  --pgn-elevation-dropzone-error-offset-x: 0;
+  --pgn-elevation-dropzone-error-offset-y: 0;
+  --pgn-elevation-dropzone-error-blur: 0;
+  --pgn-elevation-dropzone-error-inset: inset;
+  --pgn-elevation-form-input-base: none;
+  --pgn-elevation-form-input-focus-spread: 1px;
+  --pgn-elevation-form-input-focus-offset-x: 0;
+  --pgn-elevation-form-input-focus-offset-y: 0;
+  --pgn-elevation-form-input-focus-blur: 0;
+  --pgn-elevation-form-control-indicator-checked-base: none;
+  --pgn-elevation-form-control-indicator-checked-focus-color: rgba(0, 0, 0, 0.1);
+  --pgn-elevation-form-control-indicator-checked-focus-spread: 4px;
+  --pgn-elevation-form-control-indicator-checked-focus-offset-x: 0;
+  --pgn-elevation-form-control-indicator-checked-focus-offset-y: 0;
+  --pgn-elevation-form-control-indicator-checked-focus-blur: 0;
+  --pgn-elevation-form-control-indicator-active: none;
+  --pgn-elevation-form-control-checkbox-indicator-indeterminate: none;
+  --pgn-elevation-form-control-range-track: none;
+  --pgn-elevation-form-control-range-thumb-base: none;
+  --pgn-elevation-form-control-range-thumb-focus-spread: 0;
+  --pgn-elevation-form-control-range-thumb-focus-offset-x: 0;
+  --pgn-elevation-form-control-range-thumb-focus-offset-y: 0.1rem;
+  --pgn-elevation-form-control-range-thumb-focus-blur: 0.25rem;
+  --pgn-elevation-form-control-file-focus-spread: 1px;
+  --pgn-elevation-form-control-file-focus-offset-x: 0;
+  --pgn-elevation-form-control-file-focus-offset-y: 0;
+  --pgn-elevation-form-control-file-focus-blur: 0;
+  --pgn-elevation-form-control-select-border-base: none;
+  --pgn-elevation-form-control-select-border-focus-offset-x: 0;
+  --pgn-elevation-form-control-select-border-focus-offset-y: 0;
+  --pgn-elevation-form-control-select-border-focus-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-primary-active: none;
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-secondary-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-secondary-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-secondary-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-secondary-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-secondary-active: none;
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-brand-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-brand-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-brand-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-brand-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-brand-active: none;
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-success-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-success-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-success-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-success-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-success-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-success-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-success-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-success-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-success-active: none;
+  --pgn-elevation-icon-button-box-shadow-success-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-warning-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-warning-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-warning-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-warning-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-warning-active: none;
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-danger-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-danger-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-danger-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-danger-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-danger-active: none;
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-light-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-light-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-light-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-light-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-light-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-light-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-light-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-light-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-light-active: none;
+  --pgn-elevation-icon-button-box-shadow-light-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-dark-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-dark-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-dark-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-dark-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-dark-active: none;
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-active: none;
+  --pgn-elevation-icon-button-box-shadow-black-base-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-black-base-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-black-base-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-black-base-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-black-inverse-offset-x: 0;
+  --pgn-elevation-icon-button-box-shadow-black-inverse-offset-y: 0;
+  --pgn-elevation-icon-button-box-shadow-black-inverse-blur: 0;
+  --pgn-elevation-icon-button-box-shadow-black-inverse-inset: inset;
+  --pgn-elevation-icon-button-box-shadow-black-active: none;
+  --pgn-elevation-icon-button-box-shadow-black-inverse-active: none;
+  --pgn-elevation-image-thumbnail-box-shadow: none;
+  --pgn-elevation-menu-box-shadow-color: rgba(0, 0, 0, 0.3);
+  --pgn-elevation-menu-box-shadow-offset-x: 0;
+  --pgn-elevation-menu-box-shadow-offset-y: 0.125rem;
+  --pgn-elevation-menu-box-shadow-blur: 0.25rem;
+  --pgn-elevation-pagination-focus-box-shadow-offset-x: 0;
+  --pgn-elevation-pagination-focus-box-shadow-offset-y: 0;
+  --pgn-elevation-pagination-focus-box-shadow-blur: 0;
+  --pgn-elevation-progress-bar-box-shadow: none;
+  --pgn-elevation-sticky-shadow-top-1-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-sticky-shadow-top-1-offset-x: 0;
+  --pgn-elevation-sticky-shadow-top-1-offset-y: -0.5rem;
+  --pgn-elevation-sticky-shadow-top-1-blur: 1rem;
+  --pgn-elevation-sticky-shadow-top-2-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-sticky-shadow-top-2-offset-x: 0;
+  --pgn-elevation-sticky-shadow-top-2-offset-y: -0.25rem;
+  --pgn-elevation-sticky-shadow-top-2-blur: 0.625rem;
+  --pgn-elevation-sticky-shadow-bottom-1-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-sticky-shadow-bottom-1-offset-x: 0;
+  --pgn-elevation-sticky-shadow-bottom-1-offset-y: 0.5rem;
+  --pgn-elevation-sticky-shadow-bottom-1-blur: 1rem;
+  --pgn-elevation-sticky-shadow-bottom-2-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-sticky-shadow-bottom-2-offset-x: 0;
+  --pgn-elevation-sticky-shadow-bottom-2-offset-y: 0.25rem;
+  --pgn-elevation-sticky-shadow-bottom-2-blur: 0.625rem;
+  --pgn-elevation-toast-box-shadow-1-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-toast-box-shadow-1-offset-x: 0;
+  --pgn-elevation-toast-box-shadow-1-offset-y: 1.25rem;
+  --pgn-elevation-toast-box-shadow-1-blur: 2.5rem;
+  --pgn-elevation-toast-box-shadow-2-color: rgba(0, 0, 0, 0.15);
+  --pgn-elevation-toast-box-shadow-2-offset-x: 0;
+  --pgn-elevation-toast-box-shadow-2-offset-y: 0.5rem;
+  --pgn-elevation-toast-box-shadow-2-blur: 3rem;
+  --pgn-elevation-input-btn-focus-box-shadow-offset-x: 0;
+  --pgn-elevation-input-btn-focus-box-shadow-offset-y: 0;
+  --pgn-elevation-input-btn-focus-box-shadow-blur: 0;
+  --pgn-elevation-box-shadow-level-1-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-1-offset-x: 0; /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-1-offset-y: 0.0625rem; /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-1-blur: 0.125rem; /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-2-offset-x: 0; /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-2-offset-y: 0.0625rem; /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-1-2-blur: 0.25rem; /* Basic box shadow of level 1. */
+  --pgn-elevation-box-shadow-level-2-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-1-offset-x: 0; /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-1-offset-y: 0.125rem; /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-1-blur: 0.25rem; /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-2-offset-x: 0; /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-2-offset-y: 0.125rem; /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-2-2-blur: 0.5rem; /* Basic box shadow of level 2. */
+  --pgn-elevation-box-shadow-level-3-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-1-offset-x: 0; /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-1-offset-y: 0; /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-1-blur: 0.625rem; /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-2-offset-x: 0; /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-2-offset-y: 0; /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-3-2-blur: 1rem; /* Basic box shadow of level 3. */
+  --pgn-elevation-box-shadow-level-4-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-1-offset-x: 0; /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-1-offset-y: 0.625rem; /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-1-blur: 1.25rem; /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-2-offset-x: 0; /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-2-offset-y: 0.5rem; /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-4-2-blur: 1.25rem; /* Basic box shadow of level 4. */
+  --pgn-elevation-box-shadow-level-5-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-1-offset-x: 0; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-1-offset-y: 1.25px; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-1-blur: 2.5rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-2-offset-x: 0; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-2-offset-y: 0.5rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-2-blur: 2.5rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-base-color: rgba(0, 0, 0, 0.3); /* Default box shadow. */
+  --pgn-elevation-box-shadow-base-offset-x: 0; /* Default box shadow. */
+  --pgn-elevation-box-shadow-base-offset-y: 0.125rem; /* Default box shadow. */
+  --pgn-elevation-box-shadow-base-blur: 0.25rem; /* Default box shadow. */
+  --pgn-elevation-box-shadow-sm-color: rgba(0, 0, 0, 0.2); /* Small box shadow. */
+  --pgn-elevation-box-shadow-sm-offset-x: 0; /* Small box shadow. */
+  --pgn-elevation-box-shadow-sm-offset-y: 0.0625rem; /* Small box shadow. */
+  --pgn-elevation-box-shadow-sm-blur: 0.125rem; /* Small box shadow. */
+  --pgn-elevation-box-shadow-lg-color: rgba(0, 0, 0, 0.3); /* Large box shadow. */
+  --pgn-elevation-box-shadow-lg-offset-x: 0; /* Large box shadow. */
+  --pgn-elevation-box-shadow-lg-offset-y: 0.25rem; /* Large box shadow. */
+  --pgn-elevation-box-shadow-lg-blur: 0.5rem; /* Large box shadow. */
+  --pgn-elevation-box-shadow-down-1-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-1-offset-x: 0; /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-1-offset-y: 0.0625rem; /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-1-blur: 0.125rem; /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-2-offset-x: 0; /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-2-offset-y: 0.0625rem; /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-1-2-blur: 0.25rem; /* Bottom box shadow of level 1. */
+  --pgn-elevation-box-shadow-down-2-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-1-offset-x: 0; /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-1-offset-y: 0.125rem; /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-1-blur: 0.25rem; /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-2-offset-x: 0; /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-2-offset-y: 0.125rem; /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-2-2-blur: 0.5rem; /* Bottom box shadow of level 2. */
+  --pgn-elevation-box-shadow-down-3-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-1-offset-x: 0; /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-1-offset-y: 0.5rem; /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-1-blur: 1rem; /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-2-offset-x: 0; /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-2-offset-y: 0.25rem; /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-3-2-blur: 0.625rem; /* Bottom box shadow of level 3. */
+  --pgn-elevation-box-shadow-down-4-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-1-offset-x: 0; /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-1-offset-y: 0.625rem; /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-1-blur: 1.25rem; /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-2-offset-x: 0; /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-2-offset-y: 0.5rem; /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-4-2-blur: 1.25rem; /* Bottom box shadow of level 4. */
+  --pgn-elevation-box-shadow-down-5-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-1-offset-x: 0; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-1-offset-y: 1.25px; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-1-blur: 2.5rem; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-2-offset-x: 0; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-2-offset-y: 0.5rem; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-2-blur: 2.5rem; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-1-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-1-offset-x: -0.0625rem; /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-1-offset-y: 0; /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-1-blur: 0.125rem; /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-2-offset-x: -0.0625rem; /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-2-offset-y: 0; /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-1-2-blur: 0.25rem; /* Left box shadow of level 1. */
+  --pgn-elevation-box-shadow-left-2-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-1-offset-x: -0.125rem; /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-1-offset-y: 0; /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-1-blur: 0.25rem; /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-2-offset-x: -0.125rem; /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-2-offset-y: 0; /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-2-2-blur: 0.5rem; /* Left box shadow of level 2. */
+  --pgn-elevation-box-shadow-left-3-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-1-offset-x: -0.5rem; /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-1-offset-y: 0; /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-1-blur: 1rem; /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-2-offset-x: -0.25rem; /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-2-offset-y: 0; /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-3-2-blur: 0.625rem; /* Left box shadow of level 3. */
+  --pgn-elevation-box-shadow-left-4-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-1-offset-x: -0.625rem; /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-1-offset-y: 0; /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-1-blur: 1.25rem; /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-2-offset-x: -0.5rem; /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-2-offset-y: 0; /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-4-2-blur: 1.25rem; /* Left box shadow of level 4. */
+  --pgn-elevation-box-shadow-left-5-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-1-offset-x: -1.25rem; /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-1-offset-y: 0; /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-1-blur: 2.5rem; /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-2-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-2-offset-x: -0.5rem; /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-2-offset-y: 0; /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-left-5-2-blur: 3rem; /* Left box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-1-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-1-offset-x: 0; /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-1-offset-y: -0.0625rem; /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-1-blur: 0.125rem; /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-2-offset-x: 0; /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-2-offset-y: -0.0625rem; /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-1-2-blur: 0.25rem; /* Top box shadow of level 1. */
+  --pgn-elevation-box-shadow-up-2-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-1-offset-x: 0; /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-1-offset-y: -0.125rem; /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-1-blur: 0.25rem; /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-2-offset-x: 0; /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-2-offset-y: -0.125rem; /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-2-2-blur: 0.5rem; /* Top box shadow of level 2. */
+  --pgn-elevation-box-shadow-up-3-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-1-offset-x: 0; /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-1-offset-y: -0.5rem; /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-1-blur: 1rem; /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-2-offset-x: 0; /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-2-offset-y: -0.25rem; /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-3-2-blur: 0.625rem; /* Top box shadow of level 3. */
+  --pgn-elevation-box-shadow-up-4-1-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-1-offset-x: 0; /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-1-offset-y: -0.625rem; /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-1-blur: 1.25rem; /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-2-color: rgba(0, 0, 0, 0.15); /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-2-offset-x: 0; /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-2-offset-y: -0.5rem; /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-4-2-blur: 1.25rem; /* Top box shadow of level 4. */
+  --pgn-elevation-box-shadow-up-5-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-1-offset-x: 0; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-1-offset-y: -1.25rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-1-blur: 2.5rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-2-offset-x: 0; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-2-offset-y: -0.5rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-up-5-2-blur: 3rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-1-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-1-offset-x: 0.0625rem; /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-1-offset-y: 0; /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-1-blur: 0.125rem; /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-2-offset-x: 0.0625rem; /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-2-offset-y: 0; /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-1-2-blur: 0.25rem; /* Right box shadow of level 1. */
+  --pgn-elevation-box-shadow-right-2-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-1-offset-x: 0.125rem; /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-1-offset-y: 0; /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-1-blur: 0.25rem; /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-2-offset-x: 0.125rem; /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-2-offset-y: 0; /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-2-2-blur: 0.5rem; /* Right box shadow of level 2. */
+  --pgn-elevation-box-shadow-right-3-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-1-offset-x: 0.5rem; /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-1-offset-y: 0; /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-1-blur: 1rem; /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-2-offset-x: 0.25rem; /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-2-offset-y: 0; /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-3-2-blur: 0.625rem; /* Right box shadow of level 3. */
+  --pgn-elevation-box-shadow-right-4-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-1-offset-x: 0.625rem; /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-1-offset-y: 0; /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-1-blur: 1.25rem; /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-2-offset-x: 0.5rem; /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-2-offset-y: 0; /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-4-2-blur: 1.25rem; /* Right box shadow of level 4. */
+  --pgn-elevation-box-shadow-right-5-1-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-1-offset-x: 1.25rem; /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-1-offset-y: 0; /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-1-blur: 2.5rem; /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-2-color: rgba(0, 0, 0, 0.15); /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-2-offset-x: 0.5rem; /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-2-offset-y: 0; /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-right-5-2-blur: 3rem; /* Right box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-1-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-1-offset-x: 0; /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-1-offset-y: 0; /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-1-blur: 0.125rem; /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-2-offset-x: 0; /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-2-offset-y: 0; /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-1-2-blur: 0.25rem; /* Centered box shadow of level 1. */
+  --pgn-elevation-box-shadow-centered-2-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-1-offset-x: 0; /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-1-offset-y: 0; /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-1-blur: 0.25rem; /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-2-offset-x: 0; /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-2-offset-y: 0; /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-2-2-blur: 0.5rem; /* Centered box shadow of level 2. */
+  --pgn-elevation-box-shadow-centered-3-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-1-offset-x: 0; /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-1-offset-y: 0; /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-1-blur: 0.625rem; /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-2-offset-x: 0; /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-2-offset-y: 0; /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-3-2-blur: 1rem; /* Centered box shadow of level 3. */
+  --pgn-elevation-box-shadow-centered-4-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-1-offset-x: 0; /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-1-offset-y: 0; /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-1-blur: 1.25rem; /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-2-offset-x: 0; /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-2-offset-y: 0; /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-4-2-blur: 1.25rem; /* Centered box shadow of level 4. */
+  --pgn-elevation-box-shadow-centered-5-1-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-1-offset-x: 0; /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-1-offset-y: 0; /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-1-blur: 2.5rem; /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-2-color: rgba(0, 0, 0, 0.15); /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-2-offset-x: 0; /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-2-offset-y: 0; /* Centered box shadow of level 5. */
+  --pgn-elevation-box-shadow-centered-5-2-blur: 3rem; /* Centered box shadow of level 5. */
+  --pgn-other-form-feedback-tooltip-opacity: .9;
+  --pgn-other-btn-disabled-opacity: .65;
+  --pgn-other-carousel-control-opacity-base: .5;
+  --pgn-other-carousel-control-opacity-hover: .9;
+  --pgn-other-chip-opacity-disabled: .3;
+  --pgn-other-content-form-control-select-bg-repeat: no-repeat;
+  --pgn-other-content-form-control-select-bg-position-x: right;
+  --pgn-other-content-form-control-select-bg-position-y: center;
+  --pgn-other-modal-opacity: .5;
+  --pgn-other-search-field-disabled-opacity: .3;
+  --pgn-other-tooltip-opacity: 1;
+  --pgn-other-link-emphasized-hover-darken-percentage: 15%;
+  --pgn-color-btn-bg-outline-brand: inherit;
+  --pgn-color-btn-bg-inverse-outline-brand: #00000000;
+  --pgn-color-btn-bg-outline-danger: inherit;
+  --pgn-color-btn-bg-inverse-outline-danger: #00000000;
+  --pgn-color-btn-bg-outline-dark: inherit;
+  --pgn-color-btn-bg-inverse-outline-dark: #00000000;
+  --pgn-color-btn-bg-outline-info: inherit;
+  --pgn-color-btn-bg-inverse-outline-info: inherit;
+  --pgn-color-btn-bg-outline-light: inherit;
+  --pgn-color-btn-bg-inverse-outline-light: inherit;
+  --pgn-color-btn-bg-outline-primary: #00000000;
+  --pgn-color-btn-bg-inverse-outline-primary: #00000000;
+  --pgn-color-btn-bg-outline-secondary: inherit;
+  --pgn-color-btn-bg-inverse-outline-secondary: inherit;
+  --pgn-color-btn-bg-outline-success: inherit;
+  --pgn-color-btn-bg-inverse-outline-success: inherit;
+  --pgn-color-btn-bg-tertiary: #00000000;
+  --pgn-color-btn-bg-inverse-tertiary: #00000000;
+  --pgn-color-btn-bg-outline-warning: inherit;
+  --pgn-color-btn-bg-inverse-outline-warning: inherit;
+  --pgn-color-btn-border-inverse-brand: #00000000;
+  --pgn-color-btn-border-inverse-danger: #00000000;
+  --pgn-color-btn-border-inverse-dark: #00000000;
+  --pgn-color-btn-border-inverse-info: #00000000;
+  --pgn-color-btn-border-inverse-light: #00000000;
+  --pgn-color-btn-border-inverse-primary: #00000000;
+  --pgn-color-btn-border-inverse-secondary: #00000000;
+  --pgn-color-btn-border-inverse-success: #00000000;
+  --pgn-color-btn-border-tertiary: #00000000;
+  --pgn-color-btn-border-inverse-tertiary: #00000000;
+  --pgn-color-btn-border-inverse-warning: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-brand: #00000000;
+  --pgn-color-btn-hover-border-inverse-brand: #00000000;
+  --pgn-color-btn-hover-border-inverse-danger: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-danger: #00000000;
+  --pgn-color-btn-hover-border-inverse-dark: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-dark: #00000000;
+  --pgn-color-btn-hover-border-inverse-info: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-info: #00000000;
+  --pgn-color-btn-hover-border-inverse-light: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-light: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-primary: #00000000;
+  --pgn-color-btn-hover-border-inverse-primary: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-secondary: #00000000;
+  --pgn-color-btn-hover-border-inverse-secondary: #00000000;
+  --pgn-color-btn-hover-border-inverse-success: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-success: #00000000;
+  --pgn-color-btn-hover-border-tertiary: #00000000;
+  --pgn-color-btn-hover-border-inverse-tertiary: #00000000;
+  --pgn-color-btn-hover-border-inverse-warning: #00000000;
+  --pgn-color-btn-hover-border-inverse-outline-warning: #00000000;
+  --pgn-color-btn-active-border-inverse-brand: #00000000;
+  --pgn-color-btn-active-border-inverse-outline-brand: #00000000;
+  --pgn-color-btn-active-border-inverse-danger: #00000000;
+  --pgn-color-btn-active-border-inverse-outline-danger: #00000000;
+  --pgn-color-btn-active-border-inverse-dark: #00000000;
+  --pgn-color-btn-active-border-inverse-outline-dark: #00000000;
+  --pgn-color-btn-active-border-inverse-info: #00000000;
+  --pgn-color-btn-active-border-inverse-outline-info: #00000000;
+  --pgn-color-btn-active-border-inverse-light: inherit;
+  --pgn-color-btn-active-border-inverse-outline-light: #00000000;
+  --pgn-color-btn-active-border-inverse-outline-primary: #00000000;
+  --pgn-color-btn-active-border-inverse-primary: #00000000;
+  --pgn-color-btn-active-border-inverse-outline-secondary: #00000000;
+  --pgn-color-btn-active-border-inverse-secondary: #00000000;
+  --pgn-color-btn-active-border-inverse-success: inherit;
+  --pgn-color-btn-active-border-inverse-outline-success: #00000000;
+  --pgn-color-btn-active-border-tertiary: #00000000;
+  --pgn-color-btn-active-border-inverse-tertiary: #00000000;
+  --pgn-color-btn-active-border-inverse-warning: inherit;
+  --pgn-color-btn-active-border-inverse-outline-warning: #00000000;
+  --pgn-color-btn-focus-text-outline-dark: inherit;
+  --pgn-color-btn-focus-text-inverse-secondary: inherit;
+  --pgn-color-btn-focus-border-inverse-tertiary: #00000000;
+  --pgn-color-btn-focus-bg-outline-brand: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-brand: inherit;
+  --pgn-color-btn-focus-bg-outline-danger: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-danger: inherit;
+  --pgn-color-btn-focus-bg-outline-dark: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-dark: inherit;
+  --pgn-color-btn-focus-bg-outline-info: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-info: inherit;
+  --pgn-color-btn-focus-bg-outline-light: #00000000;
+  --pgn-color-btn-focus-bg-inverse-outline-light: inherit;
+  --pgn-color-btn-focus-bg-outline-primary: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-primary: inherit;
+  --pgn-color-btn-focus-bg-outline-secondary: #00000000;
+  --pgn-color-btn-focus-bg-inverse-outline-secondary: inherit;
+  --pgn-color-btn-focus-bg-outline-success: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-success: inherit;
+  --pgn-color-btn-focus-bg-tertiary: inherit;
+  --pgn-color-btn-focus-bg-inverse-tertiary: inherit;
+  --pgn-color-btn-focus-bg-outline-warning: inherit;
+  --pgn-color-btn-focus-bg-inverse-outline-warning: inherit;
+  --pgn-color-btn-focus-outline-inverse-outline-warning: inherit;
+  --pgn-color-btn-disabled-text-outline-dark: inherit;
+  --pgn-color-btn-disabled-text-outline-secondary: inherit;
+  --pgn-color-btn-disabled-text-inverse-secondary: inherit;
+  --pgn-color-btn-disabled-bg-outline-brand: inherit;
+  --pgn-color-btn-disabled-bg-outline-danger: inherit;
+  --pgn-color-btn-disabled-bg-inverse-danger: #00000000;
+  --pgn-color-btn-disabled-bg-inverse-outline-danger: inherit;
+  --pgn-color-btn-disabled-bg-outline-dark: inherit;
+  --pgn-color-btn-disabled-bg-inverse-dark: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-dark: inherit;
+  --pgn-color-btn-disabled-bg-outline-info: inherit;
+  --pgn-color-btn-disabled-bg-inverse-info: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-info: inherit;
+  --pgn-color-btn-disabled-bg-outline-light: inherit;
+  --pgn-color-btn-disabled-bg-inverse-light: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-light: inherit;
+  --pgn-color-btn-disabled-bg-outline-primary: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-primary: inherit;
+  --pgn-color-btn-disabled-bg-outline-secondary: inherit;
+  --pgn-color-btn-disabled-bg-inverse-secondary: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-secondary: inherit;
+  --pgn-color-btn-disabled-bg-outline-success: inherit;
+  --pgn-color-btn-disabled-bg-inverse-success: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-success: inherit;
+  --pgn-color-btn-disabled-bg-tertiary: inherit;
+  --pgn-color-btn-disabled-bg-inverse-tertiary: inherit;
+  --pgn-color-btn-disabled-bg-outline-warning: inherit;
+  --pgn-color-btn-disabled-bg-inverse-warning: inherit;
+  --pgn-color-btn-disabled-bg-inverse-outline-warning: inherit;
+  --pgn-color-btn-disabled-border-inverse-danger: #00000000;
+  --pgn-color-btn-disabled-border-inverse-dark: #00000000;
+  --pgn-color-btn-disabled-border-inverse-info: #00000000;
+  --pgn-color-btn-disabled-border-inverse-light: #00000000;
+  --pgn-color-btn-disabled-border-inverse-primary: #00000000;
+  --pgn-color-btn-disabled-border-secondary: inherit;
+  --pgn-color-btn-disabled-border-inverse-success: #00000000;
+  --pgn-color-btn-disabled-border-inverse-outline-success: inherit;
+  --pgn-color-btn-disabled-border-inverse-warning: #00000000;
+  --pgn-color-card-base: inherit;
+  --pgn-color-code-base: #E83E8CFF;
+  --pgn-color-form-control-label-base: inherit;
+  --pgn-color-icon-button-bg-base: #00000000;
+  --pgn-color-menu-item-bg: #00000000;
+  --pgn-color-nav-link-border: #00000000;
+  --pgn-color-nav-tabs-base-bg-hover: #00000000;
+  --pgn-color-nav-tabs-base-link-active-bg: #00000000;
+  --pgn-color-nav-tabs-inverse-link-bg-active-hover: #00000000;
+  --pgn-color-overflow-scroll-opacity-mask-transparent: #00000066;
+  --pgn-color-popover-border: #00000033;
+  --pgn-color-product-tour-checkpoint-arrow-border-transparent: #00000000;
+  --pgn-color-progress-bg: #00000000;
+  --pgn-color-stepper-header-bg-base: #00000000;
+  --pgn-color-stepper-header-step-border: none;
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-hover: #00000000;
+  --pgn-color-toast-base: inherit;
+  --pgn-color-list-group-base: inherit;
+  --pgn-color-mark-bg: #FFF243FF;
+  --pgn-color-white: #FFFFFFFF; /* White color. */
+  --pgn-color-black: #000000FF; /* Black color. */
+  --pgn-color-blue: #23419FFF; /* Blue color. */
+  --pgn-color-red: #C32D3AFF; /* Red color. */
+  --pgn-color-green: #178253FF; /* Green color. */
+  --pgn-color-yellow: #FFD900FF; /* Yellow color. */
+  --pgn-color-teal: #006DAAFF; /* Teal color. */
+  --pgn-color-accent-a: #00BBF9FF; /* Accent-A color. */
+  --pgn-color-accent-b: #FFEE88FF; /* Accent-B color. */
+  --pgn-color-gray-100: #EBEBEBFF; /* Gray color of level 100. */
+  --pgn-color-gray-200: #CCCCCCFF; /* Gray color of level 200. */
+  --pgn-color-gray-300: #ADADADFF; /* Gray color of level 300. */
+  --pgn-color-gray-400: #8F8F8FFF; /* Gray color of level 400. */
+  --pgn-color-gray-600: #5C5C5CFF; /* Gray color of level 600. */
+  --pgn-color-gray-700: #454545FF; /* Gray color of level 700. */
+  --pgn-color-gray-800: #333333FF; /* Gray color of level 800. */
+  --pgn-color-gray-900: #212529FF; /* Gray color of level 900. */
+  --pgn-color-gray-base: #707070FF; /* Basic gray color. */
+  --pgn-color-primary-base: #0A3055FF; /* Basic primary color. */
+  --pgn-color-brand-base: #9D0054FF; /* Basic brand color. */
+  --pgn-color-light-base: #E1DDDBFF; /* Basic light color. */
+  --pgn-color-dark-base: #273F2FFF; /* Basic dark color. */
+  --pgn-border-color-nav-tabs-link-border-hover-top: transparent;
+  --pgn-border-color-nav-tabs-link-border-hover-right: transparent;
+  --pgn-border-color-nav-tabs-link-border-hover-left: transparent;
+  --pgn-spacing-form-input-padding-y-base: var(--pgn-spacing-input-btn-padding-y);
+  --pgn-elevation-close-button-text-shadow-color: var(--pgn-color-white);
+  --pgn-elevation-form-control-indicator-base: var(--pgn-elevation-form-input-base);
+  --pgn-elevation-form-control-file-base: var(--pgn-elevation-form-input-base);
+  --pgn-elevation-form-control-select-border-focus-spread: var(--pgn-size-input-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-primary-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-secondary-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-brand-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-success-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-success-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-warning-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-danger-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-light-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-light-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-dark-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-black-base-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-icon-button-box-shadow-black-inverse-spread: var(--pgn-size-btn-focus-width);
+  --pgn-elevation-pagination-focus-box-shadow-spread: var(--pgn-size-input-btn-focus-width);
+  --pgn-elevation-scrollable-body-box-shadow: #0000008C;
+  --pgn-elevation-input-btn-focus-box-shadow-spread: var(--pgn-size-input-btn-focus-width);
+  --pgn-color-bg-base: var(--pgn-color-white); /* Basic background color. */
+  --pgn-color-text-50-black: #00000080; /* Black text color with transparency of 50%. */
+  --pgn-color-text-50-white: #FFFFFF80; /* White text color with transparency of 50%. */
+  --pgn-color-active: var(--pgn-color-white); /* Color for active element. */
+  --pgn-color-border: var(--pgn-color-gray-200); /* Border color. */
+  --pgn-color-theme-bg-gray: var(--pgn-color-gray-100); /* Theme-specific gray background color. */
+  --pgn-color-theme-border-gray: var(--pgn-color-gray-200); /* Theme-specific gray border color. */
+  --pgn-color-theme-hover-gray: var(--pgn-color-gray-700); /* Theme-specific gray hover color. */
+  --pgn-color-theme-active-gray: var(--pgn-color-gray-900); /* Theme-specific gray active color. */
+  --pgn-color-alert-title: var(--pgn-color-black);
+  --pgn-color-alert-content: var(--pgn-color-gray-700);
+  --pgn-color-annotation-text-success: var(--pgn-color-white);
+  --pgn-color-annotation-text-warning: var(--pgn-color-black);
+  --pgn-color-annotation-text-error: var(--pgn-color-white);
+  --pgn-color-annotation-text-dark: var(--pgn-color-white);
+  --pgn-color-annotation-bg-warning: var(--pgn-color-accent-b);
+  --pgn-color-annotation-bg-light: var(--pgn-color-white);
+  --pgn-color-annotation-bg-dark: var(--pgn-color-dark-base);
+  --pgn-color-badge-text-primary: #FFFFFFFF;
+  --pgn-color-badge-text-light: #454545FF;
+  --pgn-color-badge-text-dark: #FFFFFFFF;
+  --pgn-color-badge-bg-primary: var(--pgn-color-primary-base);
+  --pgn-color-badge-bg-light: var(--pgn-color-light-base);
+  --pgn-color-badge-bg-dark: var(--pgn-color-dark-base);
+  --pgn-color-breadcrumb-inverse-base: var(--pgn-color-white);
+  --pgn-color-bubble-text-success: var(--pgn-color-white);
+  --pgn-color-bubble-text-warning: var(--pgn-color-white);
+  --pgn-color-bubble-text-error: var(--pgn-color-white);
+  --pgn-color-bubble-text-primary: var(--pgn-color-white);
+  --pgn-color-bubble-bg-primary: var(--pgn-color-primary-base);
+  --pgn-color-btn-text-outline-brand: var(--pgn-color-brand-base);
+  --pgn-color-btn-text-inverse-brand: var(--pgn-color-brand-base);
+  --pgn-color-btn-text-inverse-outline-brand: var(--pgn-color-white);
+  --pgn-color-btn-text-inverse-outline-danger: var(--pgn-color-white);
+  --pgn-color-btn-text-outline-dark: var(--pgn-color-dark-base);
+  --pgn-color-btn-text-inverse-dark: var(--pgn-color-dark-base);
+  --pgn-color-btn-text-inverse-outline-dark: var(--pgn-color-white);
+  --pgn-color-btn-text-inverse-outline-info: var(--pgn-color-white);
+  --pgn-color-btn-text-outline-light: var(--pgn-color-light-base);
+  --pgn-color-btn-text-inverse-light: var(--pgn-color-light-base);
+  --pgn-color-btn-text-inverse-outline-light: var(--pgn-color-white);
+  --pgn-color-btn-text-outline-primary: var(--pgn-color-primary-base);
+  --pgn-color-btn-text-inverse-primary: var(--pgn-color-primary-base);
+  --pgn-color-btn-text-inverse-outline-primary: var(--pgn-color-white);
+  --pgn-color-btn-text-inverse-outline-secondary: var(--pgn-color-white);
+  --pgn-color-btn-text-inverse-outline-success: var(--pgn-color-white);
+  --pgn-color-btn-text-tertiary: var(--pgn-color-gray-700);
+  --pgn-color-btn-text-inverse-tertiary: var(--pgn-color-white);
+  --pgn-color-btn-text-inverse-outline-warning: var(--pgn-color-white);
+  --pgn-color-btn-bg-brand: var(--pgn-color-brand-base);
+  --pgn-color-btn-bg-dark: var(--pgn-color-dark-base);
+  --pgn-color-btn-bg-light: var(--pgn-color-light-base);
+  --pgn-color-btn-bg-primary: var(--pgn-color-primary-base);
+  --pgn-color-btn-border-outline-brand: var(--pgn-color-brand-base);
+  --pgn-color-btn-border-inverse-outline-brand: var(--pgn-color-white);
+  --pgn-color-btn-border-inverse-outline-danger: var(--pgn-color-white);
+  --pgn-color-btn-border-outline-dark: var(--pgn-color-dark-base);
+  --pgn-color-btn-border-inverse-outline-dark: var(--pgn-color-white);
+  --pgn-color-btn-border-inverse-outline-info: var(--pgn-color-white);
+  --pgn-color-btn-border-outline-light: var(--pgn-color-light-base);
+  --pgn-color-btn-border-inverse-outline-light: var(--pgn-color-white);
+  --pgn-color-btn-border-outline-primary: var(--pgn-color-primary-base);
+  --pgn-color-btn-border-inverse-outline-primary: var(--pgn-color-white);
+  --pgn-color-btn-border-inverse-outline-secondary: var(--pgn-color-white);
+  --pgn-color-btn-border-inverse-outline-success: var(--pgn-color-white);
+  --pgn-color-btn-border-inverse-outline-warning: var(--pgn-color-white);
+  --pgn-color-btn-hover-text-tertiary: var(--pgn-color-gray-700);
+  --pgn-color-btn-hover-text-inverse-tertiary: var(--pgn-color-white);
+  --pgn-color-btn-hover-bg-inverse-tertiary: #FFFFFF1A;
+  --pgn-color-btn-active-text-tertiary: var(--pgn-color-gray-700);
+  --pgn-color-btn-active-text-inverse-tertiary: var(--pgn-color-white);
+  --pgn-color-btn-active-bg-inverse-brand: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-danger: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-dark: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-info: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-light: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-primary: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-secondary: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-success: var(--pgn-color-gray-100);
+  --pgn-color-btn-active-bg-inverse-warning: var(--pgn-color-gray-100);
+  --pgn-color-btn-focus-border-inverse-brand: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-danger: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-outline-danger: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-dark: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-outline-dark: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-info: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-light: var(--pgn-color-btn-border-inverse-light);
+  --pgn-color-btn-focus-border-inverse-primary: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-secondary: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-outline-secondary: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-success: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-tertiary: var(--pgn-color-btn-border-tertiary);
+  --pgn-color-btn-focus-border-inverse-warning: var(--pgn-color-btn-border-inverse-warning);
+  --pgn-color-btn-focus-outline-inverse-light: var(--pgn-color-white);
+  --pgn-color-btn-focus-outline-inverse-secondary: var(--pgn-color-white);
+  --pgn-color-btn-focus-outline-inverse-tertiary: var(--pgn-color-white);
+  --pgn-color-btn-focus-outline-inverse-warning: var(--pgn-color-white);
+  --pgn-color-btn-disabled-bg-inverse-brand: var(--pgn-color-white);
+  --pgn-color-btn-disabled-bg-inverse-outline-brand: var(--pgn-color-btn-bg-inverse-outline-brand);
+  --pgn-color-btn-disabled-bg-inverse-primary: var(--pgn-color-white);
+  --pgn-color-btn-disabled-border-inverse-secondary: var(--pgn-color-btn-border-inverse-secondary);
+  --pgn-color-btn-disabled-border-tertiary: var(--pgn-color-btn-border-tertiary);
+  --pgn-color-btn-disabled-border-inverse-tertiary: var(--pgn-color-btn-border-inverse-tertiary);
+  --pgn-color-card-border-base: #00000020;
+  --pgn-color-carousel-control-base: var(--pgn-color-white);
+  --pgn-color-carousel-indicator-active-bg: var(--pgn-color-white);
+  --pgn-color-carousel-caption: var(--pgn-color-white);
+  --pgn-color-chip-text-light: var(--pgn-color-black);
+  --pgn-color-chip-text-dark: var(--pgn-color-white);
+  --pgn-color-chip-bg-light: var(--pgn-color-white);
+  --pgn-color-chip-outline-dark: var(--pgn-color-white);
+  --pgn-color-close-button: var(--pgn-color-black);
+  --pgn-color-code-kbd-base: var(--pgn-color-white);
+  --pgn-color-code-kbd-bg: var(--pgn-color-gray-700);
+  --pgn-color-code-pre: var(--pgn-color-gray-900);
+  --pgn-color-data-table-bg-is-loading: #FFFFFFB3;
+  --pgn-color-dropdown-border: #00000026;
+  --pgn-color-dropdown-divider-bg: var(--pgn-color-gray-100);
+  --pgn-color-dropdown-link-base: var(--pgn-color-gray-900);
+  --pgn-color-dropdown-link-hover-base: #000000FF;
+  --pgn-color-form-input-base: var(--pgn-color-gray-700);
+  --pgn-color-form-input-bg-disabled: var(--pgn-color-gray-100);
+  --pgn-color-form-input-group-addon-bg: var(--pgn-color-gray-100);
+  --pgn-color-form-control-indicator-border: var(--pgn-color-gray-700);
+  --pgn-color-form-control-indicator-checked-bg-disabled: #0A305580;
+  --pgn-color-form-control-select-bg-disabled: var(--pgn-color-gray-100);
+  --pgn-color-form-control-select-bg-size: var(--pgn-color-gray-100);
+  --pgn-color-form-control-range-track-bg: var(--pgn-color-gray-300);
+  --pgn-color-icon-button-bg-primary-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-primary-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-primary-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-primary-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-secondary-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-secondary-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-secondary-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-secondary-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-brand-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-brand-hover: var(--pgn-color-brand-base);
+  --pgn-color-icon-button-bg-brand-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-brand-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-brand-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-brand-active-base: var(--pgn-color-brand-base);
+  --pgn-color-icon-button-bg-success-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-success-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-success-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-success-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-warning-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-warning-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-warning-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-warning-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-danger-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-danger-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-danger-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-danger-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-light-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-light-hover: var(--pgn-color-light-base);
+  --pgn-color-icon-button-bg-light-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-light-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-light-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-light-active-base: var(--pgn-color-light-base);
+  --pgn-color-icon-button-bg-dark-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-dark-hover: var(--pgn-color-dark-base);
+  --pgn-color-icon-button-bg-dark-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-dark-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-dark-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-dark-active-base: var(--pgn-color-dark-base);
+  --pgn-color-icon-button-bg-black-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-black-hover: var(--pgn-color-black);
+  --pgn-color-icon-button-bg-black-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-black-inverse-base: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-black-inverse-focus: var(--pgn-color-icon-button-bg-base);
+  --pgn-color-icon-button-bg-black-active-base: var(--pgn-color-black);
+  --pgn-color-icon-button-text-primary-base: var(--pgn-color-primary-base);
+  --pgn-color-icon-button-text-brand-base: var(--pgn-color-brand-base);
+  --pgn-color-icon-button-text-brand-inverse-hover: var(--pgn-color-brand-base);
+  --pgn-color-icon-button-text-brand-inverse-active-base: var(--pgn-color-brand-base);
+  --pgn-color-icon-button-text-light-base: var(--pgn-color-light-base);
+  --pgn-color-icon-button-text-light-inverse-hover: var(--pgn-color-light-base);
+  --pgn-color-icon-button-text-light-inverse-active-base: var(--pgn-color-light-base);
+  --pgn-color-icon-button-text-dark-base: var(--pgn-color-dark-base);
+  --pgn-color-icon-button-text-dark-inverse-hover: var(--pgn-color-dark-base);
+  --pgn-color-icon-button-text-dark-inverse-active-base: var(--pgn-color-dark-base);
+  --pgn-color-icon-button-text-black-base: var(--pgn-color-black);
+  --pgn-color-icon-button-text-black-inverse-hover: var(--pgn-color-black);
+  --pgn-color-icon-button-text-black-inverse-active-base: var(--pgn-color-black);
+  --pgn-color-icon-button-accent: var(--pgn-color-white);
+  --pgn-color-icon-button-black: var(--pgn-color-black);
+  --pgn-color-image-thumbnail-border: var(--pgn-color-gray-200);
+  --pgn-color-menu-bg: var(--pgn-color-white);
+  --pgn-color-menu-item-border: var(--pgn-color-menu-item-bg);
+  --pgn-color-menu-item-hover-border: var(--pgn-color-menu-item-bg);
+  --pgn-color-modal-content-border: #00000033;
+  --pgn-color-modal-backdrop-bg: var(--pgn-color-black);
+  --pgn-color-nav-link-text-base: var(--pgn-color-gray-700);
+  --pgn-color-nav-link-text-disabled: var(--pgn-color-gray-300);
+  --pgn-color-nav-tabs-base-text-disabled: var(--pgn-color-nav-tabs-base-bg-hover);
+  --pgn-color-nav-tabs-base-border-focus: var(--pgn-color-nav-tabs-base-bg-hover);
+  --pgn-color-nav-tabs-base-link-disabled-border: var(--pgn-color-nav-link-border);
+  --pgn-color-nav-tabs-inverse-link-text-base: var(--pgn-color-white);
+  --pgn-color-nav-tabs-inverse-dropdown-border: var(--pgn-color-nav-tabs-inverse-link-bg-active-hover);
+  --pgn-color-nav-pills-base-link-active-border: var(--pgn-color-white);
+  --pgn-color-nav-pills-inverse-link-text-base: var(--pgn-color-white);
+  --pgn-color-nav-pills-inverse-link-border-active-focus: var(--pgn-color-primary-base);
+  --pgn-color-nav-divider: var(--pgn-color-gray-100);
+  --pgn-color-nav-dark: #FFFFFF80;
+  --pgn-color-nav-light: #00000080;
+  --pgn-color-navbar-dark-text: #FFFFFF80;
+  --pgn-color-navbar-dark-hover: #FFFFFFBF;
+  --pgn-color-navbar-dark-disabled: #FFFFFF40;
+  --pgn-color-navbar-dark-toggler-border: #FFFFFF1A;
+  --pgn-color-navbar-light-text: #00000080;
+  --pgn-color-navbar-light-hover: #000000B3;
+  --pgn-color-navbar-light-active: #000000E6;
+  --pgn-color-navbar-light-disabled: #0000004D;
+  --pgn-color-navbar-light-toggler-border: #0000001A;
+  --pgn-color-page-banner-bg-accent-a: var(--pgn-color-accent-a);
+  --pgn-color-page-banner-bg-accent-b: var(--pgn-color-accent-b);
+  --pgn-color-page-banner-text-dark: var(--pgn-color-white);
+  --pgn-color-page-banner-text-light: var(--pgn-color-black);
+  --pgn-color-page-banner-text-accent-a: var(--pgn-color-black);
+  --pgn-color-page-banner-text-accent-b: var(--pgn-color-black);
+  --pgn-color-page-banner-text-warning: var(--pgn-color-black);
+  --pgn-color-pagination-text-inverse: var(--pgn-color-white);
+  --pgn-color-pagination-bg-hover: var(--pgn-color-gray-100);
+  --pgn-color-pagination-bg-disabled: var(--pgn-color-white);
+  --pgn-color-pagination-border-base: var(--pgn-color-gray-200);
+  --pgn-color-pagination-border-hover: var(--pgn-color-gray-200);
+  --pgn-color-pagination-border-disabled: var(--pgn-color-gray-100);
+  --pgn-color-pagination-focus-text: var(--pgn-color-black);
+  --pgn-color-pagination-dropdown-text-inverse: var(--pgn-color-white);
+  --pgn-color-popover-header-bg: var(--pgn-color-white);
+  --pgn-color-popover-header-bg-dark: #808080FF;
+  --pgn-color-popover-header-border-bottom-dark: #F2F2F2FF;
+  --pgn-color-popover-arrow-outer: #0000000D;
+  --pgn-color-product-tour-checkpoint-body: var(--pgn-color-gray-700);
+  --pgn-color-product-tour-checkpoint-border: var(--pgn-color-brand-base);
+  --pgn-color-product-tour-checkpoint-breadcrumb: var(--pgn-color-primary-base);
+  --pgn-color-product-tour-checkpoint-box-shadow: #0000004D;
+  --pgn-color-progress-bar-base: var(--pgn-color-white);
+  --pgn-color-progress-bar-bg-base: var(--pgn-color-accent-a);
+  --pgn-color-search-field-border-interaction: var(--pgn-color-black);
+  --pgn-color-search-field-border-focus: var(--pgn-color-black);
+  --pgn-color-search-field-form-bg: var(--pgn-color-white);
+  --pgn-color-sheet-skrim-bg: #ADADAD80;
+  --pgn-color-sheet-skrim-component-box-shadow: #00000026;
+  --pgn-color-stepper-header-bg-line: var(--pgn-color-light-base);
+  --pgn-color-stepper-header-step-base: var(--pgn-color-primary-base);
+  --pgn-color-stepper-header-step-bg-base: var(--pgn-color-stepper-header-bg-base);
+  --pgn-color-tab-more-link-dropdown-toggle-text-focus: var(--pgn-color-white);
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-focus: var(--pgn-color-white);
+  --pgn-color-toast-bg: var(--pgn-color-gray-700);
+  --pgn-color-toast-border: #0000001A;
+  --pgn-color-toast-header-text: var(--pgn-color-white);
+  --pgn-color-toast-header-bg: var(--pgn-color-gray-700);
+  --pgn-color-toast-header-border: #00000080;
+  --pgn-color-tooltip-text: var(--pgn-color-white);
+  --pgn-color-tooltip-light: var(--pgn-color-black);
+  --pgn-color-tooltip-bg-base: var(--pgn-color-black);
+  --pgn-color-tooltip-bg-light: var(--pgn-color-white);
+  --pgn-color-tooltip-arrow-light: var(--pgn-color-white);
+  --pgn-color-body-base: var(--pgn-color-gray-700);
+  --pgn-color-headings-base: var(--pgn-color-black);
+  --pgn-color-hr-border: #0000001A;
+  --pgn-color-list-group-bg-base: var(--pgn-color-white);
+  --pgn-color-list-group-bg-hover: var(--pgn-color-gray-100);
+  --pgn-color-list-group-border: #00000020;
+  --pgn-color-list-group-disabled-base: var(--pgn-color-gray-600);
+  --pgn-color-list-group-action-base: var(--pgn-color-gray-700);
+  --pgn-color-list-group-action-active-bg: var(--pgn-color-gray-200);
+  --pgn-color-yiq-light: var(--pgn-color-white);
+  --pgn-color-gray-500: var(--pgn-color-gray-base); /* Gray color of level 500. */
+  --pgn-color-primary-100: #F0F3F5FF; /* Primary color of level 100. */
+  --pgn-color-primary-200: #C2CBD5FF; /* Primary color of level 200. */
+  --pgn-color-primary-300: #8598AAFF; /* Primary color of level 300. */
+  --pgn-color-primary-400: #476480FF; /* Primary color of level 400. */
+  --pgn-color-primary-500: var(--pgn-color-primary-base); /* Primary color of level 500. */
+  --pgn-color-primary-600: #092B4DFF; /* Primary color of level 600. */
+  --pgn-color-primary-700: #082644FF; /* Primary color of level 700. */
+  --pgn-color-primary-800: #082440FF; /* Primary color of level 800. */
+  --pgn-color-primary-900: #07223CFF; /* Primary color of level 900. */
+  --pgn-color-secondary-base: var(--pgn-color-gray-700); /* Basic secondary color. */
+  --pgn-color-brand-100: #F9F0F5FF; /* Brand color of level 100. */
+  --pgn-color-brand-200: #E7BFD4FF; /* Brand color of level 200. */
+  --pgn-color-brand-300: #CE80AAFF; /* Brand color of level 300. */
+  --pgn-color-brand-400: #B6407FFF; /* Brand color of level 400. */
+  --pgn-color-brand-500: var(--pgn-color-brand-base); /* Brand color of level 500. */
+  --pgn-color-brand-600: #8D004CFF; /* Brand color of level 600. */
+  --pgn-color-brand-700: #7E0043FF; /* Brand color of level 700. */
+  --pgn-color-brand-800: #76003FFF; /* Brand color of level 800. */
+  --pgn-color-brand-900: #6E003BFF; /* Brand color of level 900. */
+  --pgn-color-success-base: var(--pgn-color-green); /* Basic success color. */
+  --pgn-color-info-base: var(--pgn-color-teal); /* Basic info color. */
+  --pgn-color-warning-base: var(--pgn-color-yellow); /* Basic warning color. */
+  --pgn-color-danger-base: var(--pgn-color-red); /* Basic danger color. */
+  --pgn-color-light-100: #FDFDFDFF; /* Light color of level 100. */
+  --pgn-color-light-200: #F8F7F6FF; /* Light color of level 200. */
+  --pgn-color-light-300: #F0EEEDFF; /* Light color of level 300. */
+  --pgn-color-light-400: #E9E6E4FF; /* Light color of level 400. */
+  --pgn-color-light-500: var(--pgn-color-light-base); /* Light color of level 500. */
+  --pgn-color-light-600: #CBC7C5FF; /* Light color of level 600. */
+  --pgn-color-light-700: #B4B1AFFF; /* Light color of level 700. */
+  --pgn-color-light-800: #A9A6A4FF; /* Light color of level 800. */
+  --pgn-color-light-900: #9E9B99FF; /* Light color of level 900. */
+  --pgn-color-dark-100: #F2F3F3FF; /* Dark color of level 100. */
+  --pgn-color-dark-200: #C9CFCBFF; /* Dark color of level 200. */
+  --pgn-color-dark-300: #939F97FF; /* Dark color of level 300. */
+  --pgn-color-dark-400: #5D6F63FF; /* Dark color of level 400. */
+  --pgn-color-dark-500: var(--pgn-color-dark-base); /* Dark color of level 500. */
+  --pgn-color-dark-600: #23392AFF; /* Dark color of level 600. */
+  --pgn-color-dark-700: #1F3226FF; /* Info color of level 700. */
+  --pgn-color-dark-800: #1D2F23FF; /* Dark color of level 800. */
+  --pgn-color-dark-900: #1B2C21FF; /* Dark color of level 900. */
+  --pgn-color-action-default-gray-100: #D2D2D2FF;
+  --pgn-color-action-default-gray-200: #B3B3B3FF;
+  --pgn-color-action-default-gray-300: #949494FF;
+  --pgn-color-action-default-gray-400: #767676FF;
+  --pgn-color-action-default-gray-600: #424242FF;
+  --pgn-color-action-default-gray-700: #2B2B2BFF;
+  --pgn-color-action-default-gray-800: #1A1A1AFF;
+  --pgn-color-action-default-gray-900: #0A0C0DFF;
+  --pgn-color-action-default-gray-base: #575757FF;
+  --pgn-color-action-default-primary-base: #051627FF;
+  --pgn-color-action-default-brand-base: #6A0039FF;
+  --pgn-color-action-default-light-base: #CAC3BFFF;
+  --pgn-color-action-default-dark-base: #142018FF;
+  --pgn-color-action-default-accent-a: #0095C6FF;
+  --pgn-color-action-default-accent-b: #FFE755FF;
+  --pgn-elevation-dropzone-active-color: var(--pgn-color-primary-500);
+  --pgn-elevation-form-input-focus-color: var(--pgn-color-primary-500);
+  --pgn-elevation-form-control-file-focus-color: var(--pgn-color-primary-500);
+  --pgn-elevation-icon-button-box-shadow-primary-base-color: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-elevation-icon-button-box-shadow-primary-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-secondary-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-brand-base-color: var(--pgn-color-icon-button-text-brand-base);
+  --pgn-elevation-icon-button-box-shadow-brand-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-success-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-warning-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-danger-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-light-base-color: var(--pgn-color-icon-button-text-light-base);
+  --pgn-elevation-icon-button-box-shadow-light-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-dark-base-color: var(--pgn-color-icon-button-text-dark-base);
+  --pgn-elevation-icon-button-box-shadow-dark-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-elevation-icon-button-box-shadow-black-base-color: var(--pgn-color-icon-button-text-black-base);
+  --pgn-elevation-icon-button-box-shadow-black-inverse-color: var(--pgn-color-icon-button-accent);
+  --pgn-other-content-form-control-select-bg-offset-y: var(--pgn-spacing-form-input-padding-y-base);
+  --pgn-color-bg-active: var(--pgn-color-primary-500); /* Active background color. */
+  --pgn-color-disabled: var(--pgn-color-gray-500); /* Color for disabled element. */
+  --pgn-color-input-focus: var(--pgn-color-primary-500); /* Focused input value color. */
+  --pgn-color-table-border: var(--pgn-color-border); /* Table border color. */
+  --pgn-color-theme-bg-primary: var(--pgn-color-primary-100); /* Theme-specific primary background color. */
+  --pgn-color-theme-bg-brand: var(--pgn-color-brand-100); /* Theme-specific brand background color. */
+  --pgn-color-theme-bg-light: var(--pgn-color-light-100); /* Theme-specific light background color. */
+  --pgn-color-theme-bg-dark: var(--pgn-color-dark-100); /* Theme-specific dark background color. */
+  --pgn-color-theme-border-primary: var(--pgn-color-primary-200); /* Theme-specific primary border color. */
+  --pgn-color-theme-border-brand: var(--pgn-color-brand-200); /* Theme-specific brand border color. */
+  --pgn-color-theme-border-light: var(--pgn-color-light-200); /* Theme-specific light border color. */
+  --pgn-color-theme-border-dark: var(--pgn-color-dark-200); /* Theme-specific dark border color. */
+  --pgn-color-theme-focus-primary: var(--pgn-color-primary-500); /* Theme-specific primary focus color. */
+  --pgn-color-theme-focus-brand: var(--pgn-color-brand-500); /* Theme-specific brand focus color. */
+  --pgn-color-theme-focus-light: var(--pgn-color-light-500); /* Theme-specific light focus color. */
+  --pgn-color-theme-focus-dark: var(--pgn-color-dark-500); /* Theme-specific dark focus color. */
+  --pgn-color-theme-focus-gray: var(--pgn-color-gray-500); /* Theme-specific gray focus color. */
+  --pgn-color-theme-default-primary: var(--pgn-color-primary-500); /* Theme-specific primary default color. */
+  --pgn-color-theme-default-brand: var(--pgn-color-brand-500); /* Theme-specific brand default color. */
+  --pgn-color-theme-default-light: var(--pgn-color-light-500); /* Theme-specific light default color. */
+  --pgn-color-theme-default-dark: var(--pgn-color-dark-500); /* Theme-specific dark default color. */
+  --pgn-color-theme-default-gray: var(--pgn-color-gray-500); /* Theme-specific gray default color. */
+  --pgn-color-theme-hover-primary: var(--pgn-color-primary-700); /* Theme-specific primary hover color. */
+  --pgn-color-theme-hover-brand: var(--pgn-color-brand-700); /* Theme-specific brand hover color. */
+  --pgn-color-theme-hover-light: var(--pgn-color-light-700); /* Theme-specific light hover color. */
+  --pgn-color-theme-hover-dark: var(--pgn-color-dark-700); /* Theme-specific dark hover color. */
+  --pgn-color-theme-active-primary: var(--pgn-color-primary-900); /* Theme-specific primary active color. */
+  --pgn-color-theme-active-brand: var(--pgn-color-brand-900); /* Theme-specific brand active color. */
+  --pgn-color-theme-active-light: var(--pgn-color-light-900); /* Theme-specific light active color. */
+  --pgn-color-theme-active-dark: var(--pgn-color-dark-900); /* Theme-specific dark active color. */
+  --pgn-color-annotation-text-light: var(--pgn-color-primary-500);
+  --pgn-color-annotation-bg-success: var(--pgn-color-success-base);
+  --pgn-color-annotation-bg-error: var(--pgn-color-danger-base);
+  --pgn-color-avatar-border: var(--pgn-color-light-300);
+  --pgn-color-badge-text-secondary: #FFFFFFFF;
+  --pgn-color-badge-text-success: #FFFFFFFF;
+  --pgn-color-badge-text-danger: #FFFFFFFF;
+  --pgn-color-badge-text-warning: #454545FF;
+  --pgn-color-badge-text-info: #FFFFFFFF;
+  --pgn-color-badge-bg-secondary: var(--pgn-color-secondary-base);
+  --pgn-color-badge-bg-success: var(--pgn-color-success-base);
+  --pgn-color-badge-bg-warning: var(--pgn-color-warning-base);
+  --pgn-color-badge-bg-danger: var(--pgn-color-danger-base);
+  --pgn-color-badge-bg-info: var(--pgn-color-info-base);
+  --pgn-color-badge-focus-primary: var(--pgn-color-badge-text-primary);
+  --pgn-color-badge-focus-light: var(--pgn-color-badge-text-light);
+  --pgn-color-badge-focus-dark: var(--pgn-color-badge-text-dark);
+  --pgn-color-badge-focus-bg-primary: #051627FF;
+  --pgn-color-badge-focus-bg-light: #CAC3BFFF;
+  --pgn-color-badge-focus-bg-dark: #142018FF;
+  --pgn-color-badge-focus-box-shadow-primary: #0A30550D;
+  --pgn-color-badge-focus-box-shadow-light: #E1DDDB0D;
+  --pgn-color-badge-focus-box-shadow-dark: #273F2F0D;
+  --pgn-color-breadcrumb-base: var(--pgn-color-primary-500);
+  --pgn-color-breadcrumb-active: var(--pgn-color-gray-500);
+  --pgn-color-breadcrumb-inverse-active: var(--pgn-color-light-500);
+  --pgn-color-breadcrumb-inverse-spacer: var(--pgn-color-light-700);
+  --pgn-color-bubble-bg-success: var(--pgn-color-success-base);
+  --pgn-color-bubble-bg-warning: var(--pgn-color-warning-base);
+  --pgn-color-bubble-bg-error: var(--pgn-color-danger-base);
+  --pgn-color-btn-text-brand: #FFFFFFFF;
+  --pgn-color-btn-text-outline-danger: var(--pgn-color-danger-base);
+  --pgn-color-btn-text-inverse-danger: var(--pgn-color-danger-base);
+  --pgn-color-btn-text-dark: #FFFFFFFF;
+  --pgn-color-btn-text-outline-info: var(--pgn-color-info-base);
+  --pgn-color-btn-text-inverse-info: var(--pgn-color-info-base);
+  --pgn-color-btn-text-light: #454545FF;
+  --pgn-color-btn-text-primary: #FFFFFFFF;
+  --pgn-color-btn-text-outline-secondary: var(--pgn-color-secondary-base);
+  --pgn-color-btn-text-inverse-secondary: var(--pgn-color-secondary-base);
+  --pgn-color-btn-text-outline-success: var(--pgn-color-success-base);
+  --pgn-color-btn-text-inverse-success: var(--pgn-color-success-base);
+  --pgn-color-btn-text-outline-warning: var(--pgn-color-warning-base);
+  --pgn-color-btn-text-inverse-warning: var(--pgn-color-warning-base);
+  --pgn-color-btn-bg-inverse-brand: #FFFFFFFF;
+  --pgn-color-btn-bg-danger: var(--pgn-color-danger-base);
+  --pgn-color-btn-bg-inverse-dark: #FFFFFFFF;
+  --pgn-color-btn-bg-info: var(--pgn-color-info-base);
+  --pgn-color-btn-bg-inverse-light: #454545FF;
+  --pgn-color-btn-bg-inverse-primary: #FFFFFFFF;
+  --pgn-color-btn-bg-secondary: var(--pgn-color-secondary-base);
+  --pgn-color-btn-bg-success: var(--pgn-color-success-base);
+  --pgn-color-btn-bg-warning: var(--pgn-color-warning-base);
+  --pgn-color-btn-border-brand: var(--pgn-color-btn-bg-brand);
+  --pgn-color-btn-border-outline-danger: var(--pgn-color-danger-base);
+  --pgn-color-btn-border-dark: var(--pgn-color-btn-bg-dark);
+  --pgn-color-btn-border-outline-info: var(--pgn-color-info-base);
+  --pgn-color-btn-border-light: var(--pgn-color-btn-bg-light);
+  --pgn-color-btn-border-primary: var(--pgn-color-btn-bg-primary);
+  --pgn-color-btn-border-outline-secondary: var(--pgn-color-secondary-base);
+  --pgn-color-btn-border-outline-success: var(--pgn-color-success-base);
+  --pgn-color-btn-border-outline-warning: var(--pgn-color-warning-base);
+  --pgn-color-btn-hover-text-inverse-brand: #770040FF;
+  --pgn-color-btn-hover-text-inverse-dark: #18271DFF;
+  --pgn-color-btn-hover-text-inverse-light: #D0C9C6FF;
+  --pgn-color-btn-hover-text-inverse-primary: #061D33FF;
+  --pgn-color-btn-hover-bg-outline-brand: var(--pgn-color-brand-100);
+  --pgn-color-btn-hover-bg-inverse-outline-brand: var(--pgn-color-brand-100);
+  --pgn-color-btn-hover-bg-outline-dark: var(--pgn-color-dark-100);
+  --pgn-color-btn-hover-bg-inverse-outline-dark: var(--pgn-color-dark-100);
+  --pgn-color-btn-hover-bg-outline-light: var(--pgn-color-light-100);
+  --pgn-color-btn-hover-bg-inverse-outline-light: var(--pgn-color-light-100);
+  --pgn-color-btn-hover-bg-outline-primary: var(--pgn-color-primary-100);
+  --pgn-color-btn-hover-bg-inverse-outline-primary: var(--pgn-color-primary-100);
+  --pgn-color-btn-hover-bg-tertiary: var(--pgn-color-light-500);
+  --pgn-color-btn-hover-border-outline-brand: var(--pgn-color-brand-900);
+  --pgn-color-btn-hover-border-outline-dark: var(--pgn-color-dark-900);
+  --pgn-color-btn-hover-border-outline-light: var(--pgn-color-light-900);
+  --pgn-color-btn-hover-border-outline-primary: var(--pgn-color-primary-900);
+  --pgn-color-btn-active-text-inverse-brand: #6A0039FF;
+  --pgn-color-btn-active-text-inverse-dark: #142018FF;
+  --pgn-color-btn-active-text-inverse-light: #CAC3BFFF;
+  --pgn-color-btn-active-text-inverse-primary: #051627FF;
+  --pgn-color-btn-active-bg-tertiary: var(--pgn-color-light-500);
+  --pgn-color-btn-active-bg-inverse-tertiary: var(--pgn-color-btn-hover-bg-inverse-tertiary);
+  --pgn-color-btn-focus-text-inverse-brand: var(--pgn-color-btn-text-inverse-brand);
+  --pgn-color-btn-focus-text-outline-brand: var(--pgn-color-btn-text-outline-brand);
+  --pgn-color-btn-focus-text-inverse-outline-brand: var(--pgn-color-btn-text-inverse-outline-brand);
+  --pgn-color-btn-focus-text-inverse-outline-danger: var(--pgn-color-btn-text-inverse-outline-danger);
+  --pgn-color-btn-focus-text-inverse-dark: var(--pgn-color-btn-text-inverse-dark);
+  --pgn-color-btn-focus-text-inverse-outline-dark: var(--pgn-color-btn-text-inverse-outline-dark);
+  --pgn-color-btn-focus-text-inverse-outline-info: var(--pgn-color-btn-text-inverse-outline-info);
+  --pgn-color-btn-focus-text-outline-light: var(--pgn-color-btn-text-outline-light);
+  --pgn-color-btn-focus-text-inverse-light: var(--pgn-color-btn-text-inverse-light);
+  --pgn-color-btn-focus-text-inverse-outline-light: var(--pgn-color-btn-text-inverse-outline-light);
+  --pgn-color-btn-focus-text-outline-primary: var(--pgn-color-btn-text-outline-primary);
+  --pgn-color-btn-focus-text-inverse-primary: var(--pgn-color-btn-text-inverse-primary);
+  --pgn-color-btn-focus-text-inverse-outline-primary: var(--pgn-color-btn-text-inverse-outline-primary);
+  --pgn-color-btn-focus-text-inverse-outline-secondary: var(--pgn-color-btn-text-inverse-outline-secondary);
+  --pgn-color-btn-focus-text-inverse-outline-success: var(--pgn-color-btn-text-inverse-outline-success);
+  --pgn-color-btn-focus-text-tertiary: var(--pgn-color-btn-text-tertiary);
+  --pgn-color-btn-focus-text-inverse-tertiary: var(--pgn-color-btn-text-inverse-tertiary);
+  --pgn-color-btn-focus-text-inverse-outline-warning: var(--pgn-color-btn-text-inverse-outline-warning);
+  --pgn-color-btn-focus-border-outline-brand: var(--pgn-color-btn-border-outline-brand);
+  --pgn-color-btn-focus-border-inverse-outline-brand: var(--pgn-color-btn-border-inverse-outline-brand);
+  --pgn-color-btn-focus-border-outline-dark: var(--pgn-color-btn-border-outline-dark);
+  --pgn-color-btn-focus-border-inverse-outline-info: var(--pgn-color-btn-border-inverse-outline-info);
+  --pgn-color-btn-focus-border-outline-light: var(--pgn-color-btn-border-outline-light);
+  --pgn-color-btn-focus-border-inverse-outline-light: var(--pgn-color-btn-border-inverse-outline-light);
+  --pgn-color-btn-focus-border-outline-primary: var(--pgn-color-btn-border-outline-primary);
+  --pgn-color-btn-focus-border-inverse-outline-primary: var(--pgn-color-btn-border-inverse-outline-primary);
+  --pgn-color-btn-focus-border-inverse-outline-success: var(--pgn-color-btn-border-inverse-outline-success);
+  --pgn-color-btn-focus-border-inverse-outline-warning: var(--pgn-color-btn-border-inverse-outline-warning);
+  --pgn-color-btn-focus-bg-brand: var(--pgn-color-btn-bg-brand);
+  --pgn-color-btn-focus-bg-dark: var(--pgn-color-btn-bg-dark);
+  --pgn-color-btn-focus-bg-light: var(--pgn-color-btn-bg-light);
+  --pgn-color-btn-focus-bg-primary: var(--pgn-color-btn-bg-primary);
+  --pgn-color-btn-focus-outline-inverse-brand: var(--pgn-color-btn-focus-border-inverse-brand);
+  --pgn-color-btn-focus-outline-inverse-danger: var(--pgn-color-btn-focus-border-inverse-danger);
+  --pgn-color-btn-focus-outline-inverse-outline-danger: var(--pgn-color-btn-focus-border-inverse-danger);
+  --pgn-color-btn-focus-outline-inverse-dark: var(--pgn-color-btn-focus-border-inverse-dark);
+  --pgn-color-btn-focus-outline-inverse-outline-dark: var(--pgn-color-btn-focus-border-inverse-outline-dark);
+  --pgn-color-btn-focus-outline-inverse-info: var(--pgn-color-btn-focus-border-inverse-info);
+  --pgn-color-btn-focus-outline-light: var(--pgn-color-primary-300);
+  --pgn-color-btn-focus-outline-inverse-primary: var(--pgn-color-btn-focus-border-inverse-primary);
+  --pgn-color-btn-focus-outline-inverse-outline-primary: var(--pgn-color-btn-border-inverse-outline-primary);
+  --pgn-color-btn-focus-outline-inverse-outline-secondary: var(--pgn-color-btn-border-inverse-outline-secondary);
+  --pgn-color-btn-focus-outline-inverse-success: var(--pgn-color-btn-focus-border-inverse-success);
+  --pgn-color-btn-disabled-text-inverse-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-disabled-text-inverse-outline-brand: var(--pgn-color-btn-text-inverse-outline-brand);
+  --pgn-color-btn-disabled-text-inverse-danger: var(--pgn-color-danger-base);
+  --pgn-color-btn-disabled-text-inverse-outline-danger: var(--pgn-color-btn-text-inverse-outline-danger);
+  --pgn-color-btn-disabled-text-inverse-dark: var(--pgn-color-btn-text-inverse-dark);
+  --pgn-color-btn-disabled-text-inverse-outline-dark: var(--pgn-color-btn-text-inverse-outline-dark);
+  --pgn-color-btn-disabled-text-inverse-info: var(--pgn-color-info-base);
+  --pgn-color-btn-disabled-text-inverse-outline-info: var(--pgn-color-btn-text-inverse-outline-info);
+  --pgn-color-btn-disabled-text-inverse-light: var(--pgn-color-btn-text-inverse-light);
+  --pgn-color-btn-disabled-text-inverse-outline-light: var(--pgn-color-btn-text-inverse-outline-light);
+  --pgn-color-btn-disabled-text-inverse-primary: var(--pgn-color-primary-500);
+  --pgn-color-btn-disabled-text-inverse-outline-primary: var(--pgn-color-btn-text-inverse-outline-primary);
+  --pgn-color-btn-disabled-text-inverse-outline-secondary: var(--pgn-color-btn-text-inverse-outline-secondary);
+  --pgn-color-btn-disabled-text-inverse-success: var(--pgn-color-success-base);
+  --pgn-color-btn-disabled-text-inverse-outline-success: var(--pgn-color-btn-text-inverse-outline-success);
+  --pgn-color-btn-disabled-text-tertiary: var(--pgn-color-btn-text-tertiary);
+  --pgn-color-btn-disabled-text-inverse-tertiary: var(--pgn-color-btn-text-inverse-tertiary);
+  --pgn-color-btn-disabled-text-inverse-warning: var(--pgn-color-warning-base);
+  --pgn-color-btn-disabled-text-inverse-outline-warning: var(--pgn-color-btn-text-inverse-outline-warning);
+  --pgn-color-btn-disabled-bg-brand: var(--pgn-color-btn-bg-brand);
+  --pgn-color-btn-disabled-bg-dark: var(--pgn-color-btn-bg-dark);
+  --pgn-color-btn-disabled-bg-light: var(--pgn-color-btn-bg-light);
+  --pgn-color-btn-disabled-bg-primary: var(--pgn-color-btn-bg-primary);
+  --pgn-color-btn-disabled-border-outline-brand: var(--pgn-color-btn-border-outline-brand);
+  --pgn-color-btn-disabled-border-inverse-brand: var(--pgn-color-btn-disabled-bg-inverse-brand);
+  --pgn-color-btn-disabled-border-inverse-outline-brand: var(--pgn-color-btn-text-inverse-outline-brand);
+  --pgn-color-btn-disabled-border-inverse-outline-danger: var(--pgn-color-btn-border-inverse-outline-danger);
+  --pgn-color-btn-disabled-border-inverse-outline-dark: var(--pgn-color-btn-focus-border-inverse-outline-dark);
+  --pgn-color-btn-disabled-border-inverse-outline-info: var(--pgn-color-btn-border-inverse-outline-info);
+  --pgn-color-btn-disabled-border-inverse-outline-light: var(--pgn-color-btn-border-inverse-outline-light);
+  --pgn-color-btn-disabled-border-inverse-outline-primary: var(--pgn-color-btn-text-inverse-outline-primary);
+  --pgn-color-btn-disabled-border-outline-secondary: var(--pgn-color-secondary-base);
+  --pgn-color-btn-disabled-border-inverse-outline-secondary: var(--pgn-color-btn-border-inverse-outline-secondary);
+  --pgn-color-btn-disabled-border-inverse-outline-warning: var(--pgn-color-btn-border-inverse-outline-warning);
+  --pgn-color-card-bg-base: var(--pgn-color-bg-base);
+  --pgn-color-card-bg-dark: var(--pgn-color-primary-500);
+  --pgn-color-card-bg-muted: var(--pgn-color-light-200);
+  --pgn-color-card-border-focus-base: var(--pgn-color-primary-500);
+  --pgn-color-card-divider-bg: var(--pgn-color-light-400);
+  --pgn-color-chip-bg-dark: var(--pgn-color-primary-300);
+  --pgn-color-chip-border-base: var(--pgn-color-light-800);
+  --pgn-color-chip-border-focus-selected-dark: var(--pgn-color-chip-outline-dark);
+  --pgn-color-chip-border-focus-selected-light: var(--pgn-color-dark-500);
+  --pgn-color-chip-label-base: var(--pgn-color-primary-700);
+  --pgn-color-chip-label-dark: var(--pgn-color-chip-outline-dark);
+  --pgn-color-data-table-bg-base: var(--pgn-color-bg-base);
+  --pgn-color-data-table-border: var(--pgn-color-light-300);
+  --pgn-color-dropdown-text: var(--pgn-color-body-base);
+  --pgn-color-dropdown-header: var(--pgn-color-gray-500);
+  --pgn-color-dropdown-bg: var(--pgn-color-bg-base);
+  --pgn-color-dropdown-link-hover-bg: var(--pgn-color-light-300);
+  --pgn-color-dropdown-link-active-base: var(--pgn-color-active);
+  --pgn-color-dropzone-restriction-msg: var(--pgn-color-gray-500);
+  --pgn-color-dropzone-border-base: var(--pgn-color-gray-500);
+  --pgn-color-form-input-placeholder: var(--pgn-color-gray-500);
+  --pgn-color-form-input-plaintext: var(--pgn-color-body-base);
+  --pgn-color-form-input-border: var(--pgn-color-gray-500);
+  --pgn-color-form-input-bg-base: var(--pgn-color-bg-base);
+  --pgn-color-form-input-group-addon-base: var(--pgn-color-form-input-base);
+  --pgn-color-form-input-focus-base: var(--pgn-color-form-input-base);
+  --pgn-color-form-control-indicator-bg-disabled: var(--pgn-color-form-input-bg-disabled);
+  --pgn-color-form-control-indicator-checked-valid: var(--pgn-color-success-base);
+  --pgn-color-form-control-indicator-checked-invalid: var(--pgn-color-danger-base);
+  --pgn-color-form-control-indicator-active-base: var(--pgn-color-active);
+  --pgn-color-form-control-switch-indicator-checked-bg: var(--pgn-color-success-base);
+  --pgn-color-form-control-select-base: var(--pgn-color-form-input-base);
+  --pgn-color-form-control-select-indicator-base: var(--pgn-color-theme-hover-gray);
+  --pgn-color-form-control-file-base: var(--pgn-color-form-input-base);
+  --pgn-color-form-control-file-bg-disabled: var(--pgn-color-form-input-bg-disabled);
+  --pgn-color-form-control-file-button-bg: var(--pgn-color-form-input-group-addon-bg);
+  --pgn-color-form-feedback-valid: var(--pgn-color-success-base);
+  --pgn-color-form-feedback-invalid: var(--pgn-color-danger-base);
+  --pgn-color-icon-button-bg-primary-hover: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-bg-primary-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-primary-active-base: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-bg-primary-active-hover: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-bg-primary-active-focus: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-bg-primary-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-primary-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-primary-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-secondary-hover: var(--pgn-color-secondary-base);
+  --pgn-color-icon-button-bg-secondary-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-secondary-active-base: var(--pgn-color-secondary-base);
+  --pgn-color-icon-button-bg-secondary-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-secondary-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-secondary-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-brand-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-brand-active-hover: var(--pgn-color-icon-button-bg-brand-active-base);
+  --pgn-color-icon-button-bg-brand-active-focus: var(--pgn-color-icon-button-bg-brand-active-base);
+  --pgn-color-icon-button-bg-brand-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-brand-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-brand-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-success-hover: var(--pgn-color-success-base);
+  --pgn-color-icon-button-bg-success-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-success-active-base: var(--pgn-color-success-base);
+  --pgn-color-icon-button-bg-success-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-success-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-success-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-warning-hover: var(--pgn-color-warning-base);
+  --pgn-color-icon-button-bg-warning-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-warning-active-base: var(--pgn-color-warning-base);
+  --pgn-color-icon-button-bg-warning-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-warning-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-warning-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-danger-hover: var(--pgn-color-danger-base);
+  --pgn-color-icon-button-bg-danger-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-danger-active-base: var(--pgn-color-danger-base);
+  --pgn-color-icon-button-bg-danger-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-danger-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-danger-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-light-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-light-active-hover: var(--pgn-color-icon-button-bg-light-active-base);
+  --pgn-color-icon-button-bg-light-active-focus: var(--pgn-color-icon-button-bg-light-active-base);
+  --pgn-color-icon-button-bg-light-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-light-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-light-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-dark-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-dark-active-hover: var(--pgn-color-icon-button-bg-dark-active-base);
+  --pgn-color-icon-button-bg-dark-active-focus: var(--pgn-color-icon-button-bg-dark-active-base);
+  --pgn-color-icon-button-bg-dark-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-dark-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-dark-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-black-inverse-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-black-active-hover: var(--pgn-color-icon-button-bg-black-active-base);
+  --pgn-color-icon-button-bg-black-active-focus: var(--pgn-color-icon-button-bg-black-active-base);
+  --pgn-color-icon-button-bg-black-inverse-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-black-inverse-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-bg-black-inverse-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-focus: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-text-primary-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-inverse-hover: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-text-primary-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-primary-inverse-active-base: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-text-primary-inverse-active-hover: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-text-primary-inverse-active-focus: var(--pgn-color-icon-button-text-primary-base);
+  --pgn-color-icon-button-text-secondary-base: var(--pgn-color-secondary-base);
+  --pgn-color-icon-button-text-secondary-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-secondary-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-secondary-inverse-hover: var(--pgn-color-secondary-base);
+  --pgn-color-icon-button-text-secondary-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-secondary-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-secondary-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-secondary-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-secondary-inverse-active-base: var(--pgn-color-secondary-base);
+  --pgn-color-icon-button-text-brand-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-brand-focus: var(--pgn-color-icon-button-text-brand-base);
+  --pgn-color-icon-button-text-brand-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-brand-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-brand-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-brand-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-brand-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-brand-inverse-active-hover: var(--pgn-color-icon-button-text-brand-inverse-active-base);
+  --pgn-color-icon-button-text-brand-inverse-active-focus: var(--pgn-color-icon-button-text-brand-inverse-active-base);
+  --pgn-color-icon-button-text-success-base: var(--pgn-color-success-base);
+  --pgn-color-icon-button-text-success-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-success-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-success-inverse-hover: var(--pgn-color-success-base);
+  --pgn-color-icon-button-text-success-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-success-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-success-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-success-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-success-inverse-active-base: var(--pgn-color-success-base);
+  --pgn-color-icon-button-text-warning-base: var(--pgn-color-warning-base);
+  --pgn-color-icon-button-text-warning-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-warning-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-warning-inverse-hover: var(--pgn-color-warning-base);
+  --pgn-color-icon-button-text-warning-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-warning-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-warning-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-warning-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-warning-inverse-active-base: var(--pgn-color-warning-base);
+  --pgn-color-icon-button-text-danger-base: var(--pgn-color-danger-base);
+  --pgn-color-icon-button-text-danger-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-danger-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-danger-inverse-hover: var(--pgn-color-danger-base);
+  --pgn-color-icon-button-text-danger-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-danger-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-danger-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-danger-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-danger-inverse-active-base: var(--pgn-color-danger-base);
+  --pgn-color-icon-button-text-light-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-light-focus: var(--pgn-color-icon-button-text-light-base);
+  --pgn-color-icon-button-text-light-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-light-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-light-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-light-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-light-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-light-inverse-active-hover: var(--pgn-color-icon-button-text-light-inverse-active-base);
+  --pgn-color-icon-button-text-light-inverse-active-focus: var(--pgn-color-icon-button-text-light-inverse-active-base);
+  --pgn-color-icon-button-text-dark-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-dark-focus: var(--pgn-color-icon-button-text-dark-base);
+  --pgn-color-icon-button-text-dark-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-dark-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-dark-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-dark-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-dark-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-dark-inverse-active-hover: var(--pgn-color-icon-button-text-dark-inverse-active-base);
+  --pgn-color-icon-button-text-dark-inverse-active-focus: var(--pgn-color-icon-button-text-dark-inverse-active-base);
+  --pgn-color-icon-button-text-black-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-black-focus: var(--pgn-color-icon-button-text-black-base);
+  --pgn-color-icon-button-text-black-inverse-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-black-inverse-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-black-active-base: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-black-active-hover: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-black-active-focus: var(--pgn-color-icon-button-accent);
+  --pgn-color-icon-button-text-black-inverse-active-hover: var(--pgn-color-icon-button-text-black-inverse-active-base);
+  --pgn-color-icon-button-text-black-inverse-active-focus: var(--pgn-color-icon-button-text-black-inverse-active-base);
+  --pgn-color-image-figure-caption: var(--pgn-color-gray-500);
+  --pgn-color-menu-item-color: var(--pgn-color-body-base);
+  --pgn-color-menu-item-hover-color: var(--pgn-color-btn-text-tertiary);
+  --pgn-color-menu-select-btn-link-color: var(--pgn-color-primary-500);
+  --pgn-color-modal-content-bg: var(--pgn-color-bg-base);
+  --pgn-color-nav-tabs-base-border-base: var(--pgn-color-light-400);
+  --pgn-color-nav-tabs-base-link-hover-bg: var(--pgn-color-light-400);
+  --pgn-color-nav-tabs-base-link-active-text: var(--pgn-color-primary-500);
+  --pgn-color-nav-tabs-inverse-link-border-bottom: var(--pgn-color-dark-300);
+  --pgn-color-nav-tabs-inverse-link-border-active: var(--pgn-color-nav-tabs-inverse-link-text-base);
+  --pgn-color-nav-tabs-inverse-link-bg-focus: var(--pgn-color-nav-tabs-inverse-link-text-base);
+  --pgn-color-nav-tabs-inverse-link-tab-content-color: var(--pgn-color-nav-tabs-inverse-link-text-base);
+  --pgn-color-nav-pills-base-link-active-text: var(--pgn-color-active);
+  --pgn-color-nav-pills-inverse-link-text-focus: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-nav-pills-inverse-link-text-active: var(--pgn-color-primary-500);
+  --pgn-color-nav-pills-inverse-link-text-hover: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-nav-pills-inverse-link-text-active-hover: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-nav-pills-inverse-link-border-base: var(--pgn-color-dark-300);
+  --pgn-color-nav-pills-inverse-link-border-active: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-nav-pills-inverse-link-border-focus-hover: var(--pgn-color-nav-pills-inverse-link-border-active-focus);
+  --pgn-color-nav-pills-inverse-link-bg-active: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-nav-pills-inverse-link-bg-active-focus-hover: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-nav-pills-inverse-tab-content-color: var(--pgn-color-nav-pills-inverse-link-text-base);
+  --pgn-color-navbar-dark-active: var(--pgn-color-active);
+  --pgn-color-navbar-light-brand-text: var(--pgn-color-navbar-light-active);
+  --pgn-color-navbar-light-brand-hover: var(--pgn-color-navbar-light-active);
+  --pgn-color-page-banner-bg-dark: var(--pgn-color-dark-500);
+  --pgn-color-page-banner-bg-light: var(--pgn-color-light-400);
+  --pgn-color-pagination-text-active: var(--pgn-color-active);
+  --pgn-color-pagination-bg-base: var(--pgn-color-bg-base);
+  --pgn-color-pagination-focus-base: var(--pgn-color-primary-500);
+  --pgn-color-popover-bg: var(--pgn-color-bg-base);
+  --pgn-color-popover-header-text: var(--pgn-color-headings-base);
+  --pgn-color-popover-body: var(--pgn-color-body-base);
+  --pgn-color-product-tour-checkpoint-bg: var(--pgn-color-light-300);
+  --pgn-color-progress-bar-bg-annotated: var(--pgn-color-dark-500);
+  --pgn-color-progress-bar-border: var(--pgn-color-gray-500);
+  --pgn-color-search-field-border-base: var(--pgn-color-gray-500);
+  --pgn-color-search-field-button-bg-primary: var(--pgn-color-primary-500);
+  --pgn-color-search-field-button-bg-brand: var(--pgn-color-brand-500);
+  --pgn-color-stepper-header-step-bg-active: var(--pgn-color-gray-500);
+  --pgn-color-stepper-header-step-bubble-error: var(--pgn-color-danger-base);
+  --pgn-color-tab-more-link-dropdown-toggle-btn-text-focus: var(--pgn-color-tab-more-link-dropdown-toggle-text-focus);
+  --pgn-color-tab-more-link-dropdown-toggle-text-active: var(--pgn-color-tab-more-link-dropdown-toggle-text-focus);
+  --pgn-color-tab-more-link-dropdown-toggle-bg-focus: var(--pgn-color-primary-500);
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-text-focus: var(--pgn-color-primary-500);
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-text-active-hover: var(--pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-focus);
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-active-hover: var(--pgn-color-primary-300);
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-border-focus: var(--pgn-color-tab-inverse-pills-link-dropdown-toggle-bg-focus);
+  --pgn-color-tooltip-arrow-base: var(--pgn-color-tooltip-bg-base);
+  --pgn-color-body-bg: var(--pgn-color-bg-base);
+  --pgn-color-link-muted-base: var(--pgn-color-primary-500);
+  --pgn-color-link-muted-inline-base: var(--pgn-color-primary-500);
+  --pgn-color-link-brand-base: var(--pgn-color-brand-500);
+  --pgn-color-link-brand-inline-base: var(--pgn-color-brand-500);
+  --pgn-color-list-group-active-base: var(--pgn-color-active);
+  --pgn-color-list-group-disabled-bg: var(--pgn-color-list-group-bg-base);
+  --pgn-color-list-group-action-hover: var(--pgn-color-list-group-action-base);
+  --pgn-color-list-group-action-active-base: var(--pgn-color-body-base);
+  --pgn-color-text-muted: var(--pgn-color-gray-500);
+  --pgn-color-blockquote-small: var(--pgn-color-gray-500);
+  --pgn-color-secondary-100: #F4F4F4FF; /* Secondary color of level 100. */
+  --pgn-color-secondary-200: #D1D1D1FF; /* Secondary color of level 200. */
+  --pgn-color-secondary-300: #A2A2A2FF; /* Secondary color of level 300. */
+  --pgn-color-secondary-400: #747474FF; /* Secondary color of level 400. */
+  --pgn-color-secondary-500: var(--pgn-color-secondary-base); /* Secondary color of level 500. */
+  --pgn-color-secondary-600: #3E3E3EFF; /* Secondary color of level 600. */
+  --pgn-color-secondary-700: #373737FF; /* Secondary color of level 700. */
+  --pgn-color-secondary-800: #343434FF; /* Secondary color of level 800. */
+  --pgn-color-secondary-900: #303030FF; /* Secondary color of level 900. */
+  --pgn-color-success-100: #F1F8F5FF; /* Success color of level 100. */
+  --pgn-color-success-200: #C5E0D4FF; /* Success color of level 200. */
+  --pgn-color-success-300: #8BC1A9FF; /* Success color of level 300. */
+  --pgn-color-success-400: #51A17EFF; /* Success color of level 400. */
+  --pgn-color-success-500: var(--pgn-color-success-base); /* Success color of level 500. */
+  --pgn-color-success-600: #15754BFF; /* Success color of level 600. */
+  --pgn-color-success-700: #126842FF; /* Success color of level 700. */
+  --pgn-color-success-800: #11623EFF; /* Success color of level 800. */
+  --pgn-color-success-900: #105B3AFF; /* Success color of level 900. */
+  --pgn-color-info-100: #F0F6FAFF; /* Info color of level 100. */
+  --pgn-color-info-200: #BFDBEAFF; /* Info color of level 200. */
+  --pgn-color-info-300: #80B6D5FF; /* Info color of level 300. */
+  --pgn-color-info-400: #4092BFFF; /* Info color of level 400. */
+  --pgn-color-info-500: var(--pgn-color-info-base); /* Info color of level 500. */
+  --pgn-color-info-600: #006299FF; /* Info color of level 600. */
+  --pgn-color-info-700: #005788FF; /* Info color of level 700. */
+  --pgn-color-info-800: #005280FF; /* Info color of level 800. */
+  --pgn-color-info-900: #004C77FF; /* Info color of level 900. */
+  --pgn-color-warning-100: #FFFDF0FF; /* Warning color of level 100. */
+  --pgn-color-warning-200: #FFF6BFFF; /* Warning color of level 200. */
+  --pgn-color-warning-300: #FFEC80FF; /* Warning color of level 300. */
+  --pgn-color-warning-400: #FFE340FF; /* Warning color of level 400. */
+  --pgn-color-warning-500: var(--pgn-color-warning-base); /* Warning color of level 500. */
+  --pgn-color-warning-600: #E6C300FF; /* Warning color of level 600. */
+  --pgn-color-warning-700: #CCAE00FF; /* Warning color of level 700. */
+  --pgn-color-warning-800: #BFA300FF; /* Warning color of level 800. */
+  --pgn-color-warning-900: #B39800FF; /* Warning color of level 900. */
+  --pgn-color-danger-100: #FBF2F3FF; /* Danger color of level 100. */
+  --pgn-color-danger-200: #F0CBCEFF; /* Danger color of level 200. */
+  --pgn-color-danger-300: #E1969DFF; /* Danger color of level 300. */
+  --pgn-color-danger-400: #D2626BFF; /* Danger color of level 400. */
+  --pgn-color-danger-500: var(--pgn-color-danger-base); /* Danger color of level 500. */
+  --pgn-color-danger-600: #B02934FF; /* Danger color of level 600. */
+  --pgn-color-danger-700: #9C242EFF; /* Danger color of level 700. */
+  --pgn-color-danger-800: #92222CFF; /* Danger color of level 800. */
+  --pgn-color-danger-900: #892029FF; /* Danger color of level 900. */
+  --pgn-color-action-default-gray-500: #575757FF;
+  --pgn-color-action-default-primary-100: #D1DBE1FF;
+  --pgn-color-action-default-primary-200: #A4B1C0FF;
+  --pgn-color-action-default-primary-300: #677F95FF;
+  --pgn-color-action-default-primary-400: #354A5FFF;
+  --pgn-color-action-default-primary-500: #051627FF;
+  --pgn-color-action-default-primary-600: #04111FFF;
+  --pgn-color-action-default-primary-700: #030C16FF;
+  --pgn-color-action-default-primary-800: #020A13FF;
+  --pgn-color-action-default-primary-900: #02080EFF;
+  --pgn-color-action-default-secondary-base: #2B2B2BFF;
+  --pgn-color-action-default-brand-100: #EACCDDFF;
+  --pgn-color-action-default-brand-200: #D99ABBFF;
+  --pgn-color-action-default-brand-300: #C05B91FF;
+  --pgn-color-action-default-brand-400: #903365FF;
+  --pgn-color-action-default-brand-500: #6A0039FF;
+  --pgn-color-action-default-brand-600: #5A0031FF;
+  --pgn-color-action-default-brand-700: #4B0028FF;
+  --pgn-color-action-default-brand-800: #430024FF;
+  --pgn-color-action-default-brand-900: #3B0020FF;
+  --pgn-color-action-default-success-base: #0F5737FF;
+  --pgn-color-action-default-info-base: #004C77FF;
+  --pgn-color-action-default-warning-base: #CCAE00FF;
+  --pgn-color-action-default-danger-base: #9A232EFF;
+  --pgn-color-action-default-light-100: #E4E4E4FF;
+  --pgn-color-action-default-light-200: #E2DED9FF;
+  --pgn-color-action-default-light-300: #D9D4D1FF;
+  --pgn-color-action-default-light-400: #D2CCC8FF;
+  --pgn-color-action-default-light-500: #CAC3BFFF;
+  --pgn-color-action-default-light-600: #B3ADAAFF;
+  --pgn-color-action-default-light-700: #9B9795FF;
+  --pgn-color-action-default-light-800: #908C8AFF;
+  --pgn-color-action-default-light-900: #85817FFF;
+  --pgn-color-action-default-dark-100: #D7DBDBFF;
+  --pgn-color-action-default-dark-200: #AEB7B1FF;
+  --pgn-color-action-default-dark-300: #78877DFF;
+  --pgn-color-action-default-dark-400: #46534AFF;
+  --pgn-color-action-default-dark-500: #142018FF;
+  --pgn-color-action-default-dark-600: #101913FF;
+  --pgn-color-action-default-dark-700: #0B130EFF;
+  --pgn-color-action-default-dark-800: #0A0F0CFF;
+  --pgn-color-action-default-dark-900: #080C09FF;
+  --pgn-content-carousel-control-bg-prev-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e");
+  --pgn-content-carousel-control-bg-next-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e");
+  --pgn-content-navbar-toggler-dark-icon-bg: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%23FFFFFF80' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  --pgn-content-navbar-toggler-light-icon-bg: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%2300000080' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  --pgn-border-color-nav-tabs-link-border-active: var(--pgn-color-primary-500);
+  --pgn-elevation-dropzone-hover-color: var(--pgn-color-info-300);
+  --pgn-elevation-dropzone-focus-color: var(--pgn-color-info-300);
+  --pgn-elevation-dropzone-error-color: var(--pgn-color-danger-300);
+  --pgn-elevation-form-control-range-thumb-focus-color: var(--pgn-color-body-bg);
+  --pgn-elevation-icon-button-box-shadow-secondary-base-color: var(--pgn-color-icon-button-text-secondary-base);
+  --pgn-elevation-icon-button-box-shadow-success-base-color: var(--pgn-color-icon-button-text-success-base);
+  --pgn-elevation-icon-button-box-shadow-warning-base-color: var(--pgn-color-icon-button-text-warning-base);
+  --pgn-elevation-icon-button-box-shadow-danger-base-color: var(--pgn-color-icon-button-text-danger-base);
+  --pgn-other-content-form-control-checkbox-indicator-icon-checked-valid: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='%23178253FF'/></svg>");
+  --pgn-other-content-form-control-checkbox-indicator-icon-checked-invalid: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='%23C32D3AFF'/></svg>");
+  --pgn-other-content-form-control-radio-indicator-icon-checked-valid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23178253FF'/%3e%3c/svg%3e");
+  --pgn-other-content-form-control-radio-indicator-icon-checked-invalid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23C32D3AFF'/%3e%3c/svg%3e");
+  --pgn-other-content-form-control-switch-indicator-icon-on: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23FFFFFFFF'/%3e%3c/svg%3e");
+  --pgn-other-content-form-control-select-indicator-icon: url('data:image/svg+xml,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.58984L12 13.1698L7.41 8.58984L6 9.99984L12 15.9998L18 9.99984L16.59 8.58984Z" fill="%23454545FF"/></svg>');
+  --pgn-color-input-btn-focus: var(--pgn-color-bg-active);
+  --pgn-color-table-caption: var(--pgn-color-text-muted); /* Table caption color. */
+  --pgn-color-theme-bg-secondary: var(--pgn-color-secondary-100); /* Theme-specific secondary background color. */
+  --pgn-color-theme-bg-success: var(--pgn-color-success-100); /* Theme-specific success background color. */
+  --pgn-color-theme-bg-info: var(--pgn-color-info-100); /* Theme-specific info background color. */
+  --pgn-color-theme-bg-warning: var(--pgn-color-warning-100); /* Theme-specific warning background color. */
+  --pgn-color-theme-bg-danger: var(--pgn-color-danger-100); /* Theme-specific danger background color. */
+  --pgn-color-theme-border-secondary: var(--pgn-color-secondary-200); /* Theme-specific secondary border color. */
+  --pgn-color-theme-border-success: var(--pgn-color-success-200); /* Theme-specific success border color. */
+  --pgn-color-theme-border-info: var(--pgn-color-info-200); /* Theme-specific info border color. */
+  --pgn-color-theme-border-warning: var(--pgn-color-warning-200); /* Theme-specific warning border color. */
+  --pgn-color-theme-border-danger: var(--pgn-color-danger-200); /* Theme-specific danger border color. */
+  --pgn-color-theme-focus-secondary: var(--pgn-color-secondary-500); /* Theme-specific secondary focus color. */
+  --pgn-color-theme-focus-success: var(--pgn-color-success-500); /* Theme-specific success focus color. */
+  --pgn-color-theme-focus-info: var(--pgn-color-info-500); /* Theme-specific info focus color. */
+  --pgn-color-theme-focus-warning: var(--pgn-color-warning-500); /* Theme-specific warning focus color. */
+  --pgn-color-theme-focus-danger: var(--pgn-color-danger-500); /* Theme-specific danger focus color. */
+  --pgn-color-theme-default-secondary: var(--pgn-color-secondary-500); /* Theme-specific secondary default color. */
+  --pgn-color-theme-default-success: var(--pgn-color-success-500); /* Theme-specific success default color. */
+  --pgn-color-theme-default-info: var(--pgn-color-info-500); /* Theme-specific info default color. */
+  --pgn-color-theme-default-warning: var(--pgn-color-warning-500); /* Theme-specific warning default color. */
+  --pgn-color-theme-default-danger: var(--pgn-color-danger-500); /* Theme-specific danger default color. */
+  --pgn-color-theme-hover-secondary: var(--pgn-color-secondary-700); /* Theme-specific secondary hover color. */
+  --pgn-color-theme-hover-success: var(--pgn-color-success-700); /* Theme-specific success hover color. */
+  --pgn-color-theme-hover-info: var(--pgn-color-info-700); /* Theme-specific info hover color. */
+  --pgn-color-theme-hover-warning: var(--pgn-color-warning-700); /* Theme-specific warning hover color. */
+  --pgn-color-theme-hover-danger: var(--pgn-color-danger-700); /* Theme-specific danger hover color. */
+  --pgn-color-theme-active-secondary: var(--pgn-color-secondary-900); /* Theme-specific secondary active color. */
+  --pgn-color-theme-active-success: var(--pgn-color-success-900); /* Theme-specific success active color. */
+  --pgn-color-theme-active-info: var(--pgn-color-info-900); /* Theme-specific info active color. */
+  --pgn-color-theme-active-warning: var(--pgn-color-warning-900); /* Theme-specific warning active color. */
+  --pgn-color-theme-active-danger: var(--pgn-color-danger-900); /* Theme-specific danger active color. */
+  --pgn-color-badge-focus-secondary: var(--pgn-color-badge-text-secondary);
+  --pgn-color-badge-focus-success: var(--pgn-color-badge-text-success);
+  --pgn-color-badge-focus-warning: var(--pgn-color-badge-text-warning);
+  --pgn-color-badge-focus-danger: var(--pgn-color-badge-text-danger);
+  --pgn-color-badge-focus-info: var(--pgn-color-badge-text-info);
+  --pgn-color-badge-focus-bg-secondary: #2B2B2BFF;
+  --pgn-color-badge-focus-bg-success: #0F5737FF;
+  --pgn-color-badge-focus-bg-danger: #9A232EFF;
+  --pgn-color-badge-focus-bg-warning: #CCAE00FF;
+  --pgn-color-badge-focus-bg-info: #004C77FF;
+  --pgn-color-badge-focus-box-shadow-secondary: #4545450D;
+  --pgn-color-badge-focus-box-shadow-success: #1782530D;
+  --pgn-color-badge-focus-box-shadow-danger: #C32D3A0D;
+  --pgn-color-badge-focus-box-shadow-warning: #FFD9000D;
+  --pgn-color-badge-focus-box-shadow-info: #006DAA0D;
+  --pgn-color-btn-text-danger: #FFFFFFFF;
+  --pgn-color-btn-text-info: #FFFFFFFF;
+  --pgn-color-btn-text-secondary: #FFFFFFFF;
+  --pgn-color-btn-text-success: #FFFFFFFF;
+  --pgn-color-btn-text-warning: #454545FF;
+  --pgn-color-btn-bg-inverse-danger: #FFFFFFFF;
+  --pgn-color-btn-bg-inverse-info: #FFFFFFFF;
+  --pgn-color-btn-bg-inverse-secondary: #FFFFFFFF;
+  --pgn-color-btn-bg-inverse-success: #FFFFFFFF;
+  --pgn-color-btn-bg-inverse-warning: #454545FF;
+  --pgn-color-btn-border-danger: var(--pgn-color-btn-bg-danger);
+  --pgn-color-btn-border-info: var(--pgn-color-btn-bg-info);
+  --pgn-color-btn-border-secondary: var(--pgn-color-btn-bg-secondary);
+  --pgn-color-btn-border-success: var(--pgn-color-btn-bg-success);
+  --pgn-color-btn-border-warning: var(--pgn-color-btn-bg-warning);
+  --pgn-color-btn-hover-text-outline-brand: var(--pgn-color-theme-hover-brand);
+  --pgn-color-btn-hover-text-inverse-outline-brand: var(--pgn-color-theme-hover-brand);
+  --pgn-color-btn-hover-text-inverse-danger: #A42631FF;
+  --pgn-color-btn-hover-text-outline-dark: var(--pgn-color-theme-hover-dark);
+  --pgn-color-btn-hover-text-inverse-outline-dark: var(--pgn-color-theme-hover-dark);
+  --pgn-color-btn-hover-text-inverse-info: #005484FF;
+  --pgn-color-btn-hover-text-outline-light: var(--pgn-color-theme-hover-light);
+  --pgn-color-btn-hover-text-inverse-outline-light: var(--pgn-color-theme-hover-light);
+  --pgn-color-btn-hover-text-outline-primary: var(--pgn-color-theme-hover-primary);
+  --pgn-color-btn-hover-text-inverse-outline-primary: var(--pgn-color-theme-hover-primary);
+  --pgn-color-btn-hover-text-inverse-secondary: #323232FF;
+  --pgn-color-btn-hover-text-inverse-success: #11623EFF;
+  --pgn-color-btn-hover-text-inverse-warning: #D9B800FF;
+  --pgn-color-btn-hover-bg-brand: var(--pgn-color-theme-hover-brand);
+  --pgn-color-btn-hover-bg-inverse-brand: #ECECECFF;
+  --pgn-color-btn-hover-bg-outline-danger: var(--pgn-color-danger-100);
+  --pgn-color-btn-hover-bg-inverse-outline-danger: var(--pgn-color-danger-100);
+  --pgn-color-btn-hover-bg-dark: var(--pgn-color-theme-hover-dark);
+  --pgn-color-btn-hover-bg-inverse-dark: #ECECECFF;
+  --pgn-color-btn-hover-bg-outline-info: var(--pgn-color-info-100);
+  --pgn-color-btn-hover-bg-inverse-outline-info: var(--pgn-color-info-100);
+  --pgn-color-btn-hover-bg-light: var(--pgn-color-theme-hover-light);
+  --pgn-color-btn-hover-bg-inverse-light: #323232FF;
+  --pgn-color-btn-hover-bg-primary: var(--pgn-color-theme-hover-primary);
+  --pgn-color-btn-hover-bg-inverse-primary: #ECECECFF;
+  --pgn-color-btn-hover-bg-outline-secondary: var(--pgn-color-secondary-100);
+  --pgn-color-btn-hover-bg-inverse-outline-secondary: var(--pgn-color-secondary-100);
+  --pgn-color-btn-hover-bg-outline-success: var(--pgn-color-success-100);
+  --pgn-color-btn-hover-bg-inverse-outline-success: var(--pgn-color-success-100);
+  --pgn-color-btn-hover-bg-outline-warning: var(--pgn-color-warning-100);
+  --pgn-color-btn-hover-bg-inverse-outline-warning: var(--pgn-color-warning-100);
+  --pgn-color-btn-hover-border-brand: var(--pgn-color-theme-hover-brand);
+  --pgn-color-btn-hover-border-outline-danger: var(--pgn-color-danger-900);
+  --pgn-color-btn-hover-border-dark: var(--pgn-color-theme-hover-dark);
+  --pgn-color-btn-hover-border-outline-info: var(--pgn-color-info-900);
+  --pgn-color-btn-hover-border-light: var(--pgn-color-theme-hover-light);
+  --pgn-color-btn-hover-border-primary: var(--pgn-color-theme-hover-primary);
+  --pgn-color-btn-hover-border-outline-secondary: var(--pgn-color-secondary-900);
+  --pgn-color-btn-hover-border-outline-success: var(--pgn-color-success-900);
+  --pgn-color-btn-hover-border-outline-warning: var(--pgn-color-warning-900);
+  --pgn-color-btn-active-text-inverse-danger: #9A232EFF;
+  --pgn-color-btn-active-text-inverse-info: #004C77FF;
+  --pgn-color-btn-active-text-inverse-secondary: #2B2B2BFF;
+  --pgn-color-btn-active-text-inverse-success: #0F5737FF;
+  --pgn-color-btn-active-text-inverse-warning: #CCAE00FF;
+  --pgn-color-btn-active-bg-brand: var(--pgn-color-theme-active-brand);
+  --pgn-color-btn-active-bg-outline-brand: var(--pgn-color-theme-bg-brand);
+  --pgn-color-btn-active-bg-inverse-outline-brand: var(--pgn-color-theme-bg-brand);
+  --pgn-color-btn-active-bg-dark: var(--pgn-color-theme-active-dark);
+  --pgn-color-btn-active-bg-outline-dark: var(--pgn-color-theme-bg-dark);
+  --pgn-color-btn-active-bg-inverse-outline-dark: var(--pgn-color-theme-bg-dark);
+  --pgn-color-btn-active-bg-light: var(--pgn-color-theme-active-light);
+  --pgn-color-btn-active-bg-outline-light: var(--pgn-color-theme-bg-light);
+  --pgn-color-btn-active-bg-inverse-outline-light: var(--pgn-color-theme-bg-light);
+  --pgn-color-btn-active-bg-primary: var(--pgn-color-theme-active-primary);
+  --pgn-color-btn-active-bg-outline-primary: var(--pgn-color-theme-bg-primary);
+  --pgn-color-btn-active-bg-inverse-outline-primary: var(--pgn-color-theme-bg-primary);
+  --pgn-color-btn-active-border-brand: var(--pgn-color-theme-active-brand);
+  --pgn-color-btn-active-border-outline-brand: var(--pgn-color-theme-active-brand);
+  --pgn-color-btn-active-border-dark: var(--pgn-color-theme-active-dark);
+  --pgn-color-btn-active-border-outline-dark: var(--pgn-color-theme-active-dark);
+  --pgn-color-btn-active-border-light: var(--pgn-color-theme-active-light);
+  --pgn-color-btn-active-border-outline-light: var(--pgn-color-theme-active-light);
+  --pgn-color-btn-active-border-primary: var(--pgn-color-theme-active-primary);
+  --pgn-color-btn-active-border-outline-primary: var(--pgn-color-theme-active-primary);
+  --pgn-color-btn-focus-text-brand: var(--pgn-color-btn-text-brand);
+  --pgn-color-btn-focus-text-inverse-danger: var(--pgn-color-btn-text-inverse-danger);
+  --pgn-color-btn-focus-text-outline-danger: var(--pgn-color-btn-text-outline-danger);
+  --pgn-color-btn-focus-text-dark: var(--pgn-color-btn-text-dark);
+  --pgn-color-btn-focus-text-outline-info: var(--pgn-color-btn-text-outline-info);
+  --pgn-color-btn-focus-text-inverse-info: var(--pgn-color-btn-text-inverse-info);
+  --pgn-color-btn-focus-text-light: var(--pgn-color-btn-text-light);
+  --pgn-color-btn-focus-text-primary: var(--pgn-color-btn-text-primary);
+  --pgn-color-btn-focus-text-outline-secondary: var(--pgn-color-btn-text-outline-secondary);
+  --pgn-color-btn-focus-text-outline-success: var(--pgn-color-btn-text-outline-success);
+  --pgn-color-btn-focus-text-inverse-success: var(--pgn-color-btn-text-inverse-success);
+  --pgn-color-btn-focus-text-outline-warning: var(--pgn-color-btn-text-outline-warning);
+  --pgn-color-btn-focus-text-inverse-warning: var(--pgn-color-btn-text-inverse-warning);
+  --pgn-color-btn-focus-border-brand: var(--pgn-color-btn-border-brand);
+  --pgn-color-btn-focus-border-outline-danger: var(--pgn-color-btn-border-outline-danger);
+  --pgn-color-btn-focus-border-dark: var(--pgn-color-btn-focus-bg-dark);
+  --pgn-color-btn-focus-border-outline-info: var(--pgn-color-btn-border-outline-info);
+  --pgn-color-btn-focus-border-light: var(--pgn-color-btn-border-light);
+  --pgn-color-btn-focus-border-primary: var(--pgn-color-btn-border-primary);
+  --pgn-color-btn-focus-border-secondary: var(--pgn-color-btn-bg-secondary);
+  --pgn-color-btn-focus-border-outline-secondary: var(--pgn-color-btn-border-outline-secondary);
+  --pgn-color-btn-focus-border-outline-success: var(--pgn-color-btn-border-outline-success);
+  --pgn-color-btn-focus-border-outline-warning: var(--pgn-color-btn-border-outline-warning);
+  --pgn-color-btn-focus-bg-inverse-brand: var(--pgn-color-btn-bg-inverse-brand);
+  --pgn-color-btn-focus-bg-danger: var(--pgn-color-btn-bg-danger);
+  --pgn-color-btn-focus-bg-inverse-dark: var(--pgn-color-btn-bg-inverse-dark);
+  --pgn-color-btn-focus-bg-info: var(--pgn-color-btn-bg-info);
+  --pgn-color-btn-focus-bg-inverse-light: var(--pgn-color-btn-bg-inverse-light);
+  --pgn-color-btn-focus-bg-inverse-primary: var(--pgn-color-btn-bg-inverse-primary);
+  --pgn-color-btn-focus-bg-secondary: var(--pgn-color-btn-bg-secondary);
+  --pgn-color-btn-focus-bg-success: var(--pgn-color-btn-bg-success);
+  --pgn-color-btn-focus-bg-warning: var(--pgn-color-btn-bg-warning);
+  --pgn-color-btn-focus-outline-brand: var(--pgn-color-theme-focus-brand);
+  --pgn-color-btn-focus-outline-outline-brand: var(--pgn-color-theme-focus-brand);
+  --pgn-color-btn-focus-outline-inverse-outline-brand: var(--pgn-color-btn-focus-border-inverse-outline-brand);
+  --pgn-color-btn-focus-outline-dark: var(--pgn-color-theme-focus-dark);
+  --pgn-color-btn-focus-outline-outline-dark: var(--pgn-color-theme-focus-dark);
+  --pgn-color-btn-focus-outline-inverse-outline-info: var(--pgn-color-btn-focus-border-inverse-outline-info);
+  --pgn-color-btn-focus-outline-outline-light: var(--pgn-color-theme-focus-light);
+  --pgn-color-btn-focus-outline-inverse-outline-light: var(--pgn-color-btn-focus-border-inverse-outline-light);
+  --pgn-color-btn-focus-outline-primary: var(--pgn-color-theme-focus-primary);
+  --pgn-color-btn-focus-outline-outline-primary: var(--pgn-color-theme-focus-primary);
+  --pgn-color-btn-focus-outline-inverse-outline-success: var(--pgn-color-btn-focus-border-inverse-outline-success);
+  --pgn-color-btn-focus-outline-tertiary: var(--pgn-color-theme-focus-primary);
+  --pgn-color-btn-disabled-text-brand: var(--pgn-color-btn-text-brand);
+  --pgn-color-btn-disabled-text-dark: var(--pgn-color-btn-text-dark);
+  --pgn-color-btn-disabled-text-outline-info: var(--pgn-color-btn-text-outline-info);
+  --pgn-color-btn-disabled-text-light: var(--pgn-color-btn-text-light);
+  --pgn-color-btn-disabled-text-primary: var(--pgn-color-btn-text-primary);
+  --pgn-color-btn-disabled-text-outline-success: var(--pgn-color-btn-text-outline-success);
+  --pgn-color-btn-disabled-text-outline-warning: var(--pgn-color-btn-text-outline-warning);
+  --pgn-color-btn-disabled-bg-danger: var(--pgn-color-btn-bg-danger);
+  --pgn-color-btn-disabled-bg-info: var(--pgn-color-btn-bg-info);
+  --pgn-color-btn-disabled-bg-secondary: var(--pgn-color-btn-bg-secondary);
+  --pgn-color-btn-disabled-bg-success: var(--pgn-color-btn-bg-success);
+  --pgn-color-btn-disabled-bg-warning: var(--pgn-color-btn-bg-warning);
+  --pgn-color-btn-disabled-border-brand: var(--pgn-color-btn-border-brand);
+  --pgn-color-btn-disabled-border-outline-danger: var(--pgn-color-btn-border-outline-danger);
+  --pgn-color-btn-disabled-border-dark: var(--pgn-color-btn-border-dark);
+  --pgn-color-btn-disabled-border-info: var(--pgn-color-btn-bg-info);
+  --pgn-color-btn-disabled-border-outline-info: var(--pgn-color-btn-border-outline-info);
+  --pgn-color-btn-disabled-border-light: var(--pgn-color-btn-border-light);
+  --pgn-color-btn-disabled-border-primary: var(--pgn-color-btn-border-primary);
+  --pgn-color-btn-disabled-border-outline-success: var(--pgn-color-btn-border-outline-success);
+  --pgn-color-btn-disabled-border-outline-warning: var(--pgn-color-btn-border-outline-warning);
+  --pgn-color-btn-disabled-link: var(--pgn-color-disabled);
+  --pgn-color-card-border-focus-dark: var(--pgn-color-theme-focus-primary);
+  --pgn-color-chip-outline-light: var(--pgn-color-chip-label-base);
+  --pgn-color-dropdown-link-active-bg: var(--pgn-color-bg-active);
+  --pgn-color-dropdown-link-disabled: var(--pgn-color-disabled);
+  --pgn-color-dropzone-error-wrapper: var(--pgn-color-danger-500);
+  --pgn-color-form-input-group-addon-border: var(--pgn-color-form-input-border);
+  --pgn-color-form-input-focus-border: var(--pgn-color-input-focus);
+  --pgn-color-form-input-focus-bg: var(--pgn-color-form-input-bg-base);
+  --pgn-color-form-control-indicator-bg-base: var(--pgn-color-form-input-bg-base);
+  --pgn-color-form-control-indicator-checked-base: var(--pgn-color-bg-active);
+  --pgn-color-form-control-indicator-checked-bg-base: var(--pgn-color-bg-active);
+  --pgn-color-form-control-indicator-active-bg: var(--pgn-color-bg-active);
+  --pgn-color-form-control-label-disabled: var(--pgn-color-disabled);
+  --pgn-color-form-control-label-floating-text: #FFFFFF1A;
+  --pgn-color-form-control-checkbox-indicator-indeterminate-bg: var(--pgn-color-bg-active);
+  --pgn-color-form-control-select-disabled: var(--pgn-color-disabled);
+  --pgn-color-form-control-select-bg-base: var(--pgn-color-form-input-bg-base);
+  --pgn-color-form-control-select-border-base: var(--pgn-color-form-input-border);
+  --pgn-color-form-control-range-thumb-bg-base: var(--pgn-color-bg-active);
+  --pgn-color-form-control-range-thumb-bg-disabled: var(--pgn-color-disabled);
+  --pgn-color-form-control-range-thumb-bg-active: #000000FF;
+  --pgn-color-form-control-file-bg-base: var(--pgn-color-form-input-bg-base);
+  --pgn-color-form-control-file-button-base: var(--pgn-color-form-control-file-base);
+  --pgn-color-form-control-file-border-base: var(--pgn-color-form-input-border);
+  --pgn-color-form-feedback-icon-valid: var(--pgn-color-form-feedback-valid);
+  --pgn-color-form-feedback-icon-invalid: var(--pgn-color-form-feedback-invalid);
+  --pgn-color-form-feedback-tooltip-valid: #FFFFFFFF;
+  --pgn-color-form-feedback-tooltip-bg-valid: #178253E6;
+  --pgn-color-form-feedback-tooltip-bg-invalid: #C32D3AE6;
+  --pgn-color-form-feedback-tooltip-box-shadow-focus-valid: #17825340;
+  --pgn-color-form-feedback-tooltip-box-shadow-focus-invalid: #C32D3A40;
+  --pgn-color-form-feedback-checked-valid: #1FAD6FFF;
+  --pgn-color-form-feedback-checked-invalid: #D64D59FF;
+  --pgn-color-icon-button-bg-secondary-active-hover: var(--pgn-color-icon-button-bg-secondary-active-base);
+  --pgn-color-icon-button-bg-secondary-active-focus: var(--pgn-color-icon-button-bg-secondary-active-base);
+  --pgn-color-icon-button-bg-success-active-hover: var(--pgn-color-icon-button-bg-success-active-base);
+  --pgn-color-icon-button-bg-success-active-focus: var(--pgn-color-icon-button-bg-success-active-base);
+  --pgn-color-icon-button-bg-warning-active-hover: var(--pgn-color-icon-button-bg-warning-active-base);
+  --pgn-color-icon-button-bg-warning-active-focus: var(--pgn-color-icon-button-bg-warning-active-base);
+  --pgn-color-icon-button-bg-danger-active-hover: var(--pgn-color-icon-button-bg-danger-active-base);
+  --pgn-color-icon-button-bg-danger-active-focus: var(--pgn-color-icon-button-bg-danger-active-base);
+  --pgn-color-icon-button-text-secondary-focus: var(--pgn-color-icon-button-text-secondary-base);
+  --pgn-color-icon-button-text-secondary-inverse-active-hover: var(--pgn-color-icon-button-text-secondary-inverse-active-base);
+  --pgn-color-icon-button-text-secondary-inverse-active-focus: var(--pgn-color-icon-button-text-secondary-inverse-active-base);
+  --pgn-color-icon-button-text-success-focus: var(--pgn-color-icon-button-text-success-base);
+  --pgn-color-icon-button-text-success-inverse-active-hover: var(--pgn-color-icon-button-text-success-inverse-active-base);
+  --pgn-color-icon-button-text-success-inverse-active-focus: var(--pgn-color-icon-button-text-success-inverse-active-base);
+  --pgn-color-icon-button-text-warning-focus: var(--pgn-color-icon-button-text-warning-base);
+  --pgn-color-icon-button-text-warning-inverse-active-hover: var(--pgn-color-icon-button-text-warning-inverse-active-base);
+  --pgn-color-icon-button-text-warning-inverse-active-focus: var(--pgn-color-icon-button-text-warning-inverse-active-base);
+  --pgn-color-icon-button-text-danger-focus: var(--pgn-color-icon-button-text-danger-base);
+  --pgn-color-icon-button-text-danger-inverse-active-hover: var(--pgn-color-icon-button-text-danger-inverse-active-base);
+  --pgn-color-icon-button-text-danger-inverse-active-focus: var(--pgn-color-icon-button-text-danger-inverse-active-base);
+  --pgn-color-image-thumbnail-bg: var(--pgn-color-body-bg);
+  --pgn-color-menu-item-hover-bg: var(--pgn-color-btn-hover-bg-tertiary);
+  --pgn-color-menu-item-focus-bg: var(--pgn-color-btn-active-bg-tertiary);
+  --pgn-color-nav-tabs-inverse-link-bg-hover: var(--pgn-color-nav-tabs-inverse-link-border-bottom);
+  --pgn-color-nav-pills-base-link-active-bg: var(--pgn-color-bg-active);
+  --pgn-color-nav-pills-base-link-border: var(--pgn-color-nav-tabs-base-border-base);
+  --pgn-color-nav-pills-inverse-link-text-active-focus: var(--pgn-color-nav-pills-inverse-link-text-active);
+  --pgn-color-nav-pills-inverse-link-border-active-hover: var(--pgn-color-nav-pills-inverse-link-border-base);
+  --pgn-color-nav-pills-inverse-link-bg-hover: var(--pgn-color-nav-pills-inverse-link-border-base);
+  --pgn-color-nav-pills-inverse-link-bg-active-hover: var(--pgn-color-nav-pills-inverse-link-border-base);
+  --pgn-color-navbar-dark-brand-text: var(--pgn-color-navbar-dark-active);
+  --pgn-color-navbar-dark-brand-hover: var(--pgn-color-navbar-dark-active);
+  --pgn-color-page-banner-bg-warning: var(--pgn-color-warning-100);
+  --pgn-color-pagination-text-disabled: var(--pgn-color-disabled);
+  --pgn-color-pagination-bg-active: var(--pgn-color-bg-active);
+  --pgn-color-popover-arrow-base: var(--pgn-color-popover-bg);
+  --pgn-color-popover-success-bg: var(--pgn-color-success-100);
+  --pgn-color-popover-success-icon: var(--pgn-color-success-500);
+  --pgn-color-popover-warning-bg: var(--pgn-color-warning-100);
+  --pgn-color-popover-warning-icon: var(--pgn-color-warning-500);
+  --pgn-color-popover-danger-bg: var(--pgn-color-danger-100);
+  --pgn-color-popover-danger-icon: var(--pgn-color-danger-500);
+  --pgn-color-product-tour-checkpoint-arrow-border-top: var(--pgn-color-product-tour-checkpoint-bg);
+  --pgn-color-stepper-header-step-description-error: var(--pgn-color-stepper-header-step-bubble-error);
+  --pgn-color-tab-more-link-dropdown-toggle-btn-border-focus: var(--pgn-color-tab-more-link-dropdown-toggle-bg-focus);
+  --pgn-color-tab-more-link-dropdown-toggle-text-hover: var(--pgn-color-tab-more-link-dropdown-toggle-bg-focus);
+  --pgn-color-tab-more-link-dropdown-toggle-border-focus: var(--pgn-color-tab-more-link-dropdown-toggle-bg-focus);
+  --pgn-color-tab-inverse-pills-link-dropdown-toggle-text-active: var(--pgn-color-tab-inverse-pills-link-dropdown-toggle-text-focus);
+  --pgn-color-link-base: var(--pgn-color-info-500);
+  --pgn-color-link-inline-base: var(--pgn-color-info-500);
+  --pgn-color-link-muted-hover: #020911FF;
+  --pgn-color-link-muted-inline-decoration: #0A30554D;
+  --pgn-color-link-muted-inline-hover-base: #020911FF;
+  --pgn-color-link-brand-hover: #51002BFF;
+  --pgn-color-link-brand-inline-decoration: #9D00544D;
+  --pgn-color-link-brand-inline-hover-base: #51002BFF;
+  --pgn-color-list-group-active-bg: var(--pgn-color-bg-active);
+  --pgn-color-action-default-secondary-100: #DBDBDBFF;
+  --pgn-color-action-default-secondary-200: #B8B8B8FF;
+  --pgn-color-action-default-secondary-300: #898989FF;
+  --pgn-color-action-default-secondary-400: #5A5A5AFF;
+  --pgn-color-action-default-secondary-500: #2B2B2BFF;
+  --pgn-color-action-default-secondary-600: #252525FF;
+  --pgn-color-action-default-secondary-700: #1E1E1EFF;
+  --pgn-color-action-default-secondary-800: #1A1A1AFF;
+  --pgn-color-action-default-secondary-900: #161616FF;
+  --pgn-color-action-default-success-100: #CFE7DDFF;
+  --pgn-color-action-default-success-200: #A4CEBBFF;
+  --pgn-color-action-default-success-300: #6AAF90FF;
+  --pgn-color-action-default-success-400: #407F63FF;
+  --pgn-color-action-default-success-500: #0F5737FF;
+  --pgn-color-action-default-success-600: #0D4A2FFF;
+  --pgn-color-action-default-success-700: #0A3D26FF;
+  --pgn-color-action-default-success-800: #093723FF;
+  --pgn-color-action-default-success-900: #08301EFF;
+  --pgn-color-action-default-info-100: #CADFEDFF;
+  --pgn-color-action-default-info-200: #99C5DDFF;
+  --pgn-color-action-default-info-300: #5AA0C8FF;
+  --pgn-color-action-default-info-400: #337599FF;
+  --pgn-color-action-default-info-500: #004C77FF;
+  --pgn-color-action-default-info-600: #004166FF;
+  --pgn-color-action-default-info-700: #003655FF;
+  --pgn-color-action-default-info-800: #00314DFF;
+  --pgn-color-action-default-info-900: #002B44FF;
+  --pgn-color-action-default-warning-100: #FFF6BDFF;
+  --pgn-color-action-default-warning-200: #FFEF8CFF;
+  --pgn-color-action-default-warning-300: #FFE44DFF;
+  --pgn-color-action-default-warning-400: #FFDC0DFF;
+  --pgn-color-action-default-warning-500: #CCAE00FF;
+  --pgn-color-action-default-warning-600: #B39800FF;
+  --pgn-color-action-default-warning-700: #998300FF;
+  --pgn-color-action-default-warning-800: #8C7700FF;
+  --pgn-color-action-default-warning-900: #806D00FF;
+  --pgn-color-action-default-danger-100: #EFCBCFFF;
+  --pgn-color-action-default-danger-200: #E5A3A9FF;
+  --pgn-color-action-default-danger-300: #D66E78FF;
+  --pgn-color-action-default-danger-400: #C73A46FF;
+  --pgn-color-action-default-danger-500: #9A232EFF;
+  --pgn-color-action-default-danger-600: #871F28FF;
+  --pgn-color-action-default-danger-700: #731A22FF;
+  --pgn-color-action-default-danger-800: #691820FF;
+  --pgn-color-action-default-danger-900: #60161DFF;
+  --pgn-border-color-nav-tabs-link-border-hover-bottom: var(--pgn-color-nav-tabs-base-border-base);
+  --pgn-border-color-nav-tabs-link-border-focus: var(--pgn-color-nav-tabs-base-link-active-text);
+  --pgn-elevation-form-control-select-border-focus-color: var(--pgn-color-input-btn-focus);
+  --pgn-elevation-pagination-focus-box-shadow-color: var(--pgn-color-input-btn-focus);
+  --pgn-elevation-input-btn-focus-box-shadow-color: var(--pgn-color-input-btn-focus);
+  --pgn-other-content-form-control-checkbox-indicator-icon-checked-base: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='%230A3055FF'/></svg>");
+  --pgn-other-content-form-control-radio-indicator-icon-checked-base: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%230A3055FF'/%3e%3c/svg%3e");
+  --pgn-other-content-form-control-switch-indicator-icon-off: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%230A3055FF'/%3e%3c/svg%3e");
+  --pgn-other-content-form-control-select-bg-color: var(--pgn-color-form-control-select-bg-base);
+  --pgn-other-content-form-control-select-bg-image: var(--pgn-other-content-form-control-select-indicator-icon);
+  --pgn-other-content-form-feedback-icon-valid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23178253FF' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+  --pgn-other-content-form-feedback-icon-invalid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23C32D3AFF' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23C32D3AFF' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E");
+  --pgn-color-alert-icon-success: var(--pgn-color-theme-default-success);
+  --pgn-color-alert-icon-info: var(--pgn-color-theme-default-info);
+  --pgn-color-alert-icon-danger: var(--pgn-color-theme-default-danger);
+  --pgn-color-alert-icon-warning: var(--pgn-color-theme-default-warning);
+  --pgn-color-alert-bg-success: var(--pgn-color-theme-bg-success);
+  --pgn-color-alert-bg-info: var(--pgn-color-theme-bg-info);
+  --pgn-color-alert-bg-danger: var(--pgn-color-theme-bg-danger);
+  --pgn-color-alert-bg-warning: var(--pgn-color-theme-bg-warning);
+  --pgn-color-alert-border-success: var(--pgn-color-theme-border-success);
+  --pgn-color-alert-border-info: var(--pgn-color-theme-border-info);
+  --pgn-color-alert-border-danger: var(--pgn-color-theme-border-danger);
+  --pgn-color-alert-border-warning: var(--pgn-color-theme-border-warning);
+  --pgn-color-btn-hover-text-brand: #FFFFFFFF;
+  --pgn-color-btn-hover-text-outline-danger: var(--pgn-color-theme-hover-danger);
+  --pgn-color-btn-hover-text-inverse-outline-danger: var(--pgn-color-theme-hover-danger);
+  --pgn-color-btn-hover-text-dark: #FFFFFFFF;
+  --pgn-color-btn-hover-text-outline-info: var(--pgn-color-theme-hover-info);
+  --pgn-color-btn-hover-text-inverse-outline-info: var(--pgn-color-theme-hover-info);
+  --pgn-color-btn-hover-text-light: #414141FF;
+  --pgn-color-btn-hover-text-primary: #FFFFFFFF;
+  --pgn-color-btn-hover-text-outline-secondary: var(--pgn-color-theme-hover-secondary);
+  --pgn-color-btn-hover-text-inverse-outline-secondary: var(--pgn-color-theme-hover-secondary);
+  --pgn-color-btn-hover-text-outline-success: var(--pgn-color-theme-hover-success);
+  --pgn-color-btn-hover-text-inverse-outline-success: var(--pgn-color-theme-hover-success);
+  --pgn-color-btn-hover-text-outline-warning: var(--pgn-color-theme-hover-warning);
+  --pgn-color-btn-hover-text-inverse-outline-warning: var(--pgn-color-theme-hover-warning);
+  --pgn-color-btn-hover-bg-danger: var(--pgn-color-theme-hover-danger);
+  --pgn-color-btn-hover-bg-inverse-danger: #ECECECFF;
+  --pgn-color-btn-hover-bg-info: var(--pgn-color-theme-hover-info);
+  --pgn-color-btn-hover-bg-inverse-info: #ECECECFF;
+  --pgn-color-btn-hover-bg-secondary: var(--pgn-color-theme-hover-secondary);
+  --pgn-color-btn-hover-bg-inverse-secondary: #ECECECFF;
+  --pgn-color-btn-hover-bg-success: var(--pgn-color-theme-hover-success);
+  --pgn-color-btn-hover-bg-inverse-success: #ECECECFF;
+  --pgn-color-btn-hover-bg-warning: var(--pgn-color-theme-hover-warning);
+  --pgn-color-btn-hover-bg-inverse-warning: #323232FF;
+  --pgn-color-btn-hover-border-danger: var(--pgn-color-theme-hover-danger);
+  --pgn-color-btn-hover-border-info: var(--pgn-color-theme-hover-info);
+  --pgn-color-btn-hover-border-secondary: var(--pgn-color-theme-hover-secondary);
+  --pgn-color-btn-hover-border-success: var(--pgn-color-theme-hover-success);
+  --pgn-color-btn-hover-border-warning: var(--pgn-color-theme-hover-warning);
+  --pgn-color-btn-active-text-brand: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-brand: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-brand: #454545FF;
+  --pgn-color-btn-active-text-dark: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-dark: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-dark: #454545FF;
+  --pgn-color-btn-active-text-light: #313131FF;
+  --pgn-color-btn-active-text-outline-light: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-light: #454545FF;
+  --pgn-color-btn-active-text-primary: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-primary: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-primary: #454545FF;
+  --pgn-color-btn-active-bg-danger: var(--pgn-color-theme-active-danger);
+  --pgn-color-btn-active-bg-outline-danger: var(--pgn-color-theme-bg-danger);
+  --pgn-color-btn-active-bg-inverse-outline-danger: var(--pgn-color-theme-bg-danger);
+  --pgn-color-btn-active-bg-info: var(--pgn-color-theme-active-info);
+  --pgn-color-btn-active-bg-outline-info: var(--pgn-color-theme-bg-info);
+  --pgn-color-btn-active-bg-inverse-outline-info: var(--pgn-color-theme-bg-info);
+  --pgn-color-btn-active-bg-secondary: var(--pgn-color-theme-active-secondary);
+  --pgn-color-btn-active-bg-outline-secondary: var(--pgn-color-theme-bg-secondary);
+  --pgn-color-btn-active-bg-inverse-outline-secondary: var(--pgn-color-theme-bg-secondary);
+  --pgn-color-btn-active-bg-success: var(--pgn-color-theme-active-success);
+  --pgn-color-btn-active-bg-outline-success: var(--pgn-color-theme-bg-success);
+  --pgn-color-btn-active-bg-inverse-outline-success: var(--pgn-color-theme-bg-success);
+  --pgn-color-btn-active-bg-warning: var(--pgn-color-theme-active-warning);
+  --pgn-color-btn-active-bg-outline-warning: var(--pgn-color-theme-bg-warning);
+  --pgn-color-btn-active-bg-inverse-outline-warning: var(--pgn-color-theme-bg-warning);
+  --pgn-color-btn-active-border-danger: var(--pgn-color-theme-active-danger);
+  --pgn-color-btn-active-border-outline-danger: var(--pgn-color-theme-active-danger);
+  --pgn-color-btn-active-border-info: var(--pgn-color-theme-active-info);
+  --pgn-color-btn-active-border-outline-info: var(--pgn-color-theme-active-info);
+  --pgn-color-btn-active-border-secondary: var(--pgn-color-theme-active-secondary);
+  --pgn-color-btn-active-border-outline-secondary: var(--pgn-color-theme-active-secondary);
+  --pgn-color-btn-active-border-success: var(--pgn-color-theme-active-success);
+  --pgn-color-btn-active-border-outline-success: var(--pgn-color-theme-active-success);
+  --pgn-color-btn-active-border-warning: var(--pgn-color-theme-active-warning);
+  --pgn-color-btn-active-border-outline-warning: var(--pgn-color-theme-active-warning);
+  --pgn-color-btn-focus-text-danger: var(--pgn-color-btn-text-danger);
+  --pgn-color-btn-focus-text-info: var(--pgn-color-btn-text-info);
+  --pgn-color-btn-focus-text-secondary: var(--pgn-color-btn-text-secondary);
+  --pgn-color-btn-focus-text-success: var(--pgn-color-btn-text-success);
+  --pgn-color-btn-focus-text-warning: var(--pgn-color-btn-text-warning);
+  --pgn-color-btn-focus-border-danger: var(--pgn-color-btn-focus-bg-danger);
+  --pgn-color-btn-focus-border-info: var(--pgn-color-btn-border-info);
+  --pgn-color-btn-focus-border-success: var(--pgn-color-btn-border-success);
+  --pgn-color-btn-focus-border-warning: var(--pgn-color-btn-border-warning);
+  --pgn-color-btn-focus-bg-inverse-danger: var(--pgn-color-btn-bg-inverse-danger);
+  --pgn-color-btn-focus-bg-inverse-info: var(--pgn-color-btn-bg-inverse-info);
+  --pgn-color-btn-focus-bg-inverse-secondary: var(--pgn-color-btn-bg-inverse-secondary);
+  --pgn-color-btn-focus-bg-inverse-success: var(--pgn-color-btn-bg-inverse-success);
+  --pgn-color-btn-focus-bg-inverse-warning: var(--pgn-color-btn-bg-inverse-warning);
+  --pgn-color-btn-focus-outline-danger: var(--pgn-color-theme-focus-danger);
+  --pgn-color-btn-focus-outline-outline-danger: var(--pgn-color-theme-focus-danger);
+  --pgn-color-btn-focus-outline-info: var(--pgn-color-theme-focus-info);
+  --pgn-color-btn-focus-outline-outline-info: var(--pgn-color-theme-focus-info);
+  --pgn-color-btn-focus-outline-secondary: var(--pgn-color-theme-focus-secondary);
+  --pgn-color-btn-focus-outline-outline-secondary: var(--pgn-color-theme-focus-secondary);
+  --pgn-color-btn-focus-outline-success: var(--pgn-color-theme-focus-success);
+  --pgn-color-btn-focus-outline-outline-success: var(--pgn-color-theme-focus-success);
+  --pgn-color-btn-focus-outline-warning: var(--pgn-color-theme-focus-warning);
+  --pgn-color-btn-focus-outline-outline-warning: var(--pgn-color-theme-focus-warning);
+  --pgn-color-btn-disabled-text-outline-brand: var(--pgn-color-btn-hover-text-outline-brand);
+  --pgn-color-btn-disabled-text-danger: var(--pgn-color-btn-text-danger);
+  --pgn-color-btn-disabled-text-info: var(--pgn-color-btn-text-info);
+  --pgn-color-btn-disabled-text-outline-light: var(--pgn-color-btn-hover-text-outline-light);
+  --pgn-color-btn-disabled-text-outline-primary: var(--pgn-color-btn-hover-text-outline-primary);
+  --pgn-color-btn-disabled-text-secondary: var(--pgn-color-btn-text-secondary);
+  --pgn-color-btn-disabled-text-success: var(--pgn-color-btn-text-success);
+  --pgn-color-btn-disabled-text-warning: var(--pgn-color-btn-text-warning);
+  --pgn-color-btn-disabled-border-danger: var(--pgn-color-btn-border-danger);
+  --pgn-color-btn-disabled-border-outline-dark: var(--pgn-color-btn-hover-text-outline-dark);
+  --pgn-color-btn-disabled-border-outline-light: var(--pgn-color-btn-hover-text-outline-light);
+  --pgn-color-btn-disabled-border-outline-primary: var(--pgn-color-btn-hover-text-outline-primary);
+  --pgn-color-btn-disabled-border-success: var(--pgn-color-btn-border-success);
+  --pgn-color-btn-disabled-border-warning: var(--pgn-color-btn-border-warning);
+  --pgn-color-form-control-indicator-checked-border-base: var(--pgn-color-form-control-indicator-checked-base);
+  --pgn-color-form-control-indicator-checked-border-focus: var(--pgn-color-form-input-focus-border);
+  --pgn-color-form-control-indicator-active-border: var(--pgn-color-form-control-indicator-active-bg);
+  --pgn-color-form-control-checkbox-indicator-indeterminate-base: var(--pgn-color-form-control-indicator-checked-base);
+  --pgn-color-form-control-checkbox-indicator-indeterminate-border: var(--pgn-color-form-control-checkbox-indicator-indeterminate-bg);
+  --pgn-color-form-control-select-border-focus: var(--pgn-color-form-input-focus-border);
+  --pgn-color-form-control-file-border-focus: var(--pgn-color-form-input-focus-border);
+  --pgn-color-nav-tabs-inverse-link-bg-active: var(--pgn-color-nav-tabs-inverse-link-bg-hover);
+  --pgn-color-pagination-text-base: var(--pgn-color-link-base);
+  --pgn-color-pagination-border-active: var(--pgn-color-pagination-bg-active);
+  --pgn-color-link-hover: #003C5EFF;
+  --pgn-color-link-inline-decoration: #006DAA4D;
+  --pgn-color-link-inline-hover-base: #003C5EFF;
+  --pgn-color-link-muted-inline-hover-decoration: #020911FF;
+  --pgn-color-link-brand-inline-hover-decoration: #51002BFF;
+  --pgn-color-list-group-active-border: var(--pgn-color-list-group-active-bg);
+  --pgn-other-content-form-control-checkbox-indicator-indeterminate-icon: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM17 13H7V11H17V13Z' fill='%230A3055FF'/></svg>");
+  --pgn-color-btn-hover-text-danger: #FFFFFFFF;
+  --pgn-color-btn-hover-text-info: #FFFFFFFF;
+  --pgn-color-btn-hover-text-secondary: #FFFFFFFF;
+  --pgn-color-btn-hover-text-success: #FFFFFFFF;
+  --pgn-color-btn-hover-text-warning: #414141FF;
+  --pgn-color-btn-active-text-danger: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-danger: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-danger: #454545FF;
+  --pgn-color-btn-active-text-info: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-info: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-info: #454545FF;
+  --pgn-color-btn-active-text-secondary: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-secondary: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-secondary: #454545FF;
+  --pgn-color-btn-active-text-success: #FFFFFFFF;
+  --pgn-color-btn-active-text-outline-success: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-success: #454545FF;
+  --pgn-color-btn-active-text-warning: #313131FF;
+  --pgn-color-btn-active-text-outline-warning: #454545FF;
+  --pgn-color-btn-active-text-inverse-outline-warning: #454545FF;
+  --pgn-color-btn-disabled-text-outline-danger: var(--pgn-color-btn-hover-text-outline-danger);
+  --pgn-color-pagination-text-hover: var(--pgn-color-link-hover);
+  --pgn-color-link-inline-hover-decoration: #003C5EFF;
 }

--- a/styles/scss/core/_variables.scss
+++ b/styles/scss/core/_variables.scss
@@ -851,7 +851,7 @@ $user-selects: all, auto, none !default;
 
 // Printing
 
-$print-page-size:                   var(--pgn-typography-print-page-size) !default;
+$print-page-size:                   var(--pgn-print-page-size) !default;
 $print-body-min-width:              map.get($grid-breakpoints, "lg") !default;
 
 // List group

--- a/tokens/src/core/global/other.json
+++ b/tokens/src/core/global/other.json
@@ -4,5 +4,10 @@
     "$type": "percentage",
     "source": "$theme-color-interval",
     "$value": "8%"
+  },
+  "print-page-size": {
+    "source": "$print-page-size",
+    "$value": "a3",
+    "$type": "text"
   }
 }

--- a/tokens/src/core/global/typography.json
+++ b/tokens/src/core/global/typography.json
@@ -276,11 +276,6 @@
           "$description": "Mobile display line height."
         }
       }
-    },
-    "print-page-size": {
-      "source": "$print-page-size",
-      "$value": "a3",
-      "$type": "dimension"
     }
   }
 }


### PR DESCRIPTION
## Description

This PR provides changes to correct the correct building of the token design.

- Changed type for design token `print-page-size` from `dimension` to `text`.
- Improved logging of Paragon CLI command errors.

More details: https://github.com/openedx/paragon/issues/3389

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
