### PR TITLE
fix: alert header alignment [FC-0083]

### DIFF
--- a/dependent-usage.json
+++ b/dependent-usage.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": 1733926086658,
+  "lastModified": 1734012486681,
   "projectUsages": [
     {
       "version": "22.11.2",

--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -19,8 +19,12 @@
   @include border-radius($alert-border-radius);
   @include pgn-box-shadow(1, "down");
 
-  .alert-message-content > :last-child {
-    margin-bottom: 0;
+  .alert-message-content {
+    align-self: baseline;
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
   }
 
   .alert-icon {


### PR DESCRIPTION
## Description

This PR fixes the `Alert` header alignment with the icon when only the header is present.

### Deploy Preview

WIP

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
