### PR TITLE
feat: changing the header of ProductTour 

### DIFF
--- a/dependent-usage.json
+++ b/dependent-usage.json
@@ -1,5 +1,5 @@
 {
-  "lastModified": 1733926086658,
+  "lastModified": 1734012486681,
   "projectUsages": [
     {
       "version": "22.11.2",

--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -130,11 +130,9 @@ const Checkpoint = React.forwardRef(({
 Checkpoint.defaultProps = {
   advanceButtonText: null,
   body: null,
-  dismissButtonText: null,
   endButtonText: null,
   placement: 'top',
   title: null,
-  showDismissButton: undefined,
 };
 
 Checkpoint.propTypes = {
@@ -142,8 +140,6 @@ Checkpoint.propTypes = {
   advanceButtonText: PropTypes.node,
   /** The text displayed in the body of the Checkpoint */
   body: PropTypes.node,
-  /** The text displayed on the button used to dismiss the tour for the given Checkpoint. */
-  dismissButtonText: PropTypes.node,
   /** The text displayed on the button used to end the tour for the given Checkpoint. */
   endButtonText: PropTypes.node,
   /** The current index of the given Checkpoint */
@@ -168,8 +164,6 @@ Checkpoint.propTypes = {
   title: PropTypes.node,
   /** The total number of Checkpoints in a tour */
   totalCheckpoints: PropTypes.number.isRequired,
-  /** Enforces visibility of the dismiss button under all circumstances */
-  showDismissButton: PropTypes.bool,
 };
 
 export default Checkpoint;

--- a/src/ProductTour/Checkpoint.scss
+++ b/src/ProductTour/Checkpoint.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import url("variables");
 
 $checkpoint-arrow-top-color: solid $checkpoint-arrow-width $checkpoint-border-color;
 $checkpoint-arrow-default-color: solid $checkpoint-arrow-width $checkpoint-background-color;
@@ -9,7 +9,7 @@ $checkpoint-arrow-transparent: solid $checkpoint-arrow-width transparent;
   background: $checkpoint-background-color;
   border-top: $checkpoint-border-width solid $checkpoint-border-color;
   border-radius: $border-radius;
-  padding: map_get($spacers, 4);
+  padding: map_get($spacers, 3\.5);
   box-shadow: 0 .25rem .5rem rgba(0, 0, 0, .3);
   z-index: $checkpoint-z-index;
   max-width: $checkpoint-max-width;
@@ -88,12 +88,19 @@ $checkpoint-arrow-transparent: solid $checkpoint-arrow-width transparent;
   .pgn__checkpoint-header {
     display: flex;
     justify-content: space-between;
-    margin-bottom: map_get($spacers, 2\.5);
+    margin-bottom: map_get($spacers, 2);
+    align-items: center;
+    height: 30px;
   }
 
   #pgn__checkpoint-title {
     font-size: $h3-font-size;
     margin-inline-end: map_get($spacers, 2\.5);
+    margin-bottom: .5rem;
+  }
+
+  .pgn__checkpoint-page-index {
+    font-size: $small-font-size;
     margin-bottom: 0;
   }
 }

--- a/src/ProductTour/Checkpoint.test.jsx
+++ b/src/ProductTour/Checkpoint.test.jsx
@@ -30,7 +30,6 @@ describe('Checkpoint', () => {
           <Checkpoint
             advanceButtonText="Next"
             body="Lorem ipsum checkpoint body"
-            dismissButtonText="Dismiss"
             endButtonText="End"
             index={1}
             onAdvance={handleAdvance}
@@ -81,7 +80,6 @@ describe('Checkpoint', () => {
           <Checkpoint
             advanceButtonText="Next"
             body="Lorem ipsum checkpoint body"
-            dismissButtonText="Dismiss"
             endButtonText="End"
             index={4}
             onAdvance={handleAdvance}
@@ -114,7 +112,6 @@ describe('Checkpoint', () => {
           <Checkpoint
             advanceButtonText="Next"
             body="Lorem ipsum checkpoint body"
-            dismissButtonText="Dismiss"
             endButtonText="End"
             index={0}
             onAdvance={handleAdvance}
@@ -135,32 +132,6 @@ describe('Checkpoint', () => {
     it('does not render breadcrumbs', () => {
       const breadcrumbs = screen.queryAllByTestId('pgn__checkpoint-breadcrumb_', { exact: false });
       expect(breadcrumbs.length).toEqual(0);
-    });
-  });
-
-  describe('only one Checkpoint in Tour and showDismissButton set to true', () => {
-    it('it renders dismiss button and end button', () => {
-      render(
-        <IntlProvider locale="en" messages={{}}>
-          <div id="#target-element" />
-          <Checkpoint
-            advanceButtonText="Next"
-            body="Lorem ipsum checkpoint body"
-            dismissButtonText="Dismiss"
-            endButtonText="End"
-            index={0}
-            onAdvance={handleAdvance}
-            onDismiss={handleDismiss}
-            onEnd={handleEnd}
-            target="#target-element"
-            title="Checkpoint title"
-            totalCheckpoints={1}
-            showDismissButton
-          />
-        </IntlProvider>,
-      );
-      expect(screen.getByText('Dismiss', { selector: 'button' })).toBeInTheDocument();
-      expect(screen.getByText('End', { selector: 'button' })).toBeInTheDocument();
     });
   });
 });

--- a/src/ProductTour/CheckpointActionRow.jsx
+++ b/src/ProductTour/CheckpointActionRow.jsx
@@ -4,65 +4,64 @@ import Button from '../Button';
 
 const CheckpointActionRow = React.forwardRef(({
   advanceButtonText,
-  dismissButtonText,
+  backButtonText,
   endButtonText,
   isLastCheckpoint,
   onAdvance,
-  onDismiss,
+  onBack,
   onEnd,
-  showDismissButton,
   index,
-}, ref) => (
-  <div className="pgn__checkpoint-action-row" ref={ref}>
-    {(showDismissButton === undefined ? !isLastCheckpoint : showDismissButton) && (
+}, ref) => {
+  const isFirstCheckpoint = index === 0;
+  return (
+    <div className="pgn__checkpoint-action-row" ref={ref}>
+      {!isFirstCheckpoint && (
+        <Button
+          className="pgn__checkpoint-button_dismiss"
+          variant="tertiary"
+          onClick={onBack}
+        >
+          {backButtonText}
+        </Button>
+      )}
       <Button
-        variant="tertiary"
-        className="pgn__checkpoint-button_dismiss"
-        onClick={onDismiss}
+        autoFocus
+        className="pgn__checkpoint-button_advance"
+        variant="primary"
+        onClick={isLastCheckpoint ? () => onEnd(index) : () => onAdvance(index)}
       >
-        {dismissButtonText}
+        {isLastCheckpoint ? endButtonText : advanceButtonText}
       </Button>
-    )}
-    <Button
-      autoFocus
-      className="pgn__checkpoint-button_advance"
-      variant="primary"
-      onClick={isLastCheckpoint ? () => onEnd(index) : () => onAdvance(index)}
-    >
-      {isLastCheckpoint ? endButtonText : advanceButtonText}
-    </Button>
-  </div>
-));
+    </div>
+  );
+});
 
 CheckpointActionRow.defaultProps = {
   advanceButtonText: '',
-  dismissButtonText: '',
+  backButtonText: '',
   endButtonText: '',
   isLastCheckpoint: false,
-  onAdvance: () => {},
-  onDismiss: () => {},
-  onEnd: () => {},
-  showDismissButton: undefined,
+  onAdvance: () => { },
+  onBack: () => { },
+  onEnd: () => { },
   index: 0,
 };
 
 CheckpointActionRow.propTypes = {
   /** The text displayed on the button used to advance the tour. */
   advanceButtonText: PropTypes.node,
-  /** The text displayed on the button used to dismiss the tour. */
-  dismissButtonText: PropTypes.node,
+  /** The text displayed on the button used to go back on the tour */
+  backButtonText: PropTypes.node,
   /** The text displayed on the button used to end the tour. */
   endButtonText: PropTypes.node,
   /** Whether the parent Checkpoint is the last in the tour. */
   isLastCheckpoint: PropTypes.bool,
   /** A function that runs when triggering the `onClick` event of the advance button. */
   onAdvance: PropTypes.func,
-  /** A function that runs when triggering the `onClick` event of the dismiss button. */
-  onDismiss: PropTypes.func,
+  /** A function that runs when triggering the `onClick` event of the back button. */
+  onBack: PropTypes.func,
   /** A function that runs when triggering the `onClick` event of the advance button if isLastCheckpoint is true. */
   onEnd: PropTypes.func,
-  /** Enforces visibility of the dismiss button under all circumstances */
-  showDismissButton: PropTypes.bool,
   /** Allows visibility of last index value for onEnd checkpoint compatibility */
   index: PropTypes.number,
 };

--- a/src/ProductTour/CheckpointHeader.jsx
+++ b/src/ProductTour/CheckpointHeader.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import Icon from '../Icon';
+import IconButton from '../IconButton';
+import { Close } from '../../icons';
+import CheckpointTitle from './CheckpointTitle';
+import messages from './messages';
+
+const CheckpointHeader = React.forwardRef(({
+  index, onDismiss, title, totalCheckpoints,
+}) => {
+  const intl = useIntl();
+  const oneBasedIndex = index + 1;
+
+  const closeAltText = intl.formatMessage({
+    id: 'pgn.ProductTour.checkpointHeader.close',
+    defaultMessage: 'Close tour',
+    description: 'Close alt text for ProductTour component',
+  });
+
+  return (
+    <>
+      <div className="pgn__checkpoint-header">
+        <p className="pgn__checkpoint-page-index">
+          <FormattedMessage
+            {...messages.pageIndexText}
+            values={{ step: oneBasedIndex, totalSteps: totalCheckpoints }}
+          />
+        </p>
+        <IconButton
+          iconAs={Icon}
+          src={Close}
+          alt={closeAltText}
+          onClick={onDismiss}
+          variant="primary"
+        />
+      </div>
+      <CheckpointTitle>{title}</CheckpointTitle>
+    </>
+  );
+});
+
+CheckpointHeader.defaultProps = {
+  title: '',
+};
+
+CheckpointHeader.propTypes = {
+  /** The current index of the given Checkpoint */
+  index: PropTypes.number.isRequired,
+  /** A function that runs when triggering the `onClick` event of the dismiss
+   * button for the given Checkpoint. */
+  onDismiss: PropTypes.func.isRequired,
+  /** The text displayed in the title of the Checkpoint */
+  title: PropTypes.node,
+  /** The total number of Checkpoints in a tour */
+  totalCheckpoints: PropTypes.number.isRequired,
+};
+
+export default CheckpointHeader;

--- a/src/ProductTour/ProductTour.test.jsx
+++ b/src/ProductTour/ProductTour.test.jsx
@@ -27,7 +27,6 @@ describe('<ProductTour />', () => {
 
   const disabledTourData = {
     advanceButtonText: 'Next',
-    dismissButtonText: 'Dismiss',
     enabled: false,
     endButtonText: 'Okay',
     onDismiss: handleDismiss,
@@ -44,7 +43,7 @@ describe('<ProductTour />', () => {
 
   const tourData = {
     advanceButtonText: 'Next',
-    dismissButtonText: 'Dismiss',
+    backButtonText: 'Back',
     enabled: true,
     endButtonText: 'Okay',
     onDismiss: handleDismiss,
@@ -132,15 +131,56 @@ describe('<ProductTour />', () => {
         expect(screen.getByRole('dialog', { name: 'Checkpoint 1' })).toBeInTheDocument();
 
         // Click the dismiss button
-        const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
-        expect(dismissButton).toBeInTheDocument();
+        const closeButton = screen.getByRole('button', { name: 'Close tour' });
+        expect(closeButton).toBeInTheDocument();
 
         await act(async () => {
-          await userEvent.click(dismissButton);
+          await userEvent.click(closeButton);
         });
 
         // Verify no Checkpoints have rendered
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      it('onClick of close icon button disables tour', async () => {
+        const { rerender } = render(<ProductTourWrapper tours={[tourData]} />);
+        // Advance the tour, close icon only appears after first step
+        await act(async () => {
+          await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+        });
+        rerender(<ProductTourWrapper tours={[tourData]} />);
+
+        const closeIcon = screen.getByRole('button', { name: 'Close tour' });
+        expect(closeIcon).toBeInTheDocument();
+
+        await act(async () => {
+          await userEvent.click(closeIcon);
+        });
+        expect(handleDismiss).toHaveBeenCalled();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      it('onClick of back button going to the previous checkpoint', async () => {
+        const { rerender } = render(<ProductTourWrapper tours={[tourData]} />);
+        // Back button only appears when you are not on the first step of the tour
+        expect(screen.getByRole('heading', { name: 'Checkpoint 1' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+        // Advance the tour
+        await act(async () => {
+          await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+        });
+        rerender(<ProductTourWrapper tours={[tourData]} />);
+        expect(screen.getByText('Checkpoint 2')).toBeInTheDocument();
+
+        // Go back in the tour
+        const backButton = screen.getByRole('button', { name: 'Back' });
+        expect(backButton).toBeInTheDocument();
+        await act(async () => {
+          await userEvent.click(backButton);
+        });
+
+        rerender(<ProductTourWrapper tours={[tourData]} />);
+        expect(screen.getByText('Checkpoint 1')).toBeInTheDocument();
       });
 
       it('onClick of end button disables tour', async () => {
@@ -200,7 +240,6 @@ describe('<ProductTour />', () => {
     describe('with Checkpoint override settings', () => {
       const overrideTourData = {
         advanceButtonText: 'Next',
-        dismissButtonText: 'Dismiss',
         enabled: true,
         endButtonText: 'Okay',
         onDismiss: handleDismiss,
@@ -226,8 +265,7 @@ describe('<ProductTour />', () => {
             onDismiss: customOnDismiss,
             onAdvance: customOnAdvance,
             advanceButtonText: 'Override advance',
-            dismissButtonText: 'Override dismiss',
-
+            backButtonText: 'Override back',
           },
           {
             target: '#target-4',
@@ -257,15 +295,15 @@ describe('<ProductTour />', () => {
 
         expect(screen.getByText('Checkpoint 4')).toBeInTheDocument();
       });
-      it('applies override for dismissButtonText', () => {
+      it('applies override for backButtonText', () => {
         render(<ProductTourWrapper tours={[overrideTourData]} />);
-        expect(screen.getByRole('button', { name: 'Override dismiss' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Override back' })).toBeInTheDocument();
       });
       it('calls customHandleDismiss onClick of dismiss button', async () => {
         render(<ProductTourWrapper tours={[overrideTourData]} />);
-        const dismissButton = screen.getByRole('button', { name: 'Override dismiss' });
+        const closeButton = screen.getByRole('button', { name: 'Close tour' });
         await act(async () => {
-          await userEvent.click(dismissButton);
+          await userEvent.click(closeButton);
         });
         expect(customOnDismiss).toHaveBeenCalledTimes(1);
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -305,7 +343,6 @@ describe('<ProductTour />', () => {
       it('does not render', () => {
         const badTourData = {
           advanceButtonText: 'Next',
-          dismissButtonText: 'Dismiss',
           enabled: true,
           endButtonText: 'Okay',
           onDismiss: handleDismiss,
@@ -328,7 +365,6 @@ describe('<ProductTour />', () => {
       it('advances to next valid Checkpoint', () => {
         const badTourData = {
           advanceButtonText: 'Next',
-          dismissButtonText: 'Dismiss',
           enabled: true,
           endButtonText: 'Okay',
           onDismiss: handleDismiss,
@@ -361,7 +397,6 @@ describe('<ProductTour />', () => {
     it('renders first enabled tour', () => {
       const secondEnabledTourData = {
         advanceButtonText: 'Next',
-        dismissButtonText: 'Dismiss',
         enabled: true,
         endButtonText: 'Okay',
         onDismiss: handleDismiss,

--- a/src/ProductTour/README.md
+++ b/src/ProductTour/README.md
@@ -24,7 +24,7 @@ The checkpoint objects themselves have additional props that can override the pr
     const myFirstTour = {
       tourId: 'myFirstTour',
       advanceButtonText: 'Next',
-      dismissButtonText: 'Dismiss',
+      backButtonText: 'Back',
       endButtonText: 'Okay',
       enabled: isTourEnabled,
       onDismiss: () => setIsTourEnabled(false),
@@ -52,6 +52,13 @@ The checkpoint objects themselves have additional props that can override the pr
           placement: 'bottom',
           target: '#checkpoint-3',
           title: 'Third checkpoint',
+          backButtonText: 'Rewind', 
+        },
+        {
+          body: "Here's the fourth checkpoint!",
+          placement: 'bottom',
+          target: '#checkpoint-4',
+          title: 'Fourth checkpoint',
           onEnd: () => {
             console.log('Ended the third checkpoint');
             setIsTourEnabled(false);

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -6,17 +6,17 @@ import Checkpoint from './Checkpoint';
 const ProductTour = React.forwardRef(({ tours }, ref) => {
   const tourValue = tours.find((tour) => tour.enabled);
   const {
-    enabled, checkpoints = [], startingIndex, onEscape, onEnd, onDismiss: tourOnDismiss,
-    advanceButtonText: tourAdvanceButtonText, dismissButtonText: tourDismissButtonText,
-    endButtonText: tourEndButtonText,
+    enabled, checkpoints = [], startingIndex, onEscape, onEnd, onBack,
+    onDismiss: tourOnDismiss, advanceButtonText: tourAdvanceButtonText,
+    endButtonText: tourEndButtonText, backButtonText: tourBackButtonText,
   } = tourValue || {};
   const [currentCheckpointData, setCurrentCheckpointData] = useState(null);
   const [index, setIndex] = useState(0);
   const [isTourEnabled, setIsTourEnabled] = useState(false);
   const [prunedCheckpoints, setPrunedCheckpoints] = useState([]);
   const {
-    title, body, onAdvance, onDismiss, advanceButtonText, dismissButtonText,
-    endButtonText, placement, target, showDismissButton,
+    title, body, onAdvance, onDismiss, advanceButtonText, endButtonText, backButtonText,
+    placement, target,
   } = currentCheckpointData || {};
 
   /**
@@ -71,6 +71,13 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     }
   };
 
+  const handleBack = () => {
+    setIndex(index - 1);
+    if (onBack) {
+      onBack();
+    }
+  };
+
   const handleDismiss = () => {
     setIndex(0);
     setIsTourEnabled(false);
@@ -104,19 +111,19 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
   return (
     <Checkpoint
       advanceButtonText={advanceButtonText || tourAdvanceButtonText}
+      backButtonText={backButtonText || tourBackButtonText}
       body={body}
       currentCheckpointData={currentCheckpointData}
-      dismissButtonText={dismissButtonText || tourDismissButtonText}
       endButtonText={endButtonText || tourEndButtonText}
       index={index}
       onAdvance={handleAdvance}
+      onBack={handleBack}
       onDismiss={handleDismiss}
       onEnd={handleEnd}
       placement={placement}
       target={target}
       title={title}
       totalCheckpoints={prunedCheckpoints.length}
-      showDismissButton={showDismissButton}
       ref={ref}
     />
   );
@@ -128,17 +135,16 @@ ProductTour.defaultProps = {
     checkpoints: {
       advanceButtonText: '',
       body: '',
-      dismissButtonText: '',
       endButtonText: '',
       onAdvance: () => {},
+      onBack: () => {},
       onDismiss: () => {},
       placement: 'top',
       title: '',
-      showDismissButton: undefined,
     },
-    dismissButtonText: '',
     endButtonText: '',
     onDismiss: () => {},
+    onBack: () => {},
     onEnd: () => {},
     onEscape: () => {},
     startingIndex: 0,
@@ -156,9 +162,6 @@ ProductTour.propTypes = {
       advanceButtonText: PropTypes.node,
       /** The text displayed in the body of the Checkpoint */
       body: PropTypes.node,
-      /** The text displayed on the button used to dismiss the tour for the given Checkpoint
-       * (overrides the `dismissButtonText` defined in the parent tour object). */
-      dismissButtonText: PropTypes.node,
       /** The text displayed on the button used to end the tour for the given Checkpoint
        * (overrides the `endButtonText` defined in the parent tour object). */
       endButtonText: PropTypes.node,
@@ -180,11 +183,7 @@ ProductTour.propTypes = {
       target: PropTypes.string.isRequired,
       /** The text displayed in the title of the Checkpoint */
       title: PropTypes.node,
-      /** Enforces visibility of the dismiss button under all circumstances */
-      showDismissButton: PropTypes.bool,
     })),
-    /** The text displayed on the button used to dismiss the tour. */
-    dismissButtonText: PropTypes.node,
     /** Whether the tour is enabled. If there are multiple tours defined, only one should be enabled at a time. */
     enabled: PropTypes.bool.isRequired,
     /** The text displayed on the button used to end the tour. */

--- a/src/ProductTour/messages.js
+++ b/src/ProductTour/messages.js
@@ -11,6 +11,11 @@ const messages = defineMessages({
     defaultMessage: 'Bottom of step {step}',
     description: 'Screen-reader message to notify user that they are located at the bottom of the product tour step.',
   },
+  pageIndexText: {
+    id: 'pgn.ProductTour.Checkpoint.page-index-text',
+    defaultMessage: '{step} of {totalSteps}',
+    description: 'Page index showing your place in the ProductTour',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Changing the header of the ProductTour component, along with the action row buttons. Previously, the action row was "Dismiss" and "Next", but now the dismiss functionality is available in a new close button, and the button is a "Back" button to go back a step in the tour. 
[Figma](https://www.figma.com/design/CDznc7PPoNiEQmfkkT57CV/ProductTour-proposal?node-id=0-1&t=jmJsQgaR9416hMAm-0) 

Before | After 
<img width="361" alt="Screenshot 2025-05-06 at 11 15 27 AM" src="https://github.com/user-attachments/assets/9307b7c7-9503-4457-a62b-3ebad14c59e3" /><img width="364" alt="Screenshot 2025-05-06 at 11 15 45 AM" src="https://github.com/user-attachments/assets/41c31f72-90a1-4c85-ad96-9b06f889f0f2" />


## Testing instructions 
- Run `npm run start` in your local paragon repo after checking out this branch
- Navigate to `http://localhost:8000/components/producttour/`
- Go forward and back in the tour, validate the header matches Figma 
- Ensure that the overridden dismiss functionality (at step 3) works as expected

## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
