### PR TITLE
fix: separate border-radius for checkbox from the input styles

### DIFF
--- a/src/Form/_index.scss
+++ b/src/Form/_index.scss
@@ -491,7 +491,7 @@ select.form-control {
   margin-top: .25rem;
 }
 
-.pgn__form-radio-input {
+.pgn__form-radio .pgn__form-radio-input {
   border-radius: var(--pgn-size-form-control-border-radio-indicator-radius);
 
   &:checked {

--- a/src/Form/_index.scss
+++ b/src/Form/_index.scss
@@ -412,7 +412,6 @@ select.form-control {
   border:
     solid var(--pgn-size-form-control-indicator-border-width)
     var(--pgn-color-form-control-indicator-border);
-  border-radius: var(--pgn-size-form-control-border-checkbox-indicator-radius) radius;
   margin-inline-end: var(--pgn-spacing-form-control-gutter);
   background-position: center;
 
@@ -434,6 +433,8 @@ select.form-control {
 }
 
 .pgn__form-checkbox-input {
+  border-radius: var(--pgn-size-form-control-border-checkbox-indicator-radius);
+
   &:checked {
     background-image: var(--pgn-other-content-form-control-checkbox-indicator-icon-checked-base);
   }
@@ -491,7 +492,7 @@ select.form-control {
   margin-top: .25rem;
 }
 
-.pgn__form-radio .pgn__form-radio-input {
+.pgn__form-radio-input {
   border-radius: var(--pgn-size-form-control-border-radio-indicator-radius);
 
   &:checked {


### PR DESCRIPTION
## Description

There is a specificity problem in the radio input with the radius, that make it display as a square instead of a circle.

![image](https://github.com/user-attachments/assets/ac772922-9626-41ba-bf2b-91ee8633c621)

You can check the wrong behavior in the [ORA rubric](https://app.pr-394-c0f80b.sandboxes.opencraft.hosting/ora-grading/block-v1:DEMO+TC01+TC01+type@openassessment+block@10e3d79afa024fa8bad094cd76973f45) 
### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
