### PR TITLE
fix: update value of shadow-sm and shadow-lg utility classes

### DIFF
--- a/styles/scss/core/_variables.scss
+++ b/styles/scss/core/_variables.scss
@@ -653,12 +653,18 @@ $box-shadow-sides: (
   "centered"
 ) !default;
 
-$box-shadow-sm: var(--pgn-elevation-box-shadow-sm) !default;
+$box-shadow-sm:  var(--pgn-elevation-box-shadow-sm-offset-x)
+  var(--pgn-elevation-box-shadow-sm-offset-y)
+  var(--pgn-elevation-box-shadow-sm-blur)
+  var(--pgn-elevation-box-shadow-sm-color) !default;
 $box-shadow: var(--pgn-elevation-box-shadow-base-offset-x)
   var(--pgn-elevation-box-shadow-base-offset-y)
   var(--pgn-elevation-box-shadow-base-blur)
   var(--pgn-elevation-box-shadow-base-color) !default;
-$box-shadow-lg: var(--pgn-elevation-box-shadow-lg) !default;
+$box-shadow-lg:  var(--pgn-elevation-box-shadow-lg-offset-x)
+  var(--pgn-elevation-box-shadow-lg-offset-y)
+  var(--pgn-elevation-box-shadow-lg-blur)
+  var(--pgn-elevation-box-shadow-lg-color) !default;
 
 $component-active-color: var(--pgn-color-active) !default;
 $component-active-bg: var(--pgn-color-bg-active) !default;


### PR DESCRIPTION
## Description

The utility classes  .shadow-sm and .shadow-lg  are not working properly (css variable values are None  you can check in the [official documentation](https://paragon-openedx.netlify.app/foundations/css-utilities/),  we have the [values](https://github.com/openedx/paragon/blob/f3ab69aac949822c5fe30ca399d9e8f1846a6576/styles/css/themes/light/variables.css#L263-L270).

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
