### PR TITLE
feat: menu item focus token to reference color directly

### DIFF
--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -1400,6 +1400,7 @@
   --pgn-color-image-figure-caption: var(--pgn-color-gray-500);
   --pgn-color-menu-item-color: var(--pgn-color-body-base);
   --pgn-color-menu-item-hover-color: var(--pgn-color-btn-hover-text-tertiary);
+  --pgn-color-menu-item-focus-bg: var(--pgn-color-light-500);
   --pgn-color-menu-select-btn-link-color: var(--pgn-color-primary-500);
   --pgn-color-modal-content-bg: var(--pgn-color-bg-base);
   --pgn-color-nav-tabs-base-border-base: var(--pgn-color-light-400);
@@ -1812,7 +1813,6 @@
   --pgn-color-icon-button-text-danger-inverse-active-focus: var(--pgn-color-icon-button-text-danger-inverse-active-base);
   --pgn-color-image-thumbnail-bg: var(--pgn-color-body-bg);
   --pgn-color-menu-item-hover-bg: var(--pgn-color-btn-hover-bg-tertiary);
-  --pgn-color-menu-item-focus-bg: var(--pgn-color-btn-active-bg-tertiary);
   --pgn-color-nav-tabs-inverse-link-bg-hover: var(--pgn-color-nav-tabs-inverse-link-border-bottom);
   --pgn-color-nav-pills-base-link-active-bg: var(--pgn-color-bg-active);
   --pgn-color-nav-pills-base-link-border: var(--pgn-color-nav-tabs-base-border-base);

--- a/tokens/src/themes/light/components/Menu.json
+++ b/tokens/src/themes/light/components/Menu.json
@@ -19,7 +19,7 @@
           "border": { "source": "$menu-item-hover-border-color", "$value": "{color.menu.item.bg}" }
         },
         "focus": {
-          "bg": { "source": "$menu-item-focus-bg", "$value": "{color.btn.active.bg.tertiary}" }
+          "bg": { "source": "$menu-item-focus-bg", "$value": "{color.light.500}" }
         }
       },
       "select": {


### PR DESCRIPTION
## Description

Change was discussed in [Paragon Working Group Meeting 2025-05-14](https://openedx.atlassian.net/wiki/spaces/BPL/pages/4989026309/2025-05-14+Meeting+notes)

This PR makes an adjustment to the focus state background color token for the `MenuItem` component. This change has the token reference the `--pgn-color-light-500` variable rather than the `--pgn-color-btn-active-bg-tertiary` variable. Since the token is for focus state and _not_ the active state, it made sense to just reference the color directly instead of relying on a token with the same value, despite the fact that the active state may serve a similar function.

This was set up like this because it followed the pattern from previous versions of Paragon. The `$menu-item-focus-bg` SCSS variable previously referenced the `$btn-tertiary-active-bg`SCSS variable, thus paving the way for this token to do the same, but with design tokens instead.

Here are some PRs that provide historical context:

- Creating the `Menu` and `MenuItem` components #804
- Creating the `SelectMenu` component and fixes to Menu #1126
- Bug fix for the `SelectMenu` component #2279

### Breaking Change for theme authors

Since this changes the reference of a token, theme authors will need to make adjustments to their brand overrides if they are relying on the `--pgn-color-btn-active-bg-tertiary` token to determine the background for the focus state of the `MenuItem` component.

### Deploy Preview

Note, there are no visual changes here. But if you inspect the CSS for the `MenuItem` component, you will see it now references `--pgn-color-light-500` rather than the `--pgn-color-btn-active-bg-tertiary` variable.

[Preview of Menu page](https://deploy-preview-3583--paragon-openedx-v23.netlify.app/components/menu/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
