### PR TITLE
fix: fixed parsing of --themes option in build-tokens CLI command

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -92,7 +92,8 @@ const COMMANDS = {
       },
       {
         name: '-t, --themes',
-        description: 'Specify themes to include in the token build.',
+        description: `Specify themes to include in the token build.
+          Can be provided as a comma-separated list (e.g., "light,dark") or multiple arguments (e.g., "-t light -t dark").`,
         defaultValue: 'light',
       },
       {

--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -47,7 +47,9 @@ async function buildTokensCommand(commandArgs) {
     },
   );
 
-  const StyleDictionary = await initializeStyleDictionary({ themes });
+  const parsedThemes = Array.isArray(themes) ? themes : themes.split(',').map(t => t.trim());
+
+  const StyleDictionary = await initializeStyleDictionary({ themes: parsedThemes });
 
   const coreConfig = {
     include: [
@@ -144,7 +146,7 @@ async function buildTokensCommand(commandArgs) {
   // Create list of style-dictionary configurations to build (core + theme variants)
   const configs = [
     { config: coreConfig },
-    ...themes.map((themeVariant) => {
+    ...parsedThemes.map((themeVariant) => {
       const config = getStyleDictionaryConfig(themeVariant);
       return {
         config,


### PR DESCRIPTION
## Description

The build-tokens CLI command was failing when passing the `--themes` argument. This happened because themes was being captured as a string instead of an array, causing the following error:

`An error occurred: TypeError: themes.map is not a function or its return value is not iterable`

## Changelog

- Fixed handling of `--themes `argument to correctly parse multiple themes
- Updated Paragon Help command

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/59b9f85d-7768-46b2-963f-452084068e81" />

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
