### PR TITLE
docs: replace brand-edx.org with elm-theme

### DIFF
--- a/lib/build-scss.js
+++ b/lib/build-scss.js
@@ -94,7 +94,7 @@ const compileAndWriteStyleSheets = ({
       },
     }],
     // For now we can't resolve these warnings as we need to upgrade our 'bootstrap' dependency to do so:
-    silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin'],
+    silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
   });
 
   const commonPostCssPlugins = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -6953,16 +6953,18 @@
         }
       }
     },
-    "node_modules/@edx/brand-edx.org": {
-      "version": "2.1.3",
-      "license": "UNLICENSED"
-    },
     "node_modules/@edx/browserslist-config": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.5.0.tgz",
       "integrity": "sha512-d2ggwi5j4DOBJOwhWZxBWQSDR0DhT4ke/1PbzRauICdFkuOyax+PsFjK8GUh443K2OaQpy9PGfiCzZ1Yg37AUA==",
       "dev": true,
       "license": "AGPL-3.0"
+    },
+    "node_modules/@edx/elm-theme": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@edx/elm-theme/-/elm-theme-1.8.2.tgz",
+      "integrity": "sha512-zxdO8Tc+1id4KGmV+Tzp3xvUNyNpA1UpAhdx2cFVvXRHXW0dC63x7vfMLeeUElxZQEZkZw/ZUPr+T+FWegWnoA==",
+      "license": "UNLICENSED"
     },
     "node_modules/@edx/eslint-config": {
       "version": "4.3.0",
@@ -47720,7 +47722,7 @@
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.8",
-        "@edx/brand-edx.org": "^2.1.2",
+        "@edx/elm-theme": "^1.8.2",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@mdx-js/mdx": "^2",
         "@mdx-js/react": "^2",

--- a/src/Button/button-group.scss
+++ b/src/Button/button-group.scss
@@ -41,6 +41,7 @@
     @include border-right-radius(0);
   }
 
+  > .btn:not(:first-child),
   > .btn-group:not(:first-child) > .btn {
     @include border-left-radius(0);
   }

--- a/src/Button/button-group.scss
+++ b/src/Button/button-group.scss
@@ -15,7 +15,7 @@
     &:focus,
     &:active,
     &.active {
-      z-index: 2;
+      z-index: 1;
     }
   }
 }
@@ -36,64 +36,13 @@
     margin-left: calc(var(--pgn-size-btn-border-width) * -1);
   }
 
-  // Mixin for button states that affect border radius
-
-  @mixin button-border-radius-0($side) {
-    @if $side == 'right' {
-      @include border-right-radius(0);
-    }
-
-    @if $side == 'left' {
-      @include border-left-radius(0);
-    }
-    
-    // Handle pseudo-classes
-    &.btn:not(:disabled, .disabled):focus,
-    &.btn:not(:disabled, .disabled):focus::before {
-      @if $side == 'left' {
-        @include border-left-radius(0);
-      }
-
-      @if $side == 'right' {
-        @include border-right-radius(0);
-      }
-    }
-    
-    &.btn:not(:disabled, .disabled):active,
-    &.btn:not(:disabled, .disabled):active::before {
-      @if $side == 'left' {
-        @include border-left-radius(0);
-      }
-
-      @if $side == 'right' {
-        @include border-right-radius(0);
-      }
-    }
-    
-    // Handle .active class
-    &.btn:not(:disabled, .disabled).active,
-    &.btn:not(:disabled, .disabled).active::before {
-      @if $side == 'right' {
-        @include border-right-radius(0);
-      }
-
-      @if $side == 'left' {
-        @include border-left-radius(0);
-      }
-    }
-  }
-
-  // Right border radius for non-last buttons
-  > .btn:not(:last-child, .dropdown-toggle, :first-child),
   > .btn:not(:last-child, .dropdown-toggle),
   > .btn-group:not(:last-child) > .btn {
-    @include button-border-radius-0('right');
+    @include border-right-radius(0);
   }
 
-  // Left border radius for non-first buttons
-  > .btn:not(:first-child, .dropdown-toggle),
   > .btn-group:not(:first-child) > .btn {
-    @include button-border-radius-0('left');
+    @include border-left-radius(0);
   }
 }
 

--- a/src/Button/button-group.scss
+++ b/src/Button/button-group.scss
@@ -15,7 +15,7 @@
     &:focus,
     &:active,
     &.active {
-      z-index: 1;
+      z-index: 2;
     }
   }
 }
@@ -36,14 +36,50 @@
     margin-left: calc(var(--pgn-size-btn-border-width) * -1);
   }
 
-  > .btn:not(:last-child, .dropdown-toggle),
-  > .btn-group:not(:last-child) > .btn {
-    @include border-right-radius(0);
+  // Mixin for button states that affect border radius
+  @mixin button-border-radius($side) {
+    @if $side == 'right' {
+      @include border-right-radius(0);
+    } @else if $side == 'left' {
+      @include border-left-radius(0);
+    }
+    
+    // Pseudo-class states
+    $pseudo-states: 'focus', 'active';
+    
+    // Handle pseudo-classes
+    @each $state in $pseudo-states {
+      &.btn:not(:disabled):not(.disabled):#{$state},
+      &.btn:not(:disabled):not(.disabled):#{$state}::before {
+        @if $side == 'right' {
+          @include border-right-radius(0);
+        } @else if $side == 'left' {
+          @include border-left-radius(0);
+        }
+      }
+    }
+    
+    // Handle .active class separately
+    &.btn:not(:disabled):not(.disabled).active,
+    &.btn:not(:disabled):not(.disabled).active::before {
+      @if $side == 'right' {
+        @include border-right-radius(0);
+      } @else if $side == 'left' {
+        @include border-left-radius(0);
+      }
+    }
   }
 
+  // Right border radius for non-last buttons
+  > .btn:not(:last-child, .dropdown-toggle),
+  > .btn-group:not(:last-child) > .btn {
+    @include button-border-radius('right');
+  }
+
+  // Left border radius for non-first buttons
   > .btn:not(:first-child),
   > .btn-group:not(:first-child) > .btn {
-    @include border-left-radius(0);
+    @include button-border-radius('left');
   }
 }
 

--- a/src/Button/button-group.scss
+++ b/src/Button/button-group.scss
@@ -37,47 +37,61 @@
   }
 
   // Mixin for button states that affect border radius
+
   @mixin button-border-radius($side) {
     @if $side == 'right' {
       @include border-right-radius(0);
-    } @else if $side == 'left' {
+    }
+
+    @if $side == 'left' {
       @include border-left-radius(0);
     }
     
-    // Pseudo-class states
-    $pseudo-states: 'focus', 'active';
-    
     // Handle pseudo-classes
-    @each $state in $pseudo-states {
-      &.btn:not(:disabled):not(.disabled):#{$state},
-      &.btn:not(:disabled):not(.disabled):#{$state}::before {
-        @if $side == 'right' {
-          @include border-right-radius(0);
-        } @else if $side == 'left' {
-          @include border-left-radius(0);
-        }
+    &.btn:not(:disabled, .disabled):focus,
+    &.btn:not(:disabled, .disabled):focus::before {
+      @if $side == 'left' {
+        @include border-left-radius(0);
+      }
+
+      @if $side == 'right' {
+        @include border-right-radius(0);
+      }
+    }
+    
+    &.btn:not(:disabled, .disabled):active,
+    &.btn:not(:disabled, .disabled):active::before {
+      @if $side == 'left' {
+        @include border-left-radius(0);
+      }
+
+      @if $side == 'right' {
+        @include border-right-radius(0);
       }
     }
     
     // Handle .active class separately
-    &.btn:not(:disabled):not(.disabled).active,
-    &.btn:not(:disabled):not(.disabled).active::before {
+    &.btn:not(:disabled, .disabled).active,
+    &.btn:not(:disabled, .disabled).active::before {
       @if $side == 'right' {
         @include border-right-radius(0);
-      } @else if $side == 'left' {
+      }
+
+      @if $side == 'left' {
         @include border-left-radius(0);
       }
     }
   }
 
   // Right border radius for non-last buttons
+  > .btn:not(:last-child, .dropdown-toggle, :first-child),
   > .btn:not(:last-child, .dropdown-toggle),
   > .btn-group:not(:last-child) > .btn {
     @include button-border-radius('right');
   }
 
   // Left border radius for non-first buttons
-  > .btn:not(:first-child),
+  > .btn:not(:first-child, .dropdown-toggle),
   > .btn-group:not(:first-child) > .btn {
     @include button-border-radius('left');
   }

--- a/src/Button/button-group.scss
+++ b/src/Button/button-group.scss
@@ -70,7 +70,7 @@
       }
     }
     
-    // Handle .active class separately
+    // Handle .active class
     &.btn:not(:disabled, .disabled).active,
     &.btn:not(:disabled, .disabled).active::before {
       @if $side == 'right' {

--- a/src/Button/button-group.scss
+++ b/src/Button/button-group.scss
@@ -38,7 +38,7 @@
 
   // Mixin for button states that affect border radius
 
-  @mixin button-border-radius($side) {
+  @mixin button-border-radius-0($side) {
     @if $side == 'right' {
       @include border-right-radius(0);
     }
@@ -87,13 +87,13 @@
   > .btn:not(:last-child, .dropdown-toggle, :first-child),
   > .btn:not(:last-child, .dropdown-toggle),
   > .btn-group:not(:last-child) > .btn {
-    @include button-border-radius('right');
+    @include button-border-radius-0('right');
   }
 
   // Left border radius for non-first buttons
   > .btn:not(:first-child, .dropdown-toggle),
   > .btn-group:not(:first-child) > .btn {
-    @include button-border-radius('left');
+    @include button-border-radius-0('left');
   }
 }
 

--- a/www/build-themes.js
+++ b/www/build-themes.js
@@ -11,7 +11,13 @@ const importer = function importer(url) {
   if (url.startsWith('~paragon-style')) {
     file = path.resolve(__dirname, '../styles', url.substr('~paragon-style/'.length));
   } else if (url[0] === '~') {
-    file = path.resolve(__dirname, '../node_modules', url.substr(1));
+    const siblingNodeModulesPath = path.resolve(__dirname, './node_modules', url.substr(1));
+    const parentNodeModulesPath = path.resolve(__dirname, '../node_modules', url.substr(1));
+    if (fs.existsSync(siblingNodeModulesPath)) {
+      file = siblingNodeModulesPath;
+    } else {
+      file = parentNodeModulesPath;
+    }
   }
 
   return { file };
@@ -30,7 +36,7 @@ THEMES.forEach(theme => {
     importer,
     quietDeps: true,
     // For now we can't resolve these warnings as we need to upgrade our 'bootstrap' dependency to do so:
-    silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin'],
+    silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
   });
 
   postCSS([postCSSCustomMedia({ preserve: true })])

--- a/www/gatsby-config.mjs
+++ b/www/gatsby-config.mjs
@@ -36,7 +36,7 @@ const plugins = [
         },
       },
       sassOptions: {
-        silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin'],
+        silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
       },
     },
   },

--- a/www/package.json
+++ b/www/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@docsearch/react": "^3.8",
-    "@edx/brand-edx.org": "^2.1.2",
+    "@edx/elm-theme": "^1.8.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@mdx-js/mdx": "^2",
     "@mdx-js/react": "^2",

--- a/www/src/scss/edxorg-theme.scss
+++ b/www/src/scss/edxorg-theme.scss
@@ -1,4 +1,0 @@
-@import "~paragon-style/scss/core/core";
-@import "base";
-@import "https://cdn.jsdelivr.net/npm/@edx/elm-theme@1.8.1/dist/core.min.css";
-@import "https://cdn.jsdelivr.net/npm/@edx/elm-theme@1.8.1/dist/light.min.css";

--- a/www/src/scss/elm-theme.scss
+++ b/www/src/scss/elm-theme.scss
@@ -1,0 +1,4 @@
+@use "~@edx/elm-theme/dist/core.css" as elmThemeCore;
+@use "~@edx/elm-theme/dist/light.css" as elmThemeLight;
+
+@import "base";

--- a/www/src/scss/elm-theme.scss
+++ b/www/src/scss/elm-theme.scss
@@ -1,4 +1,4 @@
-@use "~@edx/elm-theme/dist/core.css" as elmThemeCore;
-@use "~@edx/elm-theme/dist/light.css" as elmThemeLight;
-
+@use "~paragon-style/scss/core/core" as paragonCore;
+@use "~@edx/elm-theme/dist/core.css" as elmCore;
+@use "~@edx/elm-theme/dist/light.css" as elmLight;
 @import "base";

--- a/www/src/scss/elm-theme.scss
+++ b/www/src/scss/elm-theme.scss
@@ -1,4 +1,4 @@
 @use "~paragon-style/scss/core/core" as paragonCore;
-@use "~@edx/elm-theme/dist/core.css" as elmCore;
-@use "~@edx/elm-theme/dist/light.css" as elmLight;
+@use "~@edx/elm-theme/dist/core" as elmCore;
+@use "~@edx/elm-theme/dist/light" as elmLight;
 @use "base";

--- a/www/src/scss/elm-theme.scss
+++ b/www/src/scss/elm-theme.scss
@@ -1,4 +1,4 @@
 @use "~paragon-style/scss/core/core" as paragonCore;
 @use "~@edx/elm-theme/dist/core.css" as elmCore;
 @use "~@edx/elm-theme/dist/light.css" as elmLight;
-@import "base";
+@use "base";

--- a/www/src/scss/openedx-theme.scss
+++ b/www/src/scss/openedx-theme.scss
@@ -1,5 +1,5 @@
-@import "~paragon-style/scss/core/core";
-@import "~paragon-style/css/themes/light/variables";
-@import "~paragon-style/css/themes/light/abstraction-variables";
-@import "~paragon-style/css/themes/light/utility-classes";
-@import "base";
+@use "~paragon-style/scss/core/core" as paragonCore;
+@use "~paragon-style/css/themes/light/variables" as paragonLight;
+@use "~paragon-style/css/themes/light/abstraction-variables" as paragonLightAbstraction;
+@use "~paragon-style/css/themes/light/utility-classes" as paragonLightUtility;
+@use "base";

--- a/www/src/scss/openedx-theme.scss
+++ b/www/src/scss/openedx-theme.scss
@@ -1,5 +1,5 @@
 @use "~paragon-style/scss/core/core" as paragonCore;
-@use "~paragon-style/css/themes/light/variables" as paragonLight;
-@use "~paragon-style/css/themes/light/abstraction-variables" as paragonLightAbstraction;
-@use "~paragon-style/css/themes/light/utility-classes" as paragonLightUtility;
+@use "~paragon-style/css/themes/light/variables" as paragonLightVariables;
+@use "~paragon-style/css/themes/light/abstraction-variables" as paragonLightAbstractionVariables;
+@use "~paragon-style/css/themes/light/utility-classes" as paragonLightUtilityClasses;
 @use "base";

--- a/www/theme-config.js
+++ b/www/theme-config.js
@@ -16,10 +16,10 @@ const THEMES = [
     pathToVariables: undefined,
   },
   {
-    id: 'edxorg',
-    label: 'edX.org',
-    stylesheet: 'edxorg-theme',
-    pathToVariables: '@edx/brand-edx.org/paragon/_variables.scss',
+    id: 'elm',
+    label: 'Elm',
+    stylesheet: 'elm-theme',
+    pathToVariables: undefined,
   },
 ];
 

--- a/www/utils/createCssUtilityClassNodes.js
+++ b/www/utils/createCssUtilityClassNodes.js
@@ -21,7 +21,7 @@ function createCssUtilityClassNodes({
         }
         return { file: resolvedUrl };
       },
-      silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin'],
+      silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
     })
     .css.toString();
 


### PR DESCRIPTION
## Description

The `v23`/`next` versions of the Paragon docs site still use `@edx/brand-edx.org`, so the colors appear incorrect when switching to the "edX" theme on the docs site.

This PR swaps out `@edx/brand-edx.org` for `@edx/elm-theme` instead, which is compatible with design tokens and CSS variables, with the goal being that the docs site has the correct colors, etc. when switching to the `@edx/elm-theme` in the browser.

### Deploy Preview

* https://deploy-preview-3594--paragon-openedx-v23.netlify.app/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
