### PR TITLE
feat: adding i18n support for modal dialog close button label

### DIFF
--- a/src/Modal/ModalDialog.tsx
+++ b/src/Modal/ModalDialog.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useMediaQuery } from 'react-responsive';
+import { useIntl } from 'react-intl';
 import ModalLayer from './ModalLayer';
 // @ts-ignore for now - this needs to be converted to TypeScript
 import ModalCloseButton from './ModalCloseButton';
@@ -18,6 +19,7 @@ import ModalDialogHero from './ModalDialogHero';
 import Icon from '../Icon';
 import IconButton from '../IconButton';
 import { Close } from '../../icons';
+import messages from './messages';
 
 export const MODAL_DIALOG_CLOSE_LABEL = 'Close';
 
@@ -64,7 +66,7 @@ function ModalDialog({
   size = 'md',
   variant = 'default',
   hasCloseButton = true,
-  closeLabel = MODAL_DIALOG_CLOSE_LABEL,
+  closeLabel,
   isFullscreenScroll = false,
   className,
   isFullscreenOnMobile = false,
@@ -73,6 +75,8 @@ function ModalDialog({
   isOverflowVisible,
 }: Props) {
   const isMobile = useMediaQuery({ query: '(max-width: 767.98px)' });
+  const intl = useIntl();
+  const closeButtonText = closeLabel || intl.formatMessage(messages.closeButtonText);
   const showFullScreen = (isFullscreenOnMobile && isMobile);
   return (
     <ModalLayer isOpen={isOpen} onClose={onClose} isBlocking={isBlocking} zIndex={zIndex}>
@@ -97,7 +101,7 @@ function ModalDialog({
               iconAs={Icon}
               invertColors={variant === 'dark'}
               src={Close}
-              alt={closeLabel}
+              alt={closeButtonText}
             />
           </div>
         )}

--- a/src/Modal/messages.ts
+++ b/src/Modal/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  closeButtonText: {
+    id: 'pgn.Modal.closeButon',
+    defaultMessage: 'Close',
+    description: 'Accessible name for the close button in the modal dialog',
+  },
+});
+
+export default messages;

--- a/src/Modal/tests/AlertModal.test.jsx
+++ b/src/Modal/tests/AlertModal.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-
+import { IntlProvider } from 'react-intl';
 import AlertModal from '../AlertModal';
 import { Info } from '../../../icons';
 
@@ -37,15 +37,17 @@ describe('<AlertModal />', () => {
 
   it('renders the body when isOpen', () => {
     render(
-      <AlertModal
-        title="some title"
-        isOpen={isOpen}
-        onClose={closeFn}
-        footerNode={<p>footer</p>}
-        isOverflowVisible={false}
-      >
-        <Body />
-      </AlertModal>,
+      <IntlProvider locale="en" messages={{}}>
+        <AlertModal
+          title="some title"
+          isOpen={isOpen}
+          onClose={closeFn}
+          footerNode={<p>footer</p>}
+          isOverflowVisible={false}
+        >
+          <Body />
+        </AlertModal>
+      </IntlProvider>,
     );
 
     const body = screen.getByText('The body of alert.');
@@ -55,16 +57,18 @@ describe('<AlertModal />', () => {
   describe('with variant prop', () => {
     it('renders warning variant', () => {
       render(
-        <AlertModal
-          title="warning"
-          isOpen={isOpen}
-          onClose={closeFn}
-          icon={Info}
-          footerNode={<p>footer</p>}
-          isOverflowVisible={false}
-        >
-          <Body />
-        </AlertModal>,
+        <IntlProvider locale="en" messages={{}}>
+          <AlertModal
+            title="warning"
+            isOpen={isOpen}
+            onClose={closeFn}
+            icon={Info}
+            footerNode={<p>footer</p>}
+            isOverflowVisible={false}
+          >
+            <Body />
+          </AlertModal>
+        </IntlProvider>,
       );
 
       const modalTitle = screen.getByTestId('title-icon');
@@ -73,16 +77,18 @@ describe('<AlertModal />', () => {
 
     it('renders success variant', () => {
       render(
-        <AlertModal
-          title="success"
-          isOpen={isOpen}
-          onClose={closeFn}
-          icon={Info}
-          footerNode={<p>footer</p>}
-          isOverflowVisible={false}
-        >
-          <Body />
-        </AlertModal>,
+        <IntlProvider locale="en" messages={{}}>
+          <AlertModal
+            title="success"
+            isOpen={isOpen}
+            onClose={closeFn}
+            icon={Info}
+            footerNode={<p>footer</p>}
+            isOverflowVisible={false}
+          >
+            <Body />
+          </AlertModal>
+        </IntlProvider>,
       );
 
       const modalTitle = screen.getByTestId('title-icon');
@@ -91,16 +97,18 @@ describe('<AlertModal />', () => {
 
     it('renders danger variant', () => {
       render(
-        <AlertModal
-          title="danger"
-          isOpen={isOpen}
-          onClose={closeFn}
-          icon={Info}
-          footerNode={<p>footer</p>}
-          isOverflowVisible={false}
-        >
-          <Body />
-        </AlertModal>,
+        <IntlProvider locale="en" messages={{}}>
+          <AlertModal
+            title="danger"
+            isOpen={isOpen}
+            onClose={closeFn}
+            icon={Info}
+            footerNode={<p>footer</p>}
+            isOverflowVisible={false}
+          >
+            <Body />
+          </AlertModal>
+        </IntlProvider>,
       );
 
       const modalTitle = screen.getByTestId('title-icon');

--- a/src/Modal/tests/ModalDialog.test.tsx
+++ b/src/Modal/tests/ModalDialog.test.tsx
@@ -1,33 +1,36 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+import { IntlProvider } from 'react-intl';
 import ModalDialog from '../ModalDialog';
 
 describe('ModalDialog', () => {
   it('renders a dialog with aria-label and content', () => {
     const onClose = jest.fn();
     render(
-      <ModalDialog
-        title="My dialog"
-        isOpen
-        onClose={onClose}
-        size="md"
-        variant="default"
-        hasCloseButton
-        isOverflowVisible={false}
-      >
-        <ModalDialog.Header>
-          <ModalDialog.Title>The title</ModalDialog.Title>
-        </ModalDialog.Header>
+      <IntlProvider locale="en" messages={{}}>
+        <ModalDialog
+          title="My dialog"
+          isOpen
+          onClose={onClose}
+          size="md"
+          variant="default"
+          hasCloseButton
+          isOverflowVisible={false}
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>The title</ModalDialog.Title>
+          </ModalDialog.Header>
 
-        <ModalDialog.Body>
-          <p>The content</p>
-        </ModalDialog.Body>
+          <ModalDialog.Body>
+            <p>The content</p>
+          </ModalDialog.Body>
 
-        <ModalDialog.Footer>
-          <ModalDialog.CloseButton>Cancel</ModalDialog.CloseButton>
-        </ModalDialog.Footer>
-      </ModalDialog>,
+          <ModalDialog.Footer>
+            <ModalDialog.CloseButton>Cancel</ModalDialog.CloseButton>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      </IntlProvider>,
     );
 
     const dialogNode = screen.getByRole('dialog');
@@ -40,15 +43,18 @@ describe('ModalDialog', () => {
   it('is hidden by default', () => {
     const onClose = jest.fn();
     render(
-      <ModalDialog
-        title="My dialog"
-        onClose={onClose}
-        isOverflowVisible={false}
-      >
-        <ModalDialog.Header><ModalDialog.Title>The title</ModalDialog.Title></ModalDialog.Header>
-        <ModalDialog.Body><p>The hidden content</p></ModalDialog.Body>
-        <ModalDialog.Footer><ModalDialog.CloseButton>Cancel</ModalDialog.CloseButton></ModalDialog.Footer>
-      </ModalDialog>,
+      <IntlProvider locale="en" messages={{}}>
+        <ModalDialog
+          title="My dialog"
+          onClose={onClose}
+          closeLabel="Close"
+          isOverflowVisible={false}
+        >
+          <ModalDialog.Header><ModalDialog.Title>The title</ModalDialog.Title></ModalDialog.Header>
+          <ModalDialog.Body><p>The hidden content</p></ModalDialog.Body>
+          <ModalDialog.Footer><ModalDialog.CloseButton>Cancel</ModalDialog.CloseButton></ModalDialog.Footer>
+        </ModalDialog>
+      </IntlProvider>,
     );
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -59,30 +65,32 @@ describe('ModalDialog with Hero', () => {
   it('renders a dialog with aria-label and hero with img', () => {
     const onClose = jest.fn();
     render(
-      <ModalDialog
-        title="My dialog"
-        isOpen
-        onClose={onClose}
-        size="md"
-        variant="default"
-        hasCloseButton
-        isOverflowVisible={false}
-      >
-        <ModalDialog.Hero>
-          <ModalDialog.Hero.Background backgroundSrc="imageurl" />
-          <ModalDialog.Hero.Content data-testid="modal-hero-content">
-            <ModalDialog.Title>The title</ModalDialog.Title>
-          </ModalDialog.Hero.Content>
-        </ModalDialog.Hero>
+      <IntlProvider locale="en" messages={{}}>
+        <ModalDialog
+          title="My dialog"
+          isOpen
+          onClose={onClose}
+          size="md"
+          variant="default"
+          hasCloseButton
+          isOverflowVisible={false}
+        >
+          <ModalDialog.Hero>
+            <ModalDialog.Hero.Background backgroundSrc="imageurl" />
+            <ModalDialog.Hero.Content data-testid="modal-hero-content">
+              <ModalDialog.Title>The title</ModalDialog.Title>
+            </ModalDialog.Hero.Content>
+          </ModalDialog.Hero>
 
-        <ModalDialog.Body>
-          <p>The content</p>
-        </ModalDialog.Body>
+          <ModalDialog.Body>
+            <p>The content</p>
+          </ModalDialog.Body>
 
-        <ModalDialog.Footer>
-          <ModalDialog.CloseButton>Cancel</ModalDialog.CloseButton>
-        </ModalDialog.Footer>
-      </ModalDialog>,
+          <ModalDialog.Footer>
+            <ModalDialog.CloseButton>Cancel</ModalDialog.CloseButton>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      </IntlProvider>,
     );
     const dialogNode = screen.getByRole('dialog');
 


### PR DESCRIPTION
## Description
#3529 
Adding i18n support for the close button label on the modal dialog component
Recomendations on unit tests were ignored since those are not user facing texts.
<img width="1594" alt="Captura de pantalla 2025-05-29 a la(s) 3 01 31 p m" src="https://github.com/user-attachments/assets/1b081191-b7cb-4759-9f28-2c4301c0e35e" />

[release 22 pr](https://github.com/openedx/paragon/pull/3624)

### Deploy Preview

https://deploy-preview-3618--paragon-openedx-v23.netlify.app

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
