### PR TITLE
fix: alert header alignment [FC-0083]

### DIFF
--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -15,9 +15,14 @@
   padding: $alert-padding-y $alert-padding-x;
   margin-bottom: $alert-margin-bottom;
   border: $alert-border-width solid transparent;
+  align-items: center;
 
   @include border-radius($alert-border-radius);
   @include pgn-box-shadow(1, "down");
+
+  &:has(.alert-heading:not(:only-child)) {
+    align-items: start;
+  }
 
   .alert-message-content > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Description

This PR fixes the `Alert` icon header alignment with the icon when only the header with buttons is present.

```jsx
<Alert
  variant="info"
  icon={Loop}
  dismissible
  actions={[
    <Button>Hello</Button>,
  ]}>
  <Alert.Heading>Alert with heading and no content</Alert.Heading>
</Alert>
```

## Additional Information
- https://github.com/openedx/frontend-app-authoring/issues/1853

### Deploy Preview

https://deploy-preview-3574--paragon-openedx-v22.netlify.app/components/alert/
|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/3fb726bc-4201-4319-969d-f52e0e9cbb5e) | ![image](https://github.com/user-attachments/assets/73a7a28d-d942-4a46-85cd-0ef4c511d7d9) |

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.