### PR TITLE
fix: design token typos

### DIFF
--- a/styles/css/themes/light/abstraction-variables.css
+++ b/styles/css/themes/light/abstraction-variables.css
@@ -183,14 +183,14 @@
     var(--pgn-elevation-box-shadow-up-3-2-color);
 
   --pgn-elevation-box-shadow-up-4:
-    var(--pgn-elevation-box-shadow-up-3-1-offset-x)
-    var(--pgn-elevation-box-shadow-up-3-1-offset-y)
-    var(--pgn-elevation-box-shadow-up-3-1-blur)
-    var(--pgn-elevation-box-shadow-up-3-1-color),
-    var(--pgn-elevation-box-shadow-up-3-2-offset-x)
-    var(--pgn-elevation-box-shadow-up-3-2-offset-y)
-    var(--pgn-elevation-box-shadow-up-3-2-blur)
-    var(--pgn-elevation-box-shadow-up-3-2-color);
+    var(--pgn-elevation-box-shadow-up-4-1-offset-x)
+    var(--pgn-elevation-box-shadow-up-4-1-offset-y)
+    var(--pgn-elevation-box-shadow-up-4-1-blur)
+    var(--pgn-elevation-box-shadow-up-4-1-color),
+    var(--pgn-elevation-box-shadow-up-4-2-offset-x)
+    var(--pgn-elevation-box-shadow-up-4-2-offset-y)
+    var(--pgn-elevation-box-shadow-up-4-2-blur)
+    var(--pgn-elevation-box-shadow-up-4-2-color);
 
   --pgn-elevation-box-shadow-up-5:
     var(--pgn-elevation-box-shadow-up-5-1-offset-x)

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -307,7 +307,7 @@
   --pgn-elevation-box-shadow-down-5-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-down-5-2-offset-x: 0; /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-down-5-2-offset-y: 0.5rem; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-2-blur: 2.5rem; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-2-blur: 3rem; /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-left-1-1-color: rgba(0, 0, 0, 0.15); /* Left box shadow of level 1. */
   --pgn-elevation-box-shadow-left-1-1-offset-x: -0.0625rem; /* Left box shadow of level 1. */
   --pgn-elevation-box-shadow-left-1-1-offset-y: 0; /* Left box shadow of level 1. */

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -250,7 +250,7 @@
   --pgn-elevation-box-shadow-level-4-2-blur: 1.25rem; /* Basic box shadow of level 4. */
   --pgn-elevation-box-shadow-level-5-1-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-level-5-1-offset-x: 0; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-1-offset-y: 1.25px; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-1-offset-y: 1.25rem; /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-level-5-1-blur: 2.5rem; /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-level-5-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-level-5-2-offset-x: 0; /* Basic box shadow of level 5. */
@@ -302,7 +302,7 @@
   --pgn-elevation-box-shadow-down-4-2-blur: 1.25rem; /* Bottom box shadow of level 4. */
   --pgn-elevation-box-shadow-down-5-1-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-down-5-1-offset-x: 0; /* Bottom box shadow of level 5. */
-  --pgn-elevation-box-shadow-down-5-1-offset-y: 1.25px; /* Bottom box shadow of level 5. */
+  --pgn-elevation-box-shadow-down-5-1-offset-y: 1.25rem; /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-down-5-1-blur: 2.5rem; /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-down-5-2-color: rgba(0, 0, 0, 0.15); /* Bottom box shadow of level 5. */
   --pgn-elevation-box-shadow-down-5-2-offset-x: 0; /* Bottom box shadow of level 5. */

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -255,7 +255,7 @@
   --pgn-elevation-box-shadow-level-5-2-color: rgba(0, 0, 0, 0.15); /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-level-5-2-offset-x: 0; /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-level-5-2-offset-y: 0.5rem; /* Basic box shadow of level 5. */
-  --pgn-elevation-box-shadow-level-5-2-blur: 2.5rem; /* Basic box shadow of level 5. */
+  --pgn-elevation-box-shadow-level-5-2-blur: 3rem; /* Basic box shadow of level 5. */
   --pgn-elevation-box-shadow-base-color: rgba(0, 0, 0, 0.3); /* Default box shadow. */
   --pgn-elevation-box-shadow-base-offset-x: 0; /* Default box shadow. */
   --pgn-elevation-box-shadow-base-offset-y: 0.125rem; /* Default box shadow. */

--- a/tokens/src/themes/light/global/elevation.json
+++ b/tokens/src/themes/light/global/elevation.json
@@ -81,7 +81,7 @@
             {
               "color": "rgba(0, 0, 0, .15)",
               "offsetX": "0",
-              "offsetY": "1.25px",
+              "offsetY": "1.25rem",
               "blur": "2.5rem"
             },
             {
@@ -203,7 +203,7 @@
             {
               "color": "rgba(0, 0, 0, .15)",
               "offsetX": "0",
-              "offsetY": "1.25px",
+              "offsetY": "1.25rem",
               "blur": "2.5rem"
             },
             {

--- a/tokens/src/themes/light/global/elevation.json
+++ b/tokens/src/themes/light/global/elevation.json
@@ -88,7 +88,7 @@
               "color": "rgba(0, 0, 0, .15)",
               "offsetX": "0",
               "offsetY": ".5rem",
-              "blur": "2.5rem"
+              "blur": "3rem"
             }
           ],
           "$description": "Basic box shadow of level 5."

--- a/tokens/src/themes/light/global/elevation.json
+++ b/tokens/src/themes/light/global/elevation.json
@@ -210,7 +210,7 @@
               "color": "rgba(0, 0, 0, .15)",
               "offsetX": "0",
               "offsetY": ".5rem",
-              "blur": "2.5rem"
+              "blur": "3rem"
             }
           ],
           "$description": "Bottom box shadow of level 5."


### PR DESCRIPTION
## Description

This corrects some typos for the elevation design tokens. I used the [Paragon Figma](https://www.figma.com/design/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=9076-7393&m=dev) to determine what the expected values are for elevation.

- `--pgn-elevation-box-shadow-up-4` was previously using values for `--pgn-elevation-box-shadow-up-3`
- `--pgn-elevation-box-shadow-level-5-1-offset-y` was set to `1.25px` when it should be `1.25rem`
- `--pgn-elevation-box-shadow-level-5-2-blur` was set to `2.5rem` when it should be `3rem`

### Deploy Preview

https://deploy-preview-3566--paragon-openedx-v23.netlify.app/foundations/elevation/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
