### PR TITLE
fix: update ControlledSelectionStatus select all logic

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -167,147 +167,154 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
 
 ```jsx live
 () => {
-  const PAGINATED_DATA = [
-    [
-      {
-        id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
-        title: 'Castle in the Sky',
-        director: 'Hayao Miyazaki',
-        producer: 'Isao Takahata',
-        release_date: 1986,
-        rt_score: 95,
-      }, {
-        id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
-        title: 'Grave of the Fireflies',
-        director: 'Isao Takahata',
-        producer: 'Toru Hara',
-        release_date: 1988,
-        rt_score: 97,
-      },
-      {
-        id: '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
-        title: 'My Neighbor Totoro',
-        director: 'Hayao Miyazaki',
-        producer: 'Hayao Miyazaki',
-        release_date: 1988,
-        rt_score: 93,
-      },
-    ],
-    [
-      {
-        id: 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
-        title: 'Kiki\'s Delivery Service',
-        director: 'Hayao Miyazaki',
-        producer: 'Hayao Miyazaki',
-        release_date: 1989,
-        rt_score: 96,
-      },
-      {
-        id: '4e236f34-b981-41c3-8c65-f8c9000b94e7',
-        title: 'Only Yesterday',
-        director: 'Isao Takahata',
-        producer: 'Toshio Suzuki',
-        release_date: 1991,
-        rt_score: 100,
-      },
-      {
-        id: 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
-        title: 'Porco Rosso',
-        director: 'Hayao Miyazaki',
-        producer: 'Toshio Suzuki',
-        release_date: 1992,
-        rt_score: 94,
-      },
-    ],
-    [
-      {
-        id: '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
-        title: 'Pom Poko',
-        director: 'Isao Takahata',
-        producer: 'Toshio Suzuki',
-        release_date: 1994,
-        rt_score: 78,
-      },
-    ],
-  ];
-  const [data, setData] = useState(PAGINATED_DATA[0]);
-  const fetchData = useCallback(
-    (args) => {
-      setTimeout(() => {
-        setData(PAGINATED_DATA[args.pageIndex]);
-      }, 1000);
-    },
-    [],
-  );
-
-  const selectColumn = {
-    id: 'selection',
-    Header: DataTable.ControlledSelectHeader,
-    Cell: DataTable.ControlledSelect,
-    disableSortBy: true,
-  };
-
-  const DownloadCSVAction = ({ as: Component, selectedFlatRows, ...rest }) => (
-    <Component onClick={() => console.log('Download CSV', selectedFlatRows, rest)}>
-      Download CSV
-    </Component>
-  );
-
-  const ClearAction = ({ as: Component, tableInstance }) => (
-    <Component
-      variant="danger"
-      onClick={() => {
-        console.log('Clear Selection');
-        tableInstance.clearSelection();
-      }}
-    >
-      Clear Selection
-    </Component>
-  );
-  
-  return (
-    <DataTable
-      isSelectable
-      manualSelectColumn={selectColumn}
-      SelectionStatusComponent={DataTable.ControlledSelectionStatus}
-      isFilterable
-      manualFilters
-      defaultColumnValues={{ Filter: TextFilter }}
-      isPaginated
-      manualPagination
-      isSortable
-      manualSortBy
-      initialState={{
-        pageSize: 3,
-        pageIndex: 0
-      }}
-      initialTableOptions={{
-        getRowId: row => row.id,
-      }}
-      itemCount={7}
-      pageCount={3}
-      fetchData={fetchData}
-      data={data}
-      columns={[
+    const DEFAULT_PAGE_SIZE = 3;
+    const DATA = [
         {
-          Header: 'Title',
-          accessor: 'title',
+            id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
+            title: 'Castle in the Sky',
+            director: 'Hayao Miyazaki',
+            producer: 'Isao Takahata',
+            release_date: 1986,
+            rt_score: 95,
+        }, {
+            id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
+            title: 'Grave of the Fireflies',
+            director: 'Isao Takahata',
+            producer: 'Toru Hara',
+            release_date: 1988,
+            rt_score: 97,
         },
         {
-          Header: 'Director',
-          accessor: 'director',
+            id: '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
+            title: 'My Neighbor Totoro',
+            director: 'Hayao Miyazaki',
+            producer: 'Hayao Miyazaki',
+            release_date: 1988,
+            rt_score: 93,
         },
         {
-          Header: 'Release date',
-          accessor: 'release_date',
+            id: 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
+            title: 'Kiki\'s Delivery Service',
+            director: 'Hayao Miyazaki',
+            producer: 'Hayao Miyazaki',
+            release_date: 1989,
+            rt_score: 96,
         },
-      ]}
-      bulkActions={[
-        <DownloadCSVAction />,
-        <ClearAction />,
-      ]}
-    />
-  );
+        {
+            id: '4e236f34-b981-41c3-8c65-f8c9000b94e7',
+            title: 'Only Yesterday',
+            director: 'Isao Takahata',
+            producer: 'Toshio Suzuki',
+            release_date: 1991,
+            rt_score: 100,
+        },
+        {
+            id: 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
+            title: 'Porco Rosso',
+            director: 'Hayao Miyazaki',
+            producer: 'Toshio Suzuki',
+            release_date: 1992,
+            rt_score: 94,
+        },
+        {
+            id: '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
+            title: 'Pom Poko',
+            director: 'Isao Takahata',
+            producer: 'Toshio Suzuki',
+            release_date: 1994,
+            rt_score: 78,
+        },
+    ];
+
+    function paginateData(data, pageSize = DEFAULT_PAGE_SIZE) {
+        if (pageSize <= 0) {
+            throw new Error('Invalid page size');
+        }
+        const pages = [];
+        for (let i = 0; i < data.length; i += pageSize) {
+            pages.push(data.slice(i, i + pageSize));
+        }
+        return pages;
+    }
+
+    function filterData(data, filters) {
+        return data.filter((item) => filters.every(filter => (
+            String(item[filter.id]).toLowerCase().includes(String(filter.value).toLowerCase())
+        )));
+    }
+
+    const useDebouncedFetchData = (setData, setTotalItems, setTotalPages) => useCallback(
+        debounce((args) => {
+            if (!args) { return; }
+            setTimeout(() => {
+                // Filter the data based on the current filters
+                const filteredData = filterData(DATA, args.filters);
+
+                // Paginate the filtered data
+                const paginatedData = paginateData(filteredData, args.pageSize);
+                const currentPageData = paginatedData[args.pageIndex] || [];
+
+                // Update the state with the paginated data, total items, and total pages
+                setData(currentPageData);
+                setTotalItems(filteredData.length);
+                setTotalPages(paginatedData.length);
+            }, 1000);
+        }, 300),
+        [],
+    );
+
+    const PAGINATED_DATA = paginateData(DATA);
+
+    const selectColumn = {
+        id: 'selection',
+        Header: DataTable.ControlledSelectHeader,
+        Cell: DataTable.ControlledSelect,
+        disableSortBy: true,
+    };
+
+    const [data, setData] = useState(PAGINATED_DATA[0]);
+    const [totalItems, setTotalItems] = useState(DATA.length);
+    const [totalPages, setTotalPages] = useState(1);
+
+    const fetchData = useDebouncedFetchData(setData, setTotalItems, setTotalPages);
+
+    return (
+        <DataTable
+            isSelectable
+            manualSelectColumn={selectColumn}
+            SelectionStatusComponent={DataTable.ControlledSelectionStatus}
+            isFilterable
+            manualFilters
+            defaultColumnValues={{ Filter: TextFilter }}
+            isPaginated
+            manualPagination
+            initialState={{
+                pageSize: 3,
+                pageIndex: 0,
+            }}
+            initialTableOptions={{
+                getRowId: row => row.id,
+            }}
+            itemCount={totalItems}
+            pageCount={totalPages}
+            fetchData={fetchData}
+            data={data}
+            columns={[
+                {
+                    Header: 'Title',
+                    accessor: 'title',
+                },
+                {
+                    Header: 'Director',
+                    accessor: 'director',
+                },
+                {
+                    Header: 'Release date',
+                    accessor: 'release_date',
+                },
+            ]}
+        />
+    );
 }
 ```
 

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -170,109 +170,110 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
   const DEFAULT_PAGE_SIZE = 3;
   const DATA = [
     {
-        id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
-        title: 'Castle in the Sky',
-        director: 'Hayao Miyazaki',
-        producer: 'Isao Takahata',
-        release_date: 1986,
-        rt_score: 95,
-    }, {
-        id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
-        title: 'Grave of the Fireflies',
-        director: 'Isao Takahata',
-        producer: 'Toru Hara',
-        release_date: 1988,
-        rt_score: 97,
+      id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
+      title: 'Castle in the Sky',
+      director: 'Hayao Miyazaki',
+      producer: 'Isao Takahata',
+      release_date: 1986,
+      rt_score: 95,
+    }, 
+    {
+      id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
+      title: 'Grave of the Fireflies',
+      director: 'Isao Takahata',
+      producer: 'Toru Hara',
+      release_date: 1988,
+      rt_score: 97,
     },
     {
-        id: '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
-        title: 'My Neighbor Totoro',
-        director: 'Hayao Miyazaki',
-        producer: 'Hayao Miyazaki',
-        release_date: 1988,
-        rt_score: 93,
+      id: '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
+      title: 'My Neighbor Totoro',
+      director: 'Hayao Miyazaki',
+      producer: 'Hayao Miyazaki',
+      release_date: 1988,
+      rt_score: 93,
     },
     {
-        id: 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
-        title: 'Kiki\'s Delivery Service',
-        director: 'Hayao Miyazaki',
-        producer: 'Hayao Miyazaki',
-        release_date: 1989,
-        rt_score: 96,
+      id: 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
+      title: 'Kiki\'s Delivery Service',
+      director: 'Hayao Miyazaki',
+      producer: 'Hayao Miyazaki',
+      release_date: 1989,
+      rt_score: 96,
     },
     {
-        id: '4e236f34-b981-41c3-8c65-f8c9000b94e7',
-        title: 'Only Yesterday',
-        director: 'Isao Takahata',
-        producer: 'Toshio Suzuki',
-        release_date: 1991,
-        rt_score: 100,
-        },
-        {
-        id: 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
-        title: 'Porco Rosso',
-        director: 'Hayao Miyazaki',
-        producer: 'Toshio Suzuki',
-        release_date: 1992,
-        rt_score: 94,
+      id: '4e236f34-b981-41c3-8c65-f8c9000b94e7',
+      title: 'Only Yesterday',
+      director: 'Isao Takahata',
+      producer: 'Toshio Suzuki',
+      release_date: 1991,
+      rt_score: 100,
     },
     {
-        id: '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
-        title: 'Pom Poko',
-        director: 'Isao Takahata',
-        producer: 'Toshio Suzuki',
-        release_date: 1994,
-        rt_score: 78,
+      id: 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
+      title: 'Porco Rosso',
+      director: 'Hayao Miyazaki',
+      producer: 'Toshio Suzuki',
+      release_date: 1992,
+      rt_score: 94,
+    },
+    {
+      id: '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
+      title: 'Pom Poko',
+      director: 'Isao Takahata',
+      producer: 'Toshio Suzuki',
+      release_date: 1994,
+      rt_score: 78,
     },
   ];
 
   function paginateData(data, pageSize = DEFAULT_PAGE_SIZE) {
-      if (pageSize <= 0) {
-          throw new Error('Invalid page size');
-        }
-      const pages = [];
-      for (let i = 0; i < data.length; i += pageSize) {
-          pages.push(data.slice(i, i + pageSize));
-        }
-      return pages;
+    if (pageSize <= 0) {
+      throw new Error('Invalid page size');
     }
+    const pages = [];
+    for (let i = 0; i < data.length; i += pageSize) {
+        pages.push(data.slice(i, i + pageSize));
+    }
+    return pages;
+  }
 
   function filterData(data, filters) {
-      return data.filter((item) => filters.every(filter => (
-          String(item[filter.id]).toLowerCase().includes(String(filter.value).toLowerCase())
-        )));
-    }
+    return data.filter((item) => filters.every(filter => (
+      String(item[filter.id]).toLowerCase().includes(String(filter.value).toLowerCase())
+    )));
+  }
 
   const useDebouncedFetchData = (setData, setTotalItems, setTotalPages, setIsLoading) => useCallback(
-      debounce((args) => {
-          if (!args) { return; }
-          setIsLoading(true);
+    debounce((args) => {
+      if (!args) { return; }
+      setIsLoading(true);
 
-          setTimeout(() => {
-                // Filter the data based on the current filters
-              const filteredData = filterData(DATA, args.filters);
+      setTimeout(() => {
+        // Filter the data based on the current filters
+        const filteredData = filterData(DATA, args.filters);
 
-                // Paginate the filtered data
-              const paginatedData = paginateData(filteredData, args.pageSize);
-              const currentPageData = paginatedData[args.pageIndex] || [];
+        // Paginate the filtered data
+        const paginatedData = paginateData(filteredData, args.pageSize);
+        const currentPageData = paginatedData[args.pageIndex] || [];
 
-                // Update the state with the paginated data, total items, and total pages
-              setData(currentPageData);
-              setTotalItems(filteredData.length);
-              setTotalPages(paginatedData.length);
+        // Update the state with the paginated data, total items, and total pages
+        setData(currentPageData);
+        setTotalItems(filteredData.length);
+        setTotalPages(paginatedData.length);
 
-              setIsLoading(false);
-            }, 1000);
-        }, 300),
-        [],
-    );
+        setIsLoading(false);
+      }, 1000);
+    }, 300),
+    [],
+  );
 
   const selectColumn = {
-      id: 'selection',
-      Header: DataTable.ControlledSelectHeader,
-      Cell: DataTable.ControlledSelect,
-      disableSortBy: true,
-    };
+    id: 'selection',
+    Header: DataTable.ControlledSelectHeader,
+    Cell: DataTable.ControlledSelect,
+    disableSortBy: true,
+  };
 
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState([]);
@@ -282,62 +283,62 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
   const fetchData = useDebouncedFetchData(setData, setTotalItems, setTotalPages, setIsLoading);
 
   const DownloadCSVAction = ({ as: Component, selectedFlatRows, ...rest }) => (
-      <Component onClick={() => console.log('Download CSV', selectedFlatRows, rest)}>
+    <Component onClick={() => console.log('Download CSV', selectedFlatRows, rest)}>
       Download CSV
-      </Component>
-    );
+    </Component>
+  );
   const ClearAction = ({ as: Component, tableInstance }) => (
-      <Component
+    <Component
       variant="danger"
       onClick={() => {
         console.log('Clear Selection');
         tableInstance.clearSelection();
-        }}
-      >
+      }}
+    >
       Clear Selection
-      </Component>
-    );
+    </Component>
+  );
 
   return (
     <DataTable
-          isLoading={isLoading}
-          bulkActions={[
-              <DownloadCSVAction />,
-              <ClearAction />,
-            ]}
-          isSelectable
-          manualSelectColumn={selectColumn}
-          SelectionStatusComponent={DataTable.ControlledSelectionStatus}
-          isFilterable
-          manualFilters
-          defaultColumnValues={{ Filter: TextFilter }}
-          isPaginated
-          manualPagination
-          initialState={{
-              pageSize: 3,
-              pageIndex: 0,
-            }}
-          initialTableOptions={{
-              getRowId: row => row.id,
-            }}
-          itemCount={totalItems}
-          pageCount={totalPages}
-          fetchData={fetchData}
-          data={data}
-          columns={[
-            {
-              Header: 'Title',
-              accessor: 'title',
-            },
-            {
-              Header: 'Director',
-              accessor: 'director',
-            },
-            {
-              Header: 'Release date',
-              accessor: 'release_date',
-            },
-        ]}
+      isLoading={isLoading}
+      bulkActions={[
+        <DownloadCSVAction />,
+        <ClearAction />,
+      ]}
+      isSelectable
+      manualSelectColumn={selectColumn}
+      SelectionStatusComponent={DataTable.ControlledSelectionStatus}
+      isFilterable
+      manualFilters
+      defaultColumnValues={{ Filter: TextFilter }}
+      isPaginated
+      manualPagination
+      initialState={{
+        pageSize: 3,
+        pageIndex: 0,
+      }}
+      initialTableOptions={{
+        getRowId: row => row.id,
+      }}
+      itemCount={totalItems}
+      pageCount={totalPages}
+      fetchData={fetchData}
+      data={data}
+      columns={[
+        {
+          Header: 'Title',
+          accessor: 'title',
+        },
+        {
+          Header: 'Director',
+          accessor: 'director',
+        },
+        {
+          Header: 'Release date',
+          accessor: 'release_date',
+        },
+      ]}
     />
   );
 }

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -167,179 +167,179 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
 
 ```jsx live
 () => {
-    const DEFAULT_PAGE_SIZE = 3;
-    const DATA = [
-        {
-            id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
-            title: 'Castle in the Sky',
-            director: 'Hayao Miyazaki',
-            producer: 'Isao Takahata',
-            release_date: 1986,
-            rt_score: 95,
-        }, {
-            id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
-            title: 'Grave of the Fireflies',
-            director: 'Isao Takahata',
-            producer: 'Toru Hara',
-            release_date: 1988,
-            rt_score: 97,
+  const DEFAULT_PAGE_SIZE = 3;
+  const DATA = [
+    {
+        id: '2baf70d1-42bb-4437-b551-e5fed5a87abe',
+        title: 'Castle in the Sky',
+        director: 'Hayao Miyazaki',
+        producer: 'Isao Takahata',
+        release_date: 1986,
+        rt_score: 95,
+    }, {
+        id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
+        title: 'Grave of the Fireflies',
+        director: 'Isao Takahata',
+        producer: 'Toru Hara',
+        release_date: 1988,
+        rt_score: 97,
+    },
+    {
+        id: '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
+        title: 'My Neighbor Totoro',
+        director: 'Hayao Miyazaki',
+        producer: 'Hayao Miyazaki',
+        release_date: 1988,
+        rt_score: 93,
+    },
+    {
+        id: 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
+        title: 'Kiki\'s Delivery Service',
+        director: 'Hayao Miyazaki',
+        producer: 'Hayao Miyazaki',
+        release_date: 1989,
+        rt_score: 96,
+    },
+    {
+        id: '4e236f34-b981-41c3-8c65-f8c9000b94e7',
+        title: 'Only Yesterday',
+        director: 'Isao Takahata',
+        producer: 'Toshio Suzuki',
+        release_date: 1991,
+        rt_score: 100,
         },
         {
-            id: '58611129-2dbc-4a81-a72f-77ddfc1b1b49',
-            title: 'My Neighbor Totoro',
-            director: 'Hayao Miyazaki',
-            producer: 'Hayao Miyazaki',
-            release_date: 1988,
-            rt_score: 93,
-        },
-        {
-            id: 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
-            title: 'Kiki\'s Delivery Service',
-            director: 'Hayao Miyazaki',
-            producer: 'Hayao Miyazaki',
-            release_date: 1989,
-            rt_score: 96,
-        },
-        {
-            id: '4e236f34-b981-41c3-8c65-f8c9000b94e7',
-            title: 'Only Yesterday',
-            director: 'Isao Takahata',
-            producer: 'Toshio Suzuki',
-            release_date: 1991,
-            rt_score: 100,
-        },
-        {
-            id: 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
-            title: 'Porco Rosso',
-            director: 'Hayao Miyazaki',
-            producer: 'Toshio Suzuki',
-            release_date: 1992,
-            rt_score: 94,
-        },
-        {
-            id: '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
-            title: 'Pom Poko',
-            director: 'Isao Takahata',
-            producer: 'Toshio Suzuki',
-            release_date: 1994,
-            rt_score: 78,
-        },
-    ];
+        id: 'ebbb6b7c-945c-41ee-a792-de0e43191bd8',
+        title: 'Porco Rosso',
+        director: 'Hayao Miyazaki',
+        producer: 'Toshio Suzuki',
+        release_date: 1992,
+        rt_score: 94,
+    },
+    {
+        id: '1b67aa9a-2e4a-45af-ac98-64d6ad15b16c',
+        title: 'Pom Poko',
+        director: 'Isao Takahata',
+        producer: 'Toshio Suzuki',
+        release_date: 1994,
+        rt_score: 78,
+    },
+  ];
 
-    function paginateData(data, pageSize = DEFAULT_PAGE_SIZE) {
-        if (pageSize <= 0) {
-            throw new Error('Invalid page size');
+  function paginateData(data, pageSize = DEFAULT_PAGE_SIZE) {
+      if (pageSize <= 0) {
+          throw new Error('Invalid page size');
         }
-        const pages = [];
-        for (let i = 0; i < data.length; i += pageSize) {
-            pages.push(data.slice(i, i + pageSize));
+      const pages = [];
+      for (let i = 0; i < data.length; i += pageSize) {
+          pages.push(data.slice(i, i + pageSize));
         }
-        return pages;
+      return pages;
     }
 
-    function filterData(data, filters) {
-        return data.filter((item) => filters.every(filter => (
-            String(item[filter.id]).toLowerCase().includes(String(filter.value).toLowerCase())
+  function filterData(data, filters) {
+      return data.filter((item) => filters.every(filter => (
+          String(item[filter.id]).toLowerCase().includes(String(filter.value).toLowerCase())
         )));
     }
 
-    const useDebouncedFetchData = (setData, setTotalItems, setTotalPages, setIsLoading) => useCallback(
-        debounce((args) => {
-            if (!args) { return; }
-            setIsLoading(true);
+  const useDebouncedFetchData = (setData, setTotalItems, setTotalPages, setIsLoading) => useCallback(
+      debounce((args) => {
+          if (!args) { return; }
+          setIsLoading(true);
 
-            setTimeout(() => {
+          setTimeout(() => {
                 // Filter the data based on the current filters
-                const filteredData = filterData(DATA, args.filters);
+              const filteredData = filterData(DATA, args.filters);
 
                 // Paginate the filtered data
-                const paginatedData = paginateData(filteredData, args.pageSize);
-                const currentPageData = paginatedData[args.pageIndex] || [];
+              const paginatedData = paginateData(filteredData, args.pageSize);
+              const currentPageData = paginatedData[args.pageIndex] || [];
 
                 // Update the state with the paginated data, total items, and total pages
-                setData(currentPageData);
-                setTotalItems(filteredData.length);
-                setTotalPages(paginatedData.length);
+              setData(currentPageData);
+              setTotalItems(filteredData.length);
+              setTotalPages(paginatedData.length);
 
-                setIsLoading(false);
+              setIsLoading(false);
             }, 1000);
         }, 300),
         [],
     );
 
-    const selectColumn = {
-        id: 'selection',
-        Header: DataTable.ControlledSelectHeader,
-        Cell: DataTable.ControlledSelect,
-        disableSortBy: true,
+  const selectColumn = {
+      id: 'selection',
+      Header: DataTable.ControlledSelectHeader,
+      Cell: DataTable.ControlledSelect,
+      disableSortBy: true,
     };
 
-    const [isLoading, setIsLoading] = useState(true);
-    const [data, setData] = useState([]);
-    const [totalItems, setTotalItems] = useState(0);
-    const [totalPages, setTotalPages] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [data, setData] = useState([]);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
 
-    const fetchData = useDebouncedFetchData(setData, setTotalItems, setTotalPages, setIsLoading);
+  const fetchData = useDebouncedFetchData(setData, setTotalItems, setTotalPages, setIsLoading);
 
-    const DownloadCSVAction = ({ as: Component, selectedFlatRows, ...rest }) => (
+  const DownloadCSVAction = ({ as: Component, selectedFlatRows, ...rest }) => (
       <Component onClick={() => console.log('Download CSV', selectedFlatRows, rest)}>
-        Download CSV
+      Download CSV
       </Component>
     );
-    const ClearAction = ({ as: Component, tableInstance }) => (
+  const ClearAction = ({ as: Component, tableInstance }) => (
       <Component
-        variant="danger"
-        onClick={() => {
-          console.log('Clear Selection');
-          tableInstance.clearSelection();
+      variant="danger"
+      onClick={() => {
+        console.log('Clear Selection');
+        tableInstance.clearSelection();
         }}
       >
-        Clear Selection
+      Clear Selection
       </Component>
     );
 
-    return (
-        <DataTable
-            isLoading={isLoading}
-            bulkActions={[
+  return (
+    <DataTable
+          isLoading={isLoading}
+          bulkActions={[
               <DownloadCSVAction />,
               <ClearAction />,
             ]}
-            isSelectable
-            manualSelectColumn={selectColumn}
-            SelectionStatusComponent={DataTable.ControlledSelectionStatus}
-            isFilterable
-            manualFilters
-            defaultColumnValues={{ Filter: TextFilter }}
-            isPaginated
-            manualPagination
-            initialState={{
-                pageSize: 3,
-                pageIndex: 0,
+          isSelectable
+          manualSelectColumn={selectColumn}
+          SelectionStatusComponent={DataTable.ControlledSelectionStatus}
+          isFilterable
+          manualFilters
+          defaultColumnValues={{ Filter: TextFilter }}
+          isPaginated
+          manualPagination
+          initialState={{
+              pageSize: 3,
+              pageIndex: 0,
             }}
-            initialTableOptions={{
-                getRowId: row => row.id,
+          initialTableOptions={{
+              getRowId: row => row.id,
             }}
-            itemCount={totalItems}
-            pageCount={totalPages}
-            fetchData={fetchData}
-            data={data}
-            columns={[
-                {
-                    Header: 'Title',
-                    accessor: 'title',
-                },
-                {
-                    Header: 'Director',
-                    accessor: 'director',
-                },
-                {
-                    Header: 'Release date',
-                    accessor: 'release_date',
-                },
-            ]}
-        />
-    );
+          itemCount={totalItems}
+          pageCount={totalPages}
+          fetchData={fetchData}
+          data={data}
+          columns={[
+            {
+              Header: 'Title',
+              accessor: 'title',
+            },
+            {
+              Header: 'Director',
+              accessor: 'director',
+            },
+            {
+              Header: 'Release date',
+              accessor: 'release_date',
+            },
+        ]}
+    />
+  );
 }
 ```
 

--- a/src/DataTable/hooks.jsx
+++ b/src/DataTable/hooks.jsx
@@ -1,6 +1,7 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import DataTableContext from './DataTableContext';
-import { clearSelectionAction } from './selection/data/actions';
+import { clearSelectionAction, setSelectedRowsAction, toggleIsEntireTableSelected } from './selection/data/actions';
+import { getRowIds, getUnselectedPageRows } from './selection/data/helpers';
 
 export const useRows = () => {
   const {
@@ -38,4 +39,56 @@ export const useSelectionActions = (
   return {
     clearSelection,
   };
+};
+
+/**
+ * Provides business logic around managing selection state, notably for controlled
+ * selections with API-driven data.
+ *
+ */
+export const useDataTableSelections = ({
+  selections,
+  selectionsDispatch,
+  itemCount,
+  selectedRows,
+  page,
+  isAllPageRowsSelected,
+}) => {
+  // If "Select all" is explicitly opted in by the user, ensure that all unselected rows are selected
+  // when the user navigates to a new page.
+  useEffect(
+    () => {
+      if (selections.isSelectAllEnabled && (itemCount > selectedRows.length || !isAllPageRowsSelected)) {
+        const selectedRowIds = getRowIds(selectedRows);
+        const unselectedPageRows = getUnselectedPageRows(selectedRowIds, page);
+        if (unselectedPageRows.length) {
+          selectionsDispatch(setSelectedRowsAction(unselectedPageRows, itemCount));
+        }
+      }
+    },
+    [selectedRows, itemCount, page, selectionsDispatch, selections.isSelectAllEnabled, isAllPageRowsSelected],
+  );
+
+  // When `selections.isSelectAllEnabled` is true, ensure `selections.isEntireTableSelected` is true.
+  useEffect(() => {
+    if (selections.isSelectAllEnabled && !selections.isEntireTableSelected) {
+      selectionsDispatch(toggleIsEntireTableSelected());
+    }
+  }, [selectionsDispatch, selections.isEntireTableSelected, selections.isSelectAllEnabled]);
+
+  // When `selections.isSelectAllEnabled` differs from `selections.isEntireTableSelected` and
+  // `isAllPageRowsSelected` matches `selections.isSelectAllEnabled`, toggle `selections.isEntireTableSelected`.
+  useEffect(() => {
+    if (!selections.isSelectAllEnabled && selections.isEntireTableSelected && !isAllPageRowsSelected) {
+      selectionsDispatch(toggleIsEntireTableSelected());
+    }
+    if (selections.isSelectAllEnabled && !selections.isEntireTableSelected && isAllPageRowsSelected) {
+      selectionsDispatch(toggleIsEntireTableSelected());
+    }
+  }, [
+    selectionsDispatch,
+    isAllPageRowsSelected,
+    selections.isEntireTableSelected,
+    selections.isSelectAllEnabled,
+  ]);
 };

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -36,7 +36,7 @@ import ExpandRow from './ExpandRow';
 import { useSelectionActions } from './hooks';
 import selectionsReducer, {
   initialState as selection,
-  initialState as initialSelectionsState
+  initialState as initialSelectionsState,
 } from './selection/data/reducer';
 import { toggleIsEntireTableSelectedAction } from './selection/data/actions';
 
@@ -84,11 +84,11 @@ function DataTable({
             };
           }
           /*  Note: We override the `toggleRowSelected` action from react-table
-              because we need to preserve the order of the selected rows.
-              While `selectedRowIds` is an object that contains the selected rows as key-value pairs,
-              it does not maintain the order of selection. Therefore, we have added the `selectedRowsOrdered` property
-              to keep track of the order in which the rows were selected.
-          */
+                because we need to preserve the order of the selected rows.
+                While `selectedRowIds` is an object that contains the selected rows as key-value pairs,
+                it does not maintain the order of selection. Therefore, we have added the `selectedRowsOrdered` property
+                to keep track of the order in which the rows were selected.
+            */
           case 'toggleRowSelected': {
             const rowIndex = parseInt(action.id, 10);
             const { selectedRowsOrdered = [] } = previousState;
@@ -188,12 +188,14 @@ function DataTable({
   }, [tableStateSelectedRowIds, onSelectedRowsChanged]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
-  const [_, dispatch] = controlledTableSelections;
-  console.log(itemCount, selectedRows.length, selection, 'index')
+  const [, dispatch] = controlledTableSelections;
+
   if (!selection.isSelectAllEnabled && selections.isEntireTableSelected && itemCount > selectedRows.length) {
     dispatch(toggleIsEntireTableSelectedAction());
   }
-  console.log(itemCount, selectedRows.length, selection, 'index')
+  if (selection.isSelectAllEnabled && !selections.isEntireTableSelected) {
+    dispatch(toggleIsEntireTableSelectedAction());
+  }
 
   const enhancedInstance = {
     ...instance,
@@ -226,12 +228,12 @@ function DataTable({
         })}
         >
           {children || (
-          <>
-            <TableControlBar />
-            <Table />
-            <EmptyTableComponent content="No results found" />
-            <TableFooter />
-          </>
+            <>
+              <TableControlBar />
+              <Table />
+              <EmptyTableComponent content="No results found" />
+              <TableFooter />
+            </>
           )}
         </div>
       </DataTableLayout>
@@ -338,7 +340,7 @@ DataTable.propTypes = {
     Cell: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
   })),
   /** Function that will fetch table data. Called when page size, page index or filters change.
-    * Meant to be used with manual filters and pagination */
+   * Meant to be used with manual filters and pagination */
   fetchData: PropTypes.func,
   /** Initial state passed to react-table's documentation https://github.com/TanStack/table/blob/v7/docs/src/pages/docs/api/useTable.md */
   initialState: PropTypes.shape({
@@ -350,7 +352,7 @@ DataTable.propTypes = {
     selectedRowsOrdered: PropTypes.arrayOf(PropTypes.number),
   }),
   /** Table options passed to react-table's useTable hook. Will override some options passed in to DataTable, such
-     as: data, columns, defaultColumn, manualFilters, manualPagination, manualSortBy, and initialState */
+   as: data, columns, defaultColumn, manualFilters, manualPagination, manualSortBy, and initialState */
   initialTableOptions: PropTypes.shape({}),
   /** Actions to be performed on the table. Called with the table instance. Not displayed if rows are selected. */
   itemCount: PropTypes.number.isRequired,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -38,7 +38,7 @@ import selectionsReducer, {
   initialState as selection,
   initialState as initialSelectionsState,
 } from './selection/data/reducer';
-import { toggleIsEntireTableSelectedAction } from './selection/data/actions';
+import { toggleIsEntireTableSelected } from './selection/data/actions';
 
 function DataTable({
   columns, data, defaultColumnValues, additionalColumns, isSelectable,
@@ -190,12 +190,14 @@ function DataTable({
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
   const [, dispatch] = controlledTableSelections;
 
-  if (!selection.isSelectAllEnabled && selections.isEntireTableSelected && itemCount > selectedRows.length) {
-    dispatch(toggleIsEntireTableSelectedAction());
-  }
-  if (selection.isSelectAllEnabled && !selections.isEntireTableSelected) {
-    dispatch(toggleIsEntireTableSelectedAction());
-  }
+  useEffect(() => {
+    if (!selection.isSelectAllEnabled && selections.isEntireTableSelected && !instance.isAllPageRowsSelected) {
+      dispatch(toggleIsEntireTableSelected());
+    }
+    if (selection.isSelectAllEnabled && !selections.isEntireTableSelected && instance.isAllPageRowsSelected) {
+      dispatch(toggleIsEntireTableSelected());
+    }
+  }, [dispatch, instance.isAllPageRowsSelected, selections.isEntireTableSelected]);
 
   const enhancedInstance = {
     ...instance,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -33,12 +33,10 @@ import DataTableLayout from './DataTableLayout';
 import ExpandAll from './ExpandAll';
 import ExpandRow from './ExpandRow';
 
-import { useSelectionActions } from './hooks';
+import { useDataTableSelections, useSelectionActions } from './hooks';
 import selectionsReducer, {
-  initialState as selection,
   initialState as initialSelectionsState,
 } from './selection/data/reducer';
-import { toggleIsEntireTableSelected } from './selection/data/actions';
 
 function DataTable({
   columns, data, defaultColumnValues, additionalColumns, isSelectable,
@@ -188,16 +186,15 @@ function DataTable({
   }, [tableStateSelectedRowIds, onSelectedRowsChanged]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
-  const [, dispatch] = controlledTableSelections;
 
-  useEffect(() => {
-    if (!selection.isSelectAllEnabled && selections.isEntireTableSelected && !instance.isAllPageRowsSelected) {
-      dispatch(toggleIsEntireTableSelected());
-    }
-    if (selection.isSelectAllEnabled && !selections.isEntireTableSelected && instance.isAllPageRowsSelected) {
-      dispatch(toggleIsEntireTableSelected());
-    }
-  }, [dispatch, instance.isAllPageRowsSelected, selections.isEntireTableSelected]);
+  useDataTableSelections({
+    selections,
+    selectionsDispatch,
+    itemCount,
+    selectedRows,
+    page: instance.page,
+    isAllPageRowsSelected: instance.isAllPageRowsSelected,
+  });
 
   const enhancedInstance = {
     ...instance,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -34,7 +34,11 @@ import ExpandAll from './ExpandAll';
 import ExpandRow from './ExpandRow';
 
 import { useSelectionActions } from './hooks';
-import selectionsReducer, { initialState as initialSelectionsState } from './selection/data/reducer';
+import selectionsReducer, {
+  initialState as selection,
+  initialState as initialSelectionsState
+} from './selection/data/reducer';
+import { toggleIsEntireTableSelectedAction } from './selection/data/actions';
 
 function DataTable({
   columns, data, defaultColumnValues, additionalColumns, isSelectable,
@@ -184,6 +188,12 @@ function DataTable({
   }, [tableStateSelectedRowIds, onSelectedRowsChanged]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
+  const [_, dispatch] = controlledTableSelections;
+  console.log(itemCount, selectedRows.length, selection, 'index')
+  if (!selection.isSelectAllEnabled && selections.isEntireTableSelected && itemCount > selectedRows.length) {
+    dispatch(toggleIsEntireTableSelectedAction());
+  }
+  console.log(itemCount, selectedRows.length, selection, 'index')
 
   const enhancedInstance = {
     ...instance,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -81,12 +81,13 @@ function DataTable({
               selectedRowIds: {},
             };
           }
-          /*  Note: We override the `toggleRowSelected` action from react-table
-                because we need to preserve the order of the selected rows.
-                While `selectedRowIds` is an object that contains the selected rows as key-value pairs,
-                it does not maintain the order of selection. Therefore, we have added the `selectedRowsOrdered` property
-                to keep track of the order in which the rows were selected.
-            */
+          /**
+           * Note: We override the `toggleRowSelected` action from react-table
+           * because we need to preserve the order of the selected rows.
+           * while `selectedRowIds` is an object that contains the selected rows as key-value pairs,
+           * it does not maintain the order of selection. Therefore, we have added the `selectedRowsOrdered` property
+           * to keep track of the order in which the rows were selected.
+           */
           case 'toggleRowSelected': {
             const rowIndex = parseInt(action.id, 10);
             const { selectedRowsOrdered = [] } = previousState;

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -18,12 +18,12 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
     page,
-    controlledTableSelections: [{ selectedRows, isEntireTableSelected }, dispatch],
+    controlledTableSelections: [{ selectedRows, isEntireTableSelected, isSelectAllRowsAllPages }, dispatch],
   } = useContext(DataTableContext);
 
   useEffect(
     () => {
-      if (isEntireTableSelected) {
+      if (isEntireTableSelected && isSelectAllRowsAllPages) {
         const selectedRowIds = getRowIds(selectedRows);
         const unselectedPageRows = getUnselectedPageRows(selectedRowIds, page);
         if (unselectedPageRows.length) {
@@ -31,7 +31,7 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
         }
       }
     },
-    [isEntireTableSelected, selectedRows, itemCount, page, dispatch],
+    [isEntireTableSelected, selectedRows, itemCount, page, dispatch, isSelectAllRowsAllPages],
   );
 
   const numSelectedRows = isEntireTableSelected ? itemCount : selectedRows.length;

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect} from 'react';
+import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import DataTableContext from '../DataTableContext';
@@ -18,10 +18,9 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
     page,
-    controlledTableSelections: [{ selectedRows, isSelectAllEnabled, isEntireTableSelected }, dispatch],
+    controlledTableSelections: [{ selectedRows, isSelectAllEnabled }, dispatch],
   } = useContext(DataTableContext);
-  console.log(useContext(DataTableContext))
-  console.log(isSelectAllEnabled, itemCount > selectedRows.length, isEntireTableSelected)
+
   useEffect(
     () => {
       if ((isSelectAllEnabled) && itemCount > selectedRows.length) {
@@ -35,10 +34,9 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
     },
     [selectedRows, itemCount, page, dispatch, isSelectAllEnabled],
   );
-  console.log(itemCount, selectedRows.length, selectedRows, 'itemCount, selectedRows.length, selectedRows', 'controlledselectionstatus')
+
   const numSelectedRows = itemCount === selectedRows.length || isSelectAllEnabled ? itemCount : selectedRows.length;
   const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;
-  console.log(numSelectedRowsOnPage, numSelectedRows, page, 'numSelectedRowsOnPage, numSelectedRows, page', 'controlledselectionstatus')
   const selectionStatusProps = {
     className,
     numSelectedRows,

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, {useContext, useEffect} from 'react';
 import PropTypes from 'prop-types';
 
 import DataTableContext from '../DataTableContext';
@@ -18,25 +18,27 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
     page,
-    controlledTableSelections: [{ selectedRows, isEntireTableSelected, isSelectAllRowsAllPages }, dispatch],
+    controlledTableSelections: [{ selectedRows, isSelectAllEnabled, isEntireTableSelected }, dispatch],
   } = useContext(DataTableContext);
-
+  console.log(useContext(DataTableContext))
+  console.log(isSelectAllEnabled, itemCount > selectedRows.length, isEntireTableSelected)
   useEffect(
     () => {
-      if (isEntireTableSelected && isSelectAllRowsAllPages) {
+      if ((isSelectAllEnabled) && itemCount > selectedRows.length) {
         const selectedRowIds = getRowIds(selectedRows);
         const unselectedPageRows = getUnselectedPageRows(selectedRowIds, page);
         if (unselectedPageRows.length) {
           dispatch(setSelectedRowsAction(unselectedPageRows, itemCount));
+          dispatch(setSelectAllRowsAllPagesAction());
         }
       }
     },
-    [isEntireTableSelected, selectedRows, itemCount, page, dispatch, isSelectAllRowsAllPages],
+    [selectedRows, itemCount, page, dispatch, isSelectAllEnabled],
   );
-
-  const numSelectedRows = isEntireTableSelected ? itemCount : selectedRows.length;
+  console.log(itemCount, selectedRows.length, selectedRows, 'itemCount, selectedRows.length, selectedRows', 'controlledselectionstatus')
+  const numSelectedRows = itemCount === selectedRows.length || isSelectAllEnabled ? itemCount : selectedRows.length;
   const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;
-
+  console.log(numSelectedRowsOnPage, numSelectedRows, page, 'numSelectedRowsOnPage, numSelectedRows, page', 'controlledselectionstatus')
   const selectionStatusProps = {
     className,
     numSelectedRows,

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import DataTableContext from '../DataTableContext';
@@ -7,48 +7,28 @@ import BaseSelectionStatus from './BaseSelectionStatus';
 import {
   clearSelectionAction,
   setSelectAllRowsAllPagesAction,
-  setSelectedRowsAction,
-  toggleIsEntireTableSelected,
 } from './data/actions';
-import {
-  getUnselectedPageRows,
-  getRowIds,
-} from './data/helpers';
 
 function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
     page,
-    controlledTableSelections: [{ selectedRows, isSelectAllEnabled, isEntireTableSelected }, dispatch],
+    controlledTableSelections: [
+      { selectedRows, isSelectAllEnabled },
+      selectionsDispatch,
+    ],
   } = useContext(DataTableContext);
-  useEffect(
-    () => {
-      if (isSelectAllEnabled && itemCount > selectedRows.length) {
-        const selectedRowIds = getRowIds(selectedRows);
-        const unselectedPageRows = getUnselectedPageRows(selectedRowIds, page);
-        if (unselectedPageRows.length) {
-          dispatch(setSelectedRowsAction(unselectedPageRows, itemCount));
-        }
-      }
-    },
-    [selectedRows, itemCount, page, dispatch, isSelectAllEnabled, isEntireTableSelected],
-  );
-
-  useEffect(() => {
-    if (isSelectAllEnabled && !isEntireTableSelected) {
-      dispatch(toggleIsEntireTableSelected());
-    }
-  }, [dispatch, isEntireTableSelected, isSelectAllEnabled]);
 
   const numSelectedRows = itemCount === selectedRows.length || isSelectAllEnabled ? itemCount : selectedRows.length;
   const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;
+
   const selectionStatusProps = {
     className,
     numSelectedRows,
     numSelectedRowsOnPage,
     clearSelectionText,
-    onSelectAll: () => dispatch(setSelectAllRowsAllPagesAction()),
-    onClear: () => dispatch(clearSelectionAction()),
+    onSelectAll: () => selectionsDispatch(setSelectAllRowsAllPagesAction()),
+    onClear: () => selectionsDispatch(clearSelectionAction()),
   };
   return <BaseSelectionStatus {...selectionStatusProps} />;
 }

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -8,6 +8,7 @@ import {
   clearSelectionAction,
   setSelectAllRowsAllPagesAction,
   setSelectedRowsAction,
+  toggleIsEntireTableSelected,
 } from './data/actions';
 import {
   getUnselectedPageRows,
@@ -18,22 +19,26 @@ function ControlledSelectionStatus({ className, clearSelectionText }) {
   const {
     itemCount,
     page,
-    controlledTableSelections: [{ selectedRows, isSelectAllEnabled }, dispatch],
+    controlledTableSelections: [{ selectedRows, isSelectAllEnabled, isEntireTableSelected }, dispatch],
   } = useContext(DataTableContext);
-
   useEffect(
     () => {
-      if ((isSelectAllEnabled) && itemCount > selectedRows.length) {
+      if (isSelectAllEnabled && itemCount > selectedRows.length) {
         const selectedRowIds = getRowIds(selectedRows);
         const unselectedPageRows = getUnselectedPageRows(selectedRowIds, page);
         if (unselectedPageRows.length) {
           dispatch(setSelectedRowsAction(unselectedPageRows, itemCount));
-          dispatch(setSelectAllRowsAllPagesAction());
         }
       }
     },
-    [selectedRows, itemCount, page, dispatch, isSelectAllEnabled],
+    [selectedRows, itemCount, page, dispatch, isSelectAllEnabled, isEntireTableSelected],
   );
+
+  useEffect(() => {
+    if (isSelectAllEnabled && !isEntireTableSelected) {
+      dispatch(toggleIsEntireTableSelected());
+    }
+  }, [dispatch, isEntireTableSelected, isSelectAllEnabled]);
 
   const numSelectedRows = itemCount === selectedRows.length || isSelectAllEnabled ? itemCount : selectedRows.length;
   const numSelectedRowsOnPage = (page || []).filter(r => r.isSelected).length;

--- a/src/DataTable/selection/data/actions.js
+++ b/src/DataTable/selection/data/actions.js
@@ -33,3 +33,8 @@ export const clearPageSelectionAction = (rowIds) => ({
   type: CLEAR_PAGE_SELECTION,
   rowIds,
 });
+
+export const TOGGLE_IS_ENTIRE_TABLE_SELECTED = 'TOGGLE IS ENTIRE TABLE SELECTED';
+export const toggleIsEntireTableSelectedAction = () => ({
+  type: TOGGLE_IS_ENTIRE_TABLE_SELECTED,
+});

--- a/src/DataTable/selection/data/actions.js
+++ b/src/DataTable/selection/data/actions.js
@@ -35,6 +35,6 @@ export const clearPageSelectionAction = (rowIds) => ({
 });
 
 export const TOGGLE_IS_ENTIRE_TABLE_SELECTED = 'TOGGLE IS ENTIRE TABLE SELECTED';
-export const toggleIsEntireTableSelectedAction = () => ({
+export const toggleIsEntireTableSelected = () => ({
   type: TOGGLE_IS_ENTIRE_TABLE_SELECTED,
 });

--- a/src/DataTable/selection/data/reducer.js
+++ b/src/DataTable/selection/data/reducer.js
@@ -23,7 +23,7 @@ const selectionsReducer = (state = initialState, action = {}) => {
         ...state,
         selectedRows,
       };
-      if (selectedRows.length === action.itemCount) {
+      if (state.isSelectAllEnabled || selectedRows.length === action.itemCount) {
         updatedState.isEntireTableSelected = true;
       }
       return updatedState;

--- a/src/DataTable/selection/data/reducer.js
+++ b/src/DataTable/selection/data/reducer.js
@@ -6,12 +6,13 @@ import {
   CLEAR_SELECTION,
   CLEAR_PAGE_SELECTION,
   SET_SELECT_ALL_ROWS_ALL_PAGES,
+  TOGGLE_IS_ENTIRE_TABLE_SELECTED,
 } from './actions';
 
 export const initialState = {
   selectedRows: [],
   isEntireTableSelected: false,
-  isSelectAllRowsAllPages: false,
+  isSelectAllEnabled: false,
 };
 
 const selectionsReducer = (state = initialState, action = {}) => {
@@ -31,13 +32,13 @@ const selectionsReducer = (state = initialState, action = {}) => {
       return {
         ...state,
         isEntireTableSelected: true,
-        isSelectAllRowsAllPages: true,
+        isSelectAllEnabled: true,
       };
     case DELETE_ROW:
       return {
         selectedRows: state.selectedRows.filter((row) => row.id !== action.rowId),
         isEntireTableSelected: false,
-        isSelectAllRowsAllPages: false,
+        isSelectAllEnabled: false,
       };
     case ADD_ROW: {
       const selectedRows = uniqBy([...state.selectedRows, action.row], row => row.id);
@@ -54,6 +55,12 @@ const selectionsReducer = (state = initialState, action = {}) => {
         isEntireTableSelected: false,
         isSelectAllRowsAllPages: false,
         selectedRows: state.selectedRows.filter(row => !action.rowIds.includes(row.id)),
+        isSelectAllEnabled: false,
+      };
+    case TOGGLE_IS_ENTIRE_TABLE_SELECTED:
+      return {
+        ...state,
+        isEntireTableSelected: !state.isEntireTableSelected,
       };
     default:
       return state;

--- a/src/DataTable/selection/data/reducer.js
+++ b/src/DataTable/selection/data/reducer.js
@@ -11,6 +11,7 @@ import {
 export const initialState = {
   selectedRows: [],
   isEntireTableSelected: false,
+  isSelectAllRowsAllPages: false,
 };
 
 const selectionsReducer = (state = initialState, action = {}) => {
@@ -30,11 +31,13 @@ const selectionsReducer = (state = initialState, action = {}) => {
       return {
         ...state,
         isEntireTableSelected: true,
+        isSelectAllRowsAllPages: true,
       };
     case DELETE_ROW:
       return {
         selectedRows: state.selectedRows.filter((row) => row.id !== action.rowId),
         isEntireTableSelected: false,
+        isSelectAllRowsAllPages: false,
       };
     case ADD_ROW: {
       const selectedRows = uniqBy([...state.selectedRows, action.row], row => row.id);
@@ -49,6 +52,7 @@ const selectionsReducer = (state = initialState, action = {}) => {
     case CLEAR_PAGE_SELECTION:
       return {
         isEntireTableSelected: false,
+        isSelectAllRowsAllPages: false,
         selectedRows: state.selectedRows.filter(row => !action.rowIds.includes(row.id)),
       };
     default:

--- a/src/DataTable/selection/data/reducer.js
+++ b/src/DataTable/selection/data/reducer.js
@@ -44,6 +44,7 @@ const selectionsReducer = (state = initialState, action = {}) => {
       const selectedRows = uniqBy([...state.selectedRows, action.row], row => row.id);
       const isEntireTableSelected = selectedRows.length === action.itemCount;
       return {
+        ...state,
         selectedRows,
         isEntireTableSelected,
       };
@@ -53,7 +54,6 @@ const selectionsReducer = (state = initialState, action = {}) => {
     case CLEAR_PAGE_SELECTION:
       return {
         isEntireTableSelected: false,
-        isSelectAllRowsAllPages: false,
         selectedRows: state.selectedRows.filter(row => !action.rowIds.includes(row.id)),
         isSelectAllEnabled: false,
       };

--- a/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
@@ -4,7 +4,11 @@ import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 
 import ControlledSelectionStatus from '../ControlledSelectionStatus';
-import { clearSelectionAction, setSelectAllRowsAllPagesAction, setSelectedRowsAction } from '../data/actions';
+import {
+  clearSelectionAction,
+  setSelectAllRowsAllPagesAction,
+  toggleIsEntireTableSelected,
+} from '../data/actions';
 import DataTableContext from '../../DataTableContext';
 import {
   SELECT_ALL_TEST_ID,
@@ -99,7 +103,8 @@ describe('<ControlledSelectionStatus />', () => {
             controlledTableSelections: [
               {
                 selectedRows,
-                isEntireTableSelected: true,
+                isEntireTableSelected: false,
+                isSelectAllEnabled: true,
               },
               dispatchSpy,
             ],
@@ -107,8 +112,9 @@ describe('<ControlledSelectionStatus />', () => {
         />,
       );
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
-      const action = setSelectedRowsAction(instance.page, instance.itemCount);
+      const action = toggleIsEntireTableSelected();
       expect(dispatchSpy).toHaveBeenCalledWith(action);
+      expect(screen.getByText(`All ${instance.itemCount} selected`)).toBeInTheDocument();
     });
   });
 

--- a/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
@@ -7,7 +7,6 @@ import ControlledSelectionStatus from '../ControlledSelectionStatus';
 import {
   clearSelectionAction,
   setSelectAllRowsAllPagesAction,
-  toggleIsEntireTableSelected,
 } from '../data/actions';
 import DataTableContext from '../../DataTableContext';
 import {
@@ -91,30 +90,6 @@ describe('<ControlledSelectionStatus />', () => {
       );
       const selectAllButton = screen.queryByTestId(SELECT_ALL_TEST_ID);
       expect(selectAllButton).not.toBeInTheDocument();
-    });
-
-    it('selects any unselected page rows', () => {
-      const selectedRows = Array(instance.itemCount).map((item, index) => ({ id: index + 1 }));
-      const dispatchSpy = jest.fn();
-      render(
-        <ControlledSelectionStatusWrapper
-          value={{
-            ...instance,
-            controlledTableSelections: [
-              {
-                selectedRows,
-                isEntireTableSelected: false,
-                isSelectAllEnabled: true,
-              },
-              dispatchSpy,
-            ],
-          }}
-        />,
-      );
-      expect(dispatchSpy).toHaveBeenCalledTimes(1);
-      const action = toggleIsEntireTableSelected();
-      expect(dispatchSpy).toHaveBeenCalledWith(action);
-      expect(screen.getByText(`All ${instance.itemCount} selected`)).toBeInTheDocument();
     });
   });
 

--- a/src/DataTable/selection/tests/reducer.test.js
+++ b/src/DataTable/selection/tests/reducer.test.js
@@ -25,6 +25,7 @@ describe('DataTable selections reducer', () => {
     const action = setSelectedRowsAction(rows, itemCount);
     const updatedState = selectionsReducer(defaultInitialState, action);
     expect(updatedState).toEqual({
+      ...defaultInitialState,
       isEntireTableSelected: true,
       selectedRows: rows,
     });
@@ -38,6 +39,7 @@ describe('DataTable selections reducer', () => {
     const updatedState = selectionsReducer(initialState, action);
     expect(updatedState).toEqual({
       isEntireTableSelected: true,
+      isSelectAllEnabled: true,
       selectedRows: initialState.selectedRows,
     });
   });
@@ -70,6 +72,7 @@ describe('DataTable selections reducer', () => {
     const action = addSelectedRowAction(row, itemCount);
     const updatedState = selectionsReducer(defaultInitialState, action);
     expect(updatedState).toEqual({
+      ...defaultInitialState,
       selectedRows: [row],
       isEntireTableSelected: true,
     });
@@ -88,6 +91,7 @@ describe('DataTable selections reducer', () => {
     const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const initialState = {
       ...defaultInitialState,
+      isSelectAllEnabled: false,
       selectedRows: rows,
     };
     const action = clearPageSelectionAction([1, 2]);

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -242,7 +242,7 @@ describe('<DataTable />', () => {
 
       const contextValue = JSON.parse(contextDiv.getAttribute('data-contextvalue'));
       expect(contextValue.controlledTableSelections).toEqual([
-        { selectedRows: [], isEntireTableSelected: false },
+        { selectedRows: [], isEntireTableSelected: false, isSelectAllEnabled: false },
         null,
       ]);
     });

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -212,7 +212,6 @@ describe('<DataTable />', () => {
       pageCount: 3,
       fetchData: jest.fn(),
     };
-
     render(<DataTableWrapper {...propsWithSelection} />);
     const filtersButton = screen.getByRole('button', { name: 'Filters' });
 
@@ -228,6 +227,10 @@ describe('<DataTable />', () => {
     // A filtered array is returned from the backend,
     // and the element counter displays its length.
     expect(selectAllButton).toHaveTextContent('Select all 7');
+
+    await userEvent.click(selectAllButton);
+
+    expect(screen.getByText('All 7 selected')).toBeInTheDocument();
   });
 
   describe('[legacy] controlled table selections', () => {

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as reactTable from 'react-table';
 import { IntlProvider } from 'react-intl';
@@ -314,6 +314,99 @@ describe('<DataTable />', () => {
 
       expect(mockOnSelectedRowsChange).toHaveBeenCalledTimes(1);
       expect(mockOnSelectedRowsChange).toHaveBeenCalledWith({});
+    });
+    it('Selects all rows across all pages with ControlledSelectionStatus component', async () => {
+      const selectColumn = {
+        id: 'selection',
+        Header: DataTable.ControlledSelectHeader,
+        Cell: DataTable.ControlledSelect,
+        disableSortBy: true,
+      };
+      const propsWithSelection = {
+        ...props,
+        isPaginated: true,
+        isSelectable: true,
+        manualSelectColumn: selectColumn,
+        SelectionStatusComponent: DataTable.ControlledSelectionStatus,
+        initialState: {
+          pageIndex: 0,
+          pageSize: 2,
+          selectedRowIds: {
+            1: true,
+          },
+        },
+      };
+      render(<DataTableWrapper {...propsWithSelection} />);
+      const selectAllButton = screen.getByTestId('test_selection_state_select_all_button');
+
+      await userEvent.click(selectAllButton);
+
+      expect(screen.getByText('All 7 selected')).toBeInTheDocument();
+    });
+
+    it('Select all item rows with ControlledSelectionStatus Component', async () => {
+      const selectColumn = {
+        id: 'selection',
+        Header: DataTable.ControlledSelectHeader,
+        Cell: DataTable.ControlledSelect,
+        disableSortBy: true,
+      };
+      const propsWithSelection = {
+        ...props,
+        isPaginated: true,
+        isSelectable: true,
+        manualSelectColumn: selectColumn,
+        SelectionStatusComponent: DataTable.ControlledSelectionStatus,
+        initialState: {
+          pageIndex: 0,
+          pageSize: 10,
+        },
+      };
+      render(<DataTableWrapper {...propsWithSelection} />);
+      const selectAllRowsButton = screen.getByTitle('Toggle All Current Page Rows Selected');
+
+      await userEvent.click(selectAllRowsButton);
+
+      expect(screen.getByText('All 7 selected')).toBeInTheDocument();
+    });
+
+    it('Select all item rows individually with ControlledSelectionStatus Component', async () => {
+      const selectColumn = {
+        id: 'selection',
+        Header: DataTable.ControlledSelectHeader,
+        Cell: DataTable.ControlledSelect,
+        disableSortBy: true,
+      };
+      const propsWithSelection = {
+        ...props,
+        isPaginated: true,
+        isSelectable: true,
+        manualSelectColumn: selectColumn,
+        SelectionStatusComponent: DataTable.ControlledSelectionStatus,
+        initialState: {
+          pageIndex: 0,
+          pageSize: 4,
+        },
+      };
+      render(<DataTableWrapper {...propsWithSelection} />);
+
+      const selectAllRows = () => {
+        const selectRowsButtons = screen.getAllByTitle('Toggle Row Selected');
+        selectRowsButtons.forEach(async (button) => {
+          await userEvent.click(button);
+        });
+      };
+      // Select all page 1
+      selectAllRows();
+
+      // Paginate to page 2
+      const nextPageButton2 = screen.getByLabelText('Next, Page 2');
+      await userEvent.click(nextPageButton2);
+
+      // Select all page 2
+      selectAllRows();
+
+      await waitFor(() => expect(screen.getByText('All 7 selected')).toBeInTheDocument());
     });
   });
 });

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -12,6 +12,7 @@ import { Link } from 'gatsby';
 import axios from 'axios';
 import classNames from 'classnames';
 import { v4 as uuidv4 } from 'uuid';
+import debounce from 'lodash.debounce';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import theme from 'prism-react-renderer/themes/duotoneDark';
 import {
@@ -165,6 +166,7 @@ function CodeBlock({
             GatsbyLink: Link,
             classNames,
             uuidv4,
+            debounce,
           }}
           theme={theme}
         >


### PR DESCRIPTION
## Description
Ticket: https://2u-internal.atlassian.net/browse/ENT-10012

This PR fixes an issue with the ControlledSelectionStatus component in Datatable. When a user with a `isPaginated`, `isFiltered` with the `SelectionStatusComponent` attribute set to the `ControlledSelectionStatus` from Datatable, makes a selection on a filtered table, where that selection sets the flag `isEntireTableSelected` to `true`, clears the filter to repopulate with the remaining data, the rest of the table is selected despite the user only selecting a filtered subset of what is its entire table. 

The resolution is to be explicit of when we actually set the remaining selected items by adding an additional state in the reducer for the select all feature. Instead of just validating entirely on `isEntireTableSelected` is truthy, we also check `isSelectAllEnabled` is truthy to indicate that the user intended to explicitly select all items. This removes the coupling of the rendering of the ControlledSelectionStatus component from`isEntireTableSelected` is true to whether the table was actually entirely selected with `isSelectAllEnabled`. We also validate whether the all selectables are actually selected in the top level Datatable and update the state of `isEntireTableSelected` appropriately if all available items to be selected are or are not selected.

It also updates an example in the documentation for Datatable under [Backend filtering and sorting](https://deploy-preview-3477--paragon-openedx-v22.netlify.app/components/datatable/#backend-filtering-and-sorting) mocking a backend driven filter. It correctly filters the items and simulates a "debounced" behavior on text input for the filter. This example also sets the `SelectionStatusComponent` to the `ControlledSelectionStatus`

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
