### PR TITLE
fix: CardImageCup stretches image on Safari

### DIFF
--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -48,8 +48,8 @@ $card-footer-text-font-size:         $x-small-font-size;
 
 $card-image-horizontal-max-width:    240px !default;
 $card-image-horizontal-min-width:    $card-image-horizontal-max-width !default;
-$card-image-horizontal-min-height:   $card-image-horizontal-min-width !default;
 $card-image-vertical-max-height:     140px !default;
+$card-image-horizontal-min-height:   $card-image-vertical-max-height !default;
 $loading-skeleton-spacer:            .313rem !default;
 
 $card-focus-border-offset:           5px !default;

--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -48,6 +48,7 @@ $card-footer-text-font-size:         $x-small-font-size;
 
 $card-image-horizontal-max-width:    240px !default;
 $card-image-horizontal-min-width:    $card-image-horizontal-max-width !default;
+$card-image-horizontal-min-height:   $card-image-horizontal-min-width !default;
 $card-image-vertical-max-height:     140px !default;
 $loading-skeleton-spacer:            .313rem !default;
 

--- a/src/Card/_variables.scss
+++ b/src/Card/_variables.scss
@@ -49,7 +49,6 @@ $card-footer-text-font-size:         $x-small-font-size;
 $card-image-horizontal-max-width:    240px !default;
 $card-image-horizontal-min-width:    $card-image-horizontal-max-width !default;
 $card-image-vertical-max-height:     140px !default;
-$card-image-horizontal-min-height:   $card-image-vertical-max-height !default;
 $loading-skeleton-spacer:            .313rem !default;
 
 $card-focus-border-offset:           5px !default;

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -314,9 +314,9 @@ a.pgn__card {
 
       .pgn__card-image-cap {
         height: 100%;
-        max-width: inherit;
+        max-width: 100%;
         border-radius: $card-image-border-radius 0 0 $card-image-border-radius;
-        width: auto;
+        width: 100%;
         object-fit: cover;
       }
 

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -315,13 +315,13 @@ a.pgn__card {
 
       .pgn__card-image-cap {
         height: 100%;
-        max-width: 100%;
+        max-width: inherit;
         border-radius: $card-image-border-radius 0 0 $card-image-border-radius;
-        width: 100%;
+        width: auto;
         object-fit: cover;
         position: absolute;
-        top: 0;
         left: 0;
+        top: 0;
       }
 
       .pgn__card-logo-cap {

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -310,6 +310,7 @@ a.pgn__card {
     &.horizontal {
       max-width: $card-image-horizontal-max-width;
       min-width: $card-image-horizontal-min-width;
+      min-height: $card-image-horizontal-min-height;
       overflow: hidden;
 
       .pgn__card-image-cap {
@@ -318,6 +319,9 @@ a.pgn__card {
         border-radius: $card-image-border-radius 0 0 $card-image-border-radius;
         width: 100%;
         object-fit: cover;
+        position: absolute;
+        top: 0;
+        left: 0;
       }
 
       .pgn__card-logo-cap {

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -310,7 +310,6 @@ a.pgn__card {
     &.horizontal {
       max-width: $card-image-horizontal-max-width;
       min-width: $card-image-horizontal-min-width;
-      min-height: $card-image-horizontal-min-height;
       overflow: hidden;
 
       .pgn__card-image-cap {
@@ -319,9 +318,16 @@ a.pgn__card {
         border-radius: $card-image-border-radius 0 0 $card-image-border-radius;
         width: auto;
         object-fit: cover;
-        position: absolute;
-        left: 0;
-        top: 0;
+      }
+
+      // Safari doesn't resolve `height: 100%` on children of flex-stretched items.
+      // `display: flex` on the wrapper lets Safari stretch the image via flex instead.
+      @supports (-webkit-touch-callout: none) {
+        display: flex;
+
+        .pgn__card-image-cap {
+          height: auto;
+        }
       }
 
       .pgn__card-logo-cap {


### PR DESCRIPTION
## Description

In Safari browser, the image inside the Card component is not stretched in height correctly.

**Issue:** https://github.com/openedx/paragon/issues/3187

![image](https://github.com/user-attachments/assets/e24d098d-8306-4e7d-a439-fa160ab2fb1f)

**Result in Safari**

https://github.com/user-attachments/assets/9abfa1f8-1eb2-4ab5-b4a3-3b49897701d9

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
