### PR TITLE
feat(cli): add `exclude-core` flag

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -97,6 +97,11 @@ const COMMANDS = {
         defaultValue: 'light',
       },
       {
+        name: '--exclude-core',
+        description: 'Exclude core from the token build.',
+        defaultValue: false,
+      },
+      {
         name: '-v, --verbose',
         description: 'Enable verbose logging.',
         defaultValue: false,

--- a/lib/__tests__/build-tokens.test.js
+++ b/lib/__tests__/build-tokens.test.js
@@ -63,6 +63,25 @@ describe('buildTokensCommand', () => {
     }));
   });
 
+  it('should handle the exclude-core flag', async () => {
+    await buildTokensCommand(['--exclude-core']);
+
+    // only light theme, not core
+    expect(StyleDictionary).toHaveBeenCalledTimes(1);
+    const callArgs = StyleDictionary.mock.calls[0][0];
+    for (const file of callArgs.platforms.css.files) {
+      expect(file.destination).toContain('themes/light');
+    }
+
+    // Verify only light theme index files are created
+    expect(createIndexCssFile).toHaveBeenCalledTimes(1);
+    expect(createIndexCssFile).toHaveBeenCalledWith(expect.objectContaining({
+      buildDir: defaultBuildDir,
+      isThemeVariant: true,
+      themeVariant: 'light',
+    }));
+  });
+
   it('should use custom build path', async () => {
     const customBuildDir = './custom-build/';
     await buildTokensCommand(['--build-dir', customBuildDir]);

--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -22,6 +22,7 @@ async function buildTokensCommand(commandArgs) {
     'build-dir': './build/',
     'source-tokens-only': false,
     'output-references': true,
+    'exclude-core': false,
     verbose: false,
   };
 
@@ -38,12 +39,13 @@ async function buildTokensCommand(commandArgs) {
     'output-references': outputReferences,
     themes,
     verbose,
+    'exclude-core': excludeCore,
   } = minimist(
     commandArgs,
     {
       alias,
       default: defaultParams,
-      boolean: ['source-tokens-only', 'output-references', 'verbose'],
+      boolean: ['source-tokens-only', 'output-references', 'exclude-core', 'verbose'],
     },
   );
 
@@ -144,17 +146,19 @@ async function buildTokensCommand(commandArgs) {
     },
   });
 
-  // Create list of style-dictionary configurations to build (core + theme variants)
-  const configs = [
-    { config: coreConfig },
-    ...parsedThemes.map((themeVariant) => {
-      const config = getStyleDictionaryConfig(themeVariant);
-      return {
-        config,
-        themeVariant,
-      };
-    }),
-  ];
+  // Create list of style-dictionary configurations to build
+  const configs = [];
+
+  //  Add core if it isn't excluded
+  if (!excludeCore) {
+    configs.push({ config: coreConfig });
+  }
+
+  //  Add theme variants
+  for (const themeVariant of parsedThemes) {
+    const config = getStyleDictionaryConfig(themeVariant);
+    configs.push({ config, themeVariant });
+  }
 
   // Build tokens for each configuration
   await Promise.all(configs.map(async ({ config, themeVariant }) => {


### PR DESCRIPTION
## Description

Add a new `--exclude-core` flag for the `build-tokens` CLI command. When using this flag, core tokens are not transformed - only theme tokens are.
