### PR TITLE
fix: define displayName for all components with forwarded refs

### DIFF
--- a/component-generator/templates/index.jsx
+++ b/component-generator/templates/index.jsx
@@ -2,21 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const componentName = React.forwardRef(({ className, children }, ref) => (
+const ComponentName = React.forwardRef(({ className, children }, ref) => (
   <div ref={ref} className={classNames('pgn__css-class', className)}>
     {children}
   </div>
 ));
+ComponentName.displayName = 'ComponentName';
 
-componentName.defaultProps = {
-  className: undefined,
-};
-
-componentName.propTypes = {
+ComponentName.propTypes = {
   /** A class name to append to the base element. */
   className: PropTypes.string,
   /** Specifies contents of the component. */
   children: PropTypes.node.isRequired,
 };
 
-export default componentName;
+export default ComponentName;

--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -83,6 +83,7 @@ const Alert = React.forwardRef(({
     </BaseAlert>
   );
 });
+Alert.displayName = 'Alert';
 
 // This is needed to display a default prop for Alert.Heading element
 // Copied from react-bootstrap since BaseAlert.Heading component doesn't have defaultProps,

--- a/src/Annotation/index.jsx
+++ b/src/Annotation/index.jsx
@@ -21,6 +21,7 @@ const Annotation = React.forwardRef(({
     {children}
   </span>
 ));
+Annotation.displayName = 'Annotation';
 
 Annotation.defaultProps = {
   className: undefined,

--- a/src/AvatarButton/index.jsx
+++ b/src/AvatarButton/index.jsx
@@ -37,6 +37,7 @@ const AvatarButton = React.forwardRef(({
     </Button>
   );
 });
+AvatarButton.displayName = 'AvatarButton';
 
 AvatarButton.propTypes = {
   /** The button text */

--- a/src/Badge/index.jsx
+++ b/src/Badge/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import BaseBadge from 'react-bootstrap/Badge';
 
 const Badge = React.forwardRef((props, ref) => <BaseBadge {...props} ref={ref} />);
+Badge.displayName = 'Badge';
 
 const STYLE_VARIANTS = [
   'primary',

--- a/src/Card/CardBody.jsx
+++ b/src/Card/CardBody.jsx
@@ -7,6 +7,7 @@ const CardBody = React.forwardRef(({ className, children, ...rest }, ref) => (
     {children}
   </div>
 ));
+CardBody.displayName = 'CardBody';
 
 CardBody.propTypes = {
   /** Specifies the content of the component. */

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -60,6 +60,7 @@ const CardDeck = React.forwardRef(({
     </div>
   );
 });
+CardDeck.displayName = 'CardDeck';
 
 CardDeck.propTypes = {
   /** The class name for the CardDeck component */

--- a/src/Card/CardDivider.jsx
+++ b/src/Card/CardDivider.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 const CardDivider = React.forwardRef(({ className, ...props }, ref) => (
   <div className={classNames('pgn__card-divider', className)} ref={ref} {...props} />
 ));
+CardDivider.displayName = 'CardDivider';
 
 CardDivider.propTypes = {
   /** Specifies class name to append to the base element. */

--- a/src/Card/CardFooter.jsx
+++ b/src/Card/CardFooter.jsx
@@ -39,6 +39,7 @@ const CardFooter = React.forwardRef(({
     </div>
   );
 });
+CardFooter.displayName = 'CardFooter';
 
 CardFooter.propTypes = {
   /** Specifies contents of the component. */

--- a/src/Card/CardHeader.jsx
+++ b/src/Card/CardHeader.jsx
@@ -58,6 +58,7 @@ const CardHeader = React.forwardRef(({
     </div>
   );
 });
+CardHeader.displayName = 'CardHeader';
 
 CardHeader.propTypes = {
   /** Optional node to render on the top right of the card header,

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -92,6 +92,7 @@ const CardImageCap = React.forwardRef(({
     </div>
   );
 });
+CardImageCap.displayName = 'CardImageCap';
 
 CardImageCap.propTypes = {
   /** Specifies class name to append to the base element. */

--- a/src/Card/CardSection.jsx
+++ b/src/Card/CardSection.jsx
@@ -40,6 +40,7 @@ const CardSection = React.forwardRef(({
     </div>
   );
 });
+CardSection.displayName = 'CardSection';
 
 CardSection.propTypes = {
   /** Specifies class name to append to the base element. */

--- a/src/Card/CardStatus.jsx
+++ b/src/Card/CardStatus.jsx
@@ -56,6 +56,7 @@ const CardStatus = React.forwardRef(({
     </div>
   );
 });
+CardStatus.displayName = 'CardStatus';
 
 CardStatus.propTypes = {
   /** Specifies the content of the component. */

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -44,6 +44,7 @@ const Card = React.forwardRef(({
     </CardContextProvider>
   );
 });
+Card.displayName = 'Card';
 
 export { default as CardColumns } from 'react-bootstrap/CardColumns';
 export { default as CardDeck } from './CardDeck';

--- a/src/Carousel/index.jsx
+++ b/src/Carousel/index.jsx
@@ -8,10 +8,13 @@ export const CAROUSEL_NEXT_LABEL_TEXT = 'Next';
 export const CAROUSEL_PREV_LABEL_TEXT = 'Previous';
 
 const Carousel = React.forwardRef((props, ref) => <BaseCarousel {...props} ref={ref} />);
+Carousel.displayName = 'Carousel';
 
 const CarouselItem = React.forwardRef((props, ref) => <BaseCarouselItem {...props} ref={ref} />);
+CarouselItem.displayName = 'CarouselItem';
 
 const CarouselCaption = React.forwardRef((props, ref) => <BaseCarouselCaption {...props} ref={ref} />);
+CarouselCaption.displayName = 'CarouselCaption';
 
 Carousel.propTypes = {
   /** Specifies element type for this component. */

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -91,6 +91,7 @@ const Chip = React.forwardRef(({
     </div>
   );
 });
+Chip.displayName = 'Chip';
 
 Chip.propTypes = {
   /** Specifies the content of the `Chip`. */

--- a/src/ChipCarousel/index.tsx
+++ b/src/ChipCarousel/index.tsx
@@ -114,6 +114,7 @@ const ChipCarousel = React.forwardRef(({
     </div>
   );
 });
+ChipCarousel.displayName = 'ChipCarousel';
 
 ChipCarousel.propTypes = {
   /** Text describing the ChipCarousel for screen readers. */

--- a/src/Collapsible/index.jsx
+++ b/src/Collapsible/index.jsx
@@ -49,6 +49,7 @@ const Collapsible = React.forwardRef((props, ref) => {
     </Collapsible.Advanced>
   );
 });
+Collapsible.displayName = 'Collapsible';
 
 Collapsible.propTypes = {
   /** Specifies contents of the component. */

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -9,66 +9,64 @@ import DropdownDeprecated from './deprecated';
 import Button from '../Button';
 import IconButton from '../IconButton';
 
-const Dropdown = React.forwardRef(
-  // eslint-disable-next-line prefer-arrow-callback
-  function Dropdown({
-    show,
-    autoClose,
-    onToggle,
-    variant,
-    className,
-    ...rest
-  }, ref) {
-    const [internalShow, setInternalShow] = React.useState(show);
-    const isClosingPermitted = (source) => {
-      // autoClose=false only permits close on button click
-      if (autoClose === false) {
-        return source === 'click';
-      }
-      // autoClose=inside doesn't permit close on rootClose
-      if (autoClose === 'inside') {
-        return source !== 'rootClose';
-      }
-      // autoClose=outside doesn't permit close on select
-      if (autoClose === 'outside') {
-        return source !== 'select';
-      }
-      return true;
-    };
+const Dropdown = React.forwardRef(({
+  show,
+  autoClose,
+  onToggle,
+  variant,
+  className,
+  ...rest
+}, ref) => {
+  const [internalShow, setInternalShow] = React.useState(show);
+  const isClosingPermitted = (source) => {
+    // autoClose=false only permits close on button click
+    if (autoClose === false) {
+      return source === 'click';
+    }
+    // autoClose=inside doesn't permit close on rootClose
+    if (autoClose === 'inside') {
+      return source !== 'rootClose';
+    }
+    // autoClose=outside doesn't permit close on select
+    if (autoClose === 'outside') {
+      return source !== 'select';
+    }
+    return true;
+  };
 
-    const handleToggle = (isOpen, event, metadata) => {
-      if (isOpen) {
-        setInternalShow(true);
-        onToggle?.(isOpen, event, metadata);
-        return;
-      }
-      let { source } = { ...metadata };
+  const handleToggle = (isOpen, event, metadata) => {
+    if (isOpen) {
+      setInternalShow(true);
+      onToggle?.(isOpen, event, metadata);
+      return;
+    }
+    let { source } = { ...metadata };
 
-      if (event.currentTarget === document && (source !== 'keydown' || event.key === 'Escape')) {
-        source = 'rootClose';
-      }
-      if (isClosingPermitted(source)) {
-        setInternalShow(false);
-        onToggle?.(isOpen, event, metadata);
-      }
-    };
+    if (event.currentTarget === document && (source !== 'keydown' || event.key === 'Escape')) {
+      source = 'rootClose';
+    }
+    if (isClosingPermitted(source)) {
+      setInternalShow(false);
+      onToggle?.(isOpen, event, metadata);
+    }
+  };
 
-    return (
-      <BaseDropdown
-        className={classNames(
-          'pgn__dropdown',
-          `pgn__dropdown-${variant}`,
-          className,
-        )}
-        data-testid="dropdown"
-        onToggle={handleToggle}
-        ref={ref}
-        show={internalShow}
-        {...rest}
-      />
-    );
-  },
-);
+  return (
+    <BaseDropdown
+      className={classNames(
+        'pgn__dropdown',
+        `pgn__dropdown-${variant}`,
+        className,
+      )}
+      data-testid="dropdown"
+      onToggle={handleToggle}
+      ref={ref}
+      show={internalShow}
+      {...rest}
+    />
+  );
+});
+Dropdown.displayName = 'Dropdown';
 
 Dropdown.propTypes = {
   autoClose: PropTypes.oneOfType([
@@ -89,19 +87,17 @@ Dropdown.defaultProps = {
   variant: 'light',
 };
 
-const DropdownToggle = React.forwardRef(
-  // eslint-disable-next-line prefer-arrow-callback
-  function DropdownToggle({
-    as,
-    bsPrefix,
-    ...otherProps
-  }, ref) {
-    // hide arrow from the toggle if it is rendered as IconButton
-    // because it hinders the positioning of IconButton
-    const prefix = as === IconButton ? 'pgn__dropdown-toggle-iconbutton' : bsPrefix;
-    return <BaseDropdownToggle {...otherProps} as={as} bsPrefix={prefix} ref={ref} />;
-  },
-);
+const DropdownToggle = React.forwardRef(({
+  as,
+  bsPrefix,
+  ...otherProps
+}, ref) => {
+  // hide arrow from the toggle if it is rendered as IconButton
+  // because it hinders the positioning of IconButton
+  const prefix = as === IconButton ? 'pgn__dropdown-toggle-iconbutton' : bsPrefix;
+  return <BaseDropdownToggle {...otherProps} as={as} bsPrefix={prefix} ref={ref} />;
+});
+DropdownToggle.displayName = 'DropdownToggle';
 
 DropdownToggle.propTypes = {
   /** Specifies the base element. */
@@ -117,29 +113,26 @@ DropdownToggle.defaultProps = {
   bsPrefix: 'dropdown-toggle',
 };
 
-Dropdown.Item = React.forwardRef(
-  // eslint-disable-next-line prefer-arrow-callback
-  function DropdownItem({ className, ...otherProps }, ref) {
-    return (
-      <BaseDropdownItem
-        className={classNames(className, 'pgn__dropdown-item')}
-        ref={ref}
-        {...otherProps}
-      />
-    );
-  },
-);
+const DropdownItem = React.forwardRef(({ className, ...otherProps }, ref) => (
+  <BaseDropdownItem
+    className={classNames(className, 'pgn__dropdown-item')}
+    ref={ref}
+    {...otherProps}
+  />
+));
+DropdownItem.displayName = 'DropdownItem';
 
-Dropdown.Item.propTypes = {
+DropdownItem.propTypes = {
   className: PropTypes.string,
 };
 
-Dropdown.Item.defaultProps = {
+DropdownItem.defaultProps = {
   className: undefined,
 };
 
 Dropdown.Deprecated = DropdownDeprecated;
 Dropdown.Toggle = DropdownToggle;
+Dropdown.Item = DropdownItem;
 Dropdown.Menu = DropdownMenu;
 Dropdown.Header = BaseDropdown.Header;
 Dropdown.Divider = BaseDropdown.Divider;

--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -362,6 +362,7 @@ const FormAutosuggest = forwardRef(
     );
   },
 );
+FormAutosuggest.displayName = 'FormAutosuggest';
 
 FormAutosuggest.defaultProps = {
   arrowKeyNavigationSelector: 'a:not(:disabled),li:not(:disabled, .btn-icon),input:not(:disabled)',

--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -37,6 +37,7 @@ const CheckboxControl = React.forwardRef(
     );
   },
 );
+CheckboxControl.displayName = 'CheckboxControl';
 
 CheckboxControl.propTypes = {
   /** Specifies whether the checkbox should be rendered in indeterminate state. */
@@ -102,6 +103,7 @@ const FormCheckbox = React.forwardRef(({
     </FormGroupContextProvider>
   );
 });
+FormCheckbox.displayName = 'FormCheckbox';
 
 FormCheckbox.propTypes = {
   /** Specifies id of the FormCheckbox component. */

--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -88,6 +88,7 @@ const FormControl = React.forwardRef(({
     </FormControlDecoratorGroup>
   );
 });
+FormControl.displayName = 'FormControl';
 
 const SIZE_CHOICES = ['sm', 'lg'];
 

--- a/src/Form/FormRadio.jsx
+++ b/src/Form/FormRadio.jsx
@@ -22,6 +22,7 @@ const RadioControl = React.forwardRef((props, ref) => {
     <input {...radioProps} type="radio" ref={ref} />
   );
 });
+RadioControl.displayName = 'RadioControl';
 
 RadioControl.propTypes = {
   className: PropTypes.string,
@@ -67,6 +68,7 @@ const FormRadio = React.forwardRef(({
     </div>
   </FormGroupContextProvider>
 ));
+FormRadio.displayName = 'FormRadio';
 
 FormRadio.propTypes = {
   /** Specifies id of the FormRadio component. */

--- a/src/Form/FormSwitch.jsx
+++ b/src/Form/FormSwitch.jsx
@@ -33,6 +33,7 @@ const SwitchControl = React.forwardRef(
     );
   },
 );
+SwitchControl.displayName = 'SwitchControl';
 
 SwitchControl.propTypes = {
   /** Specifies whether input should be rendered in indeterminate state. */
@@ -73,6 +74,7 @@ const FormSwitch = React.forwardRef(({
     )}
   </div>
 ));
+FormSwitch.displayName = 'FormSwitch';
 
 FormSwitch.propTypes = {
   /** Specifies contents of the component. */

--- a/src/Form/tests/FormGroup.test.jsx
+++ b/src/Form/tests/FormGroup.test.jsx
@@ -8,7 +8,7 @@ import FormControlFeedback from '../FormControlFeedback';
 
 jest.mock('react-bootstrap/FormControl', () => {
   const { forwardRef } = jest.requireActual('react');
-  return forwardRef((props, ref) => {
+  const FormControlWrapped = forwardRef((props, ref) => {
     const { children, ...otherProps } = props;
     return (
       <form-control {...otherProps} ref={ref}>
@@ -16,6 +16,7 @@ jest.mock('react-bootstrap/FormControl', () => {
       </form-control>
     );
   });
+  return FormControlWrapped;
 });
 
 function renderFormGroup() {

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -143,9 +143,9 @@ Input.defaultProps = {
   options: [],
 };
 
-// eslint-disable-next-line react/no-multi-comp
 const InputWithRefForwarding = React.forwardRef((props, ref) => (
   <Input forwardedRef={ref} {...props} />
 ));
+InputWithRefForwarding.displayName = 'Input';
 
 export default InputWithRefForwarding;

--- a/src/Layout/index.jsx
+++ b/src/Layout/index.jsx
@@ -7,6 +7,7 @@ const COL_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 'auto'];
 const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 const LayoutElement = React.forwardRef((props, ref) => <div ref={ref} {...props} />);
+LayoutElement.displayName = 'LayoutElement';
 
 const Layout = React.forwardRef(({ children, ...props }, ref) => {
   const childrenLength = children.length;
@@ -44,6 +45,7 @@ const Layout = React.forwardRef(({ children, ...props }, ref) => {
     </Row>
   );
 });
+Layout.displayName = 'Layout';
 
 Layout.defaultProps = {
   xs: undefined,

--- a/src/MailtoLink/index.jsx
+++ b/src/MailtoLink/index.jsx
@@ -51,6 +51,7 @@ const MailtoLink = React.forwardRef((props, ref) => {
     </Hyperlink>
   );
 });
+MailtoLink.displayName = 'MailtoLink';
 
 MailtoLink.defaultProps = {
   to: [],

--- a/src/Modal/ModalCloseButton.jsx
+++ b/src/Modal/ModalCloseButton.jsx
@@ -23,6 +23,7 @@ const ModalCloseButton = React.forwardRef(({ as, children, ...props }, ref) => {
   // finely control the component type (defaulted to Button via defaultProps)
   return React.createElement(type, componentProps, children);
 });
+ModalCloseButton.displayName = 'ModalCloseButton';
 
 ModalCloseButton.propTypes = {
   /** Specifies the base element */

--- a/src/Popover/index.jsx
+++ b/src/Popover/index.jsx
@@ -26,6 +26,7 @@ const Popover = React.forwardRef(({
     {children}
   </BasePopover>
 ));
+Popover.displayName = 'Popover';
 
 function PopoverTitle(props) {
   return <BasePopoverTitle {...props} />;

--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -126,6 +126,7 @@ const Checkpoint = React.forwardRef(({
     </div>
   );
 });
+Checkpoint.displayName = 'Checkpoint';
 
 Checkpoint.defaultProps = {
   advanceButtonText: null,

--- a/src/ProductTour/CheckpointActionRow.jsx
+++ b/src/ProductTour/CheckpointActionRow.jsx
@@ -33,6 +33,7 @@ const CheckpointActionRow = React.forwardRef(({
     </Button>
   </div>
 ));
+CheckpointActionRow.displayName = 'CheckpointActionRow';
 
 CheckpointActionRow.defaultProps = {
   advanceButtonText: '',

--- a/src/ProductTour/CheckpointBody.jsx
+++ b/src/ProductTour/CheckpointBody.jsx
@@ -12,6 +12,7 @@ const CheckpointBody = React.forwardRef(({ children }, ref) => {
     </div>
   );
 });
+CheckpointBody.displayName = 'CheckpointBody';
 
 CheckpointBody.defaultProps = {
   children: null,

--- a/src/ProductTour/CheckpointBreadcrumbs.jsx
+++ b/src/ProductTour/CheckpointBreadcrumbs.jsx
@@ -29,6 +29,7 @@ const CheckpointBreadcrumbs = React.forwardRef(({ currentIndex, totalCheckpoints
     </span>
   );
 });
+CheckpointBreadcrumbs.displayName = 'CheckpointBreadcrumbs';
 
 CheckpointBreadcrumbs.defaultProps = {
   currentIndex: null,

--- a/src/ProductTour/CheckpointTitle.jsx
+++ b/src/ProductTour/CheckpointTitle.jsx
@@ -6,6 +6,7 @@ const CheckpointTitle = React.forwardRef(({ children }, ref) => (
     {children}
   </h2>
 ));
+CheckpointTitle.displayName = 'CheckpointTitle';
 
 CheckpointTitle.defaultProps = {
   children: null,

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -121,6 +121,7 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     />
   );
 });
+ProductTour.displayName = 'ProductTour';
 
 ProductTour.defaultProps = {
   tours: {

--- a/src/SelectableBox/SelectableBoxSet.jsx
+++ b/src/SelectableBox/SelectableBoxSet.jsx
@@ -46,6 +46,7 @@ const SelectableBoxSet = React.forwardRef(({
     children,
   );
 });
+SelectableBoxSet.displayName = 'SelectableBoxSet';
 
 SelectableBoxSet.propTypes = {
   /** Specifies a name for the group of `SelectableBox`'es. */

--- a/src/SelectableBox/index.jsx
+++ b/src/SelectableBox/index.jsx
@@ -76,6 +76,7 @@ const SelectableBox = React.forwardRef(({
     </div>
   );
 });
+SelectableBox.displayName = 'SelectableBox';
 
 SelectableBox.propTypes = {
   /** Content of the `SelectableBox`. */

--- a/src/Spinner/index.jsx
+++ b/src/Spinner/index.jsx
@@ -19,6 +19,7 @@ const Spinner = React.forwardRef(({
     </BaseSpinner>
   );
 });
+Spinner.displayName = 'Spinner';
 
 Spinner.propTypes = {
   /** Specifies the class name for the component. */

--- a/src/Stack/index.jsx
+++ b/src/Stack/index.jsx
@@ -28,6 +28,7 @@ const Stack = forwardRef(({
     {children}
   </div>
 ));
+Stack.displayName = 'Stack';
 
 Stack.propTypes = {
   /** Specifies the content of the `Stack`. */

--- a/src/Sticky/index.jsx
+++ b/src/Sticky/index.jsx
@@ -63,6 +63,7 @@ const Sticky = React.forwardRef(({
     </div>
   );
 });
+Sticky.displayName = 'Sticky';
 
 Sticky.propTypes = {
   /** Specifies content of the component. */

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -40,6 +40,7 @@ const Tooltip: ComponentWithAsProp<'div', TooltipProps> = React.forwardRef(({
     {children}
   </BaseTooltip>
 ));
+Tooltip.displayName = 'Tooltip';
 
 Tooltip.propTypes = {
   ...BaseTooltip.propTypes,


### PR DESCRIPTION
## Description

https://legacy.reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
