### PR TITLE
fix: avoid merging duplicate properties during the build

### DIFF
--- a/lib/build-scss.js
+++ b/lib/build-scss.js
@@ -100,7 +100,7 @@ const compileAndWriteStyleSheets = ({
   const commonPostCssPlugins = [
     postCSSImport(),
     postCSSCustomMedia({ preserve: true }),
-    combineSelectors({ removeDuplicatedProperties: true }),
+    combineSelectors({ removeDuplicatedValues: true }),
   ];
 
   const postCSSCompilation = ora(`Compilation for ${capitalize(name)} stylesheet...`).start();


### PR DESCRIPTION
## Description
This PR aims to keep the duplicated properties defined for browser support, such as min-height in the modal container (more info in the issue https://github.com/openedx/paragon/issues/3511)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
