### PR TITLE
feat(cli): add `excludeCore` flag for `build-scss`

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -148,6 +148,11 @@ const COMMANDS = {
         defaultValue: 'styles/scss/core/core.scss',
       },
       {
+        name: '--excludeCore',
+        description: 'Exclude core from the SCSS build.',
+        defaultValue: false,
+      },
+      {
         name: '--themesPath',
         description: `Path to the directory that contains themes' files. Expects directory to have following structure:
           themes/

--- a/lib/__tests__/build-scss.test.js
+++ b/lib/__tests__/build-scss.test.js
@@ -143,4 +143,18 @@ describe('buildScssCommand', () => {
       expect.any(Object),
     );
   });
+
+  it('should exclude core properly', () => {
+    buildScssCommand(['--excludeCore']);
+
+    expect(sass.compile).not.toHaveBeenCalledWith(
+      expect.stringContaining('core.scss'),
+      expect.any(Object),
+    );
+
+    expect(fs.readdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('themes'),
+      expect.objectContaining({ withFileTypes: true }),
+    );
+  });
 });

--- a/lib/build-scss.js
+++ b/lib/build-scss.js
@@ -154,6 +154,7 @@ const compileAndWriteStyleSheets = ({
 function buildScssCommand(commandArgs) {
   const defaultArgs = {
     corePath: path.resolve(process.cwd(), 'styles/scss/core/core.scss'),
+    excludeCore: false,
     themesPath: path.resolve(process.cwd(), 'styles/css/themes'),
     outDir: './dist',
     defaultThemeVariants: 'light',
@@ -161,17 +162,20 @@ function buildScssCommand(commandArgs) {
 
   const {
     corePath,
+    excludeCore,
     themesPath,
     outDir,
     defaultThemeVariants,
-  } = minimist(commandArgs, { default: defaultArgs });
+  } = minimist(commandArgs, { default: defaultArgs, boolean: ['excludeCore'] });
 
   // Core CSS
-  compileAndWriteStyleSheets({
-    name: 'core',
-    stylesPath: corePath,
-    outDir,
-  });
+  if (!excludeCore) {
+    compileAndWriteStyleSheets({
+      name: 'core',
+      stylesPath: corePath,
+      outDir,
+    });
+  }
 
   // Theme Variants CSS
   fs.readdirSync(themesPath, { withFileTypes: true })


### PR DESCRIPTION
## Description

Add a new `--excludeCore` flag for the `build-scss` CLI command. When using this flag, core css is not generated - only theme css is.