### PR TITLE
fix: fixed incorrect form checkbox, radio, switch width

### DIFF
--- a/src/Form/_index.scss
+++ b/src/Form/_index.scss
@@ -380,6 +380,7 @@ select.form-control {
   appearance: none;
   height: $custom-control-indicator-size;
   width: $custom-control-indicator-size;
+  min-width: $custom-control-indicator-size;
   background-color: $custom-control-indicator-bg;
   border: solid $custom-control-indicator-border-width $custom-control-indicator-border-color;
   border-radius: $custom-checkbox-indicator-border-radius;
@@ -437,6 +438,7 @@ select.form-control {
 
 .pgn__form-switch-input {
   width: $custom-switch-width;
+  min-width: $custom-switch-width;
   border-radius: $custom-switch-indicator-border-radius;
   background-image: escape-svg($custom-switch-indicator-icon-off);
   background-position: left center;


### PR DESCRIPTION
## Description

Fixed incorrect width of Form.Checkbox, Form.Radio, and Form.Switch with long labels.

**Issue:** https://github.com/openedx/paragon/issues/3430

**Form.Radio**

<img width="288" alt="image" src="https://github.com/user-attachments/assets/5a835e1f-e3b5-40f8-92ec-90c21a9dc5cf" />


**Form.Checkbox**

<img width="289" alt="image" src="https://github.com/user-attachments/assets/612b4c29-d8e0-4923-8b0f-bc7afd0a53f6" />


**Form.Switch**

<img width="291" alt="image" src="https://github.com/user-attachments/assets/e7b6d1e7-0de9-4352-b3b4-78dcbb42322c" />

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
