### PR TITLE
feat: add info variant to CardStatus; refactor to TypeScript

### DIFF
--- a/src/Card/CardContext.tsx
+++ b/src/Card/CardContext.tsx
@@ -1,14 +1,32 @@
 import React, { createContext } from 'react';
 import PropTypes from 'prop-types';
 
-const CardContext = createContext({});
+type Orientation = 'horizontal' | 'vertical';
+type Variant = 'light' | 'dark' | 'muted';
+
+interface CardContextProviderProps {
+  /** Specifies which orientation to use. */
+  orientation: Orientation;
+  /** Specifies loading state. */
+  isLoading: boolean;
+  /** Specifies content of the component. */
+  children: React.ReactNode;
+  /** Specifies `Card` style variant */
+  variant: Variant;
+}
+
+const CardContext = createContext({
+  orientation: 'vertical' as Orientation,
+  isLoading: false,
+  variant: 'light' as Variant,
+});
 
 function CardContextProvider({
   orientation,
   children,
   isLoading,
   variant,
-}) {
+}: CardContextProviderProps) {
   return (
     <CardContext.Provider value={{ orientation, isLoading, variant }}>
       {children}

--- a/src/Card/CardStatus.tsx
+++ b/src/Card/CardStatus.tsx
@@ -1,14 +1,31 @@
 import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { Requireable } from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
 import Icon from '../Icon';
 import CardContext from './CardContext';
 
-const CardStatus = React.forwardRef(({
+type Variant = 'primary' | 'success' | 'danger' | 'warning' | 'info';
+
+export interface CardStatusProps {
+  /** Specifies the content of the component. */
+  children: React.ReactNode;
+  /** The class to append to the base element. */
+  className?: string;
+  /** Icon that will be shown in the top-left corner. */
+  icon?: React.ComponentType;
+  /** Specifies variant to use. */
+  variant?: Variant;
+  /** Specifies title for the `Card.Status`. */
+  title?: React.ReactNode;
+  /** Specifies any optional actions, e.g. button(s). */
+  actions?: React.ReactNode;
+}
+
+const CardStatus = React.forwardRef<HTMLDivElement, CardStatusProps>(({
   className,
   children,
-  variant,
+  variant = 'warning',
   icon,
   title,
   actions,
@@ -56,10 +73,11 @@ const CardStatus = React.forwardRef(({
     </div>
   );
 });
+CardStatus.displayName = 'CardStatus';
 
 CardStatus.propTypes = {
   /** Specifies the content of the component. */
-  children: PropTypes.node.isRequired,
+  children: (PropTypes.node as unknown as Requireable<React.ReactNode>).isRequired,
   /** The class to append to the base element. */
   className: PropTypes.string,
   /** Icon that will be shown in the top-left corner. */
@@ -70,11 +88,12 @@ CardStatus.propTypes = {
     'success',
     'danger',
     'warning',
+    'info',
   ]),
   /** Specifies title for the `Card.Status`. */
-  title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  title: (PropTypes.node as unknown as Requireable<React.ReactNode>),
   /** Specifies any optional actions, e.g. button(s). */
-  actions: PropTypes.node,
+  actions: (PropTypes.node as unknown as Requireable<React.ReactNode>),
 };
 
 CardStatus.defaultProps = {
@@ -82,7 +101,7 @@ CardStatus.defaultProps = {
   icon: undefined,
   variant: 'warning',
   title: undefined,
-  actions: undefined,
+  actions: null,
 };
 
 export default CardStatus;

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -525,7 +525,7 @@ An optional `actions` prop may be passed to include call-to-action button(s).
       <ExamplePropsForm
         inputs={[
           { value: orientation, setValue: setOrientation, options: ['horizontal', 'vertical'], name: 'orientation' },
-          { value: variant, setValue: setVariant, options: ['primary', 'warning', 'danger', 'success'], name: 'status-variant' },
+          { value: variant, setValue: setVariant, options: ['primary', 'warning', 'danger', 'success', 'info'], name: 'status-variant' },
           { value: showCardStatusActions, setValue: setCardStatusActions, options: ['true', 'false'], name: 'card-status-actions' },
         ]}
       />


### PR DESCRIPTION
## Description

This PR, in addition to migrating `CardStatus` and `CardContext` to TypeScript, adds official support for `variant="info"` on the `Card.Status`:

<img width="442" alt="image" src="https://github.com/user-attachments/assets/59f13685-c5a4-4740-9a1b-e5b973468e6b" />

Technically, all standard Bootstrap variants are supported, but not documented or defined in the available prop type options. 

[context] We likely have an upcoming use case where we'd like `Card.Status` to support the `info` variant. While it functionally works, it throws a prop type warning due to not being "officially" supported.

### Deploy Preview

https://deploy-preview-3470--paragon-openedx-v22.netlify.app/components/card/#card-status

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
