### PR TITLE
fix: ensure Style Dictionary format css/component-button-variant-overrides work for brand packages

### DIFF
--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -144,10 +144,6 @@ async function buildTokensCommand(commandArgs) {
           {
             format: 'css/component-button-variant-overrides',
             destination: `themes/${themeVariant}/overrides/component-button-variants.css`,
-            filter: transformSourceTokensOnly ? 'isSource' : undefined,
-            options: {
-              outputReferences,
-            },
           },
         ],
       },


### PR DESCRIPTION
## Description

When trying to use https://github.com/openedx/paragon/pull/3598 within `@edx/elm-theme` to generate the overrides CSS file, no output was seen.

This issue was due to the `filter` used on the `build-tokens.js` script when configuring the `css/component-button-variant-overrides` format, which conditionally filters for source tokens only (i.e., the brand package tokens only, not core Paragon tokens).

When this format keys into `dictionary.tokens` with this filter applied, the relevant JSON for the `Alert` actions button variant overrides is not found.

Removing the `filter` from the format usage in `build-tokens.js` resolves the issue; alternatively, we could keep the `filter` and rely on `dictionary.unfilteredTokens`, too. That said, if we need the unfiltered tokens for this use case, we might as well just remove the `filter` from the format usage in `build-tokens.js`.

The `filter` for this custom format handling the button variant overrides isn't really necessary, given Paragon itself does not define any key/value mapping of button variant overrides (i.e., empty object). Given this, the output overrides CSS file when running the `build-tokens` CLI command is still only generated when the brand package explicitly provided a key/value mapping of button variant overrides.

### Deploy Preview

N/A

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
