### PR TITLE
fix: inherit `font-size` on `AlertModal` title and set `line-height` on all modal titles

### DIFF
--- a/src/Modal/AlertModal.jsx
+++ b/src/Modal/AlertModal.jsx
@@ -20,11 +20,11 @@ function AlertModal({
       <ModalDialog.Header>
         <ModalDialog.Title>
           {icon && (
-          <Icon
-            data-testid="title-icon"
-            src={icon}
-            className={classNames('pgn__alert-modal__title_icon')}
-          />
+            <Icon
+              data-testid="title-icon"
+              src={icon}
+              className={classNames('pgn__alert-modal__title_icon')}
+            />
           )}
           {props.title}
         </ModalDialog.Title>

--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -125,6 +125,7 @@
 
   .pgn__modal-title {
     font-size: $h3-font-size;
+    line-height: $h3-font-size * $headings-line-height;
     margin-inline-end: 3rem; // roughly accomodate the width of the close buttonn
     text-align: start;
   }

--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -310,7 +310,6 @@
   }
 
   .pgn__modal-title {
-    font-size: $h4-font-size;
     display: flex;
     flex-grow: 1;
     align-items: center;


### PR DESCRIPTION
## Description

https://github.com/openedx/paragon/issues/3129

The `AlertModal` title was previously styled with `$h4-font-size`, despite the [Figma](https://www.figma.com/design/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=7884-23068&t=4TzYaBHY725egi6R-4) showing it styled as an `h3`. The default modal title font size is `$h3-font-size`, so removing the `$h4-font-size` falls back to the standard `$h3-font-size` instead, as expected.

[context] This has often led to consuming MFEs to try to override the default `AlertModal` titles on their end vs. fixing the problem upstream (e.g., nesting an `h3` within the rendered `h2` leading to invalid HTML, not using the `title` prop, etc.).

### Figma

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/bfab4a38-f5a5-4ae2-a3c0-3854c131be11" />

### Original `AlertModal`

Left: `@openedx/brand-openedx`
Right: `@edx/brand-edx.org`

Note the `h4`-styled title and line-height issue with `@edx/brand-edx.org`.

<img width="1593" alt="image" src="https://github.com/user-attachments/assets/ced74073-7037-41e0-b745-539c2f19528a" />

### Updated `AlertModal`

Left: `@openedx/brand-openedx`
Right: `@edx/brand-edx.org`

Note the `h3`-styled title and resolved line-height issue with `@edx/brand-edx.org`.

<img width="1597" alt="image" src="https://github.com/user-attachments/assets/c98b42b0-5a18-4d90-84e2-fe94862ac732" />

### Deploy Preview

https://deploy-preview-3448--paragon-openedx-v22.netlify.app/components/modal/alert-modal/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
