### PR TITLE
fix: change menu item hover to reference tertiary hover color

### DIFF
--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -1399,7 +1399,7 @@
   --pgn-color-icon-button-text-black-inverse-active-focus: var(--pgn-color-icon-button-text-black-inverse-active-base);
   --pgn-color-image-figure-caption: var(--pgn-color-gray-500);
   --pgn-color-menu-item-color: var(--pgn-color-body-base);
-  --pgn-color-menu-item-hover-color: var(--pgn-color-btn-text-tertiary);
+  --pgn-color-menu-item-hover-color: var(--pgn-color-btn-hover-text-tertiary);
   --pgn-color-menu-select-btn-link-color: var(--pgn-color-primary-500);
   --pgn-color-modal-content-bg: var(--pgn-color-bg-base);
   --pgn-color-nav-tabs-base-border-base: var(--pgn-color-light-400);

--- a/tokens/src/themes/light/components/Menu.json
+++ b/tokens/src/themes/light/components/Menu.json
@@ -14,7 +14,7 @@
         "bg": { "source": "$menu-item-bg", "$value": "transparent" },
         "border": { "source": "$menu-item-border-color", "$value": "{color.menu.item.bg}" },
         "hover": {
-          "color": { "source": "$menu-item-hover-color", "$value": "{color.btn.text.tertiary}" },
+          "color": { "source": "$menu-item-hover-color", "$value": "{color.btn.hover.text.tertiary}" },
           "bg": { "source": "$menu-item-hover-bg", "$value": "{color.btn.hover.bg.tertiary}" },
           "border": { "source": "$menu-item-hover-border-color", "$value": "{color.menu.item.bg}" }
         },


### PR DESCRIPTION
## Description

This sets the `MenuItem` hover state to use `--pgn-color-btn-hover-text-tertiary` rather than using `--pgn-color-btn-text-tertiary`. The `--pgn-color-btn-hover-text-tertiary` variable already existed so the only change here is that the `--pgn-color-menu-item-hover-color` variable has been changed to reference it.

The color for `--pgn-color-btn-text-tertiary` and `--pgn-color-btn-hover-text-tertiary` are the same so there is no visual change.

### Deploy Preview

https://deploy-preview-3573--paragon-openedx-v23.netlify.app/components/menu/select-menu/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
