### PR TITLE
[REFERENCE] feat: add overlay with highlighted ProductTour checkpoint target

### DIFF
--- a/src/ProductTour/Checkpoint.scss
+++ b/src/ProductTour/Checkpoint.scss
@@ -5,6 +5,10 @@ $checkpoint-arrow-top-color: solid $checkpoint-arrow-width $checkpoint-border-co
 $checkpoint-arrow-default-color: solid $checkpoint-arrow-width $checkpoint-background-color;
 $checkpoint-arrow-transparent: solid $checkpoint-arrow-width transparent;
 
+.pgn__checkpoint-overlay {
+  z-index: $checkpoint-background-z-index;
+}
+
 .pgn__checkpoint {
   position: absolute;
   background: $checkpoint-background-color;

--- a/src/ProductTour/_variables.scss
+++ b/src/ProductTour/_variables.scss
@@ -13,3 +13,4 @@ $checkpoint-arrow-width:            15px !default;
 $checkpoint-max-width:              480px !default;
 
 $checkpoint-z-index:                1060 !default;
+$checkpoint-background-z-index:     1050 !default;


### PR DESCRIPTION
## Description

Proof-of-Concept to add a transparent background overlay for the `ProductTour` checkpoints, where the `target` element is highlighted but the background is greyed out.

Example:

https://github.com/user-attachments/assets/a147ffb2-7f28-4f87-8a9f-a8a63047ae97


### Deploy Preview

https://deploy-preview-3463--paragon-openedx-v22.netlify.app/components/producttour/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
