### PR TITLE
Adding missing aria label to Dropdown with Icon

### DIFF
--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -114,6 +114,7 @@ You can use `Dropdown.Toggle` with [IconButton](/components/iconbutton) componen
     src={MoreVert}
     iconAs={Icon}
     variant="primary"
+    aria-label="More actions"
   />
   <Dropdown.Menu>
     <Dropdown.Item href="#/action-1">Action</Dropdown.Item>


### PR DESCRIPTION
## Description

Adding aria label attribute to Dropdown with Icon.
<img width="1916" alt="Captura de pantalla 2025-06-02 a la(s) 2 48 24 p m" src="https://github.com/user-attachments/assets/dda5b66b-b9f9-4251-99f2-8b3168ac1518" />
https://github.com/openedx/paragon/issues/3616

### Deploy Preview
[https://paragon-openedx.netlify.app/components/dropdown/#with-iconbutton](https://paragon-openedx.netlify.app/components/dropdown/#with-iconbutton)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
