### PR TITLE
fix: corrected filter clearing logic in DataTable component

### DIFF
--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -27,7 +27,7 @@ function CheckboxFilter({
   return (
     <Form.Group role="group" aria-labelledby={ariaLabel.current}>
       <FormLabel id={ariaLabel.current} className="pgn__checkbox-filter-label">{Header}</FormLabel>
-      <Form.CheckboxSet name={Header} value={filterValue || []}>
+      <Form.CheckboxSet name={Header} value={checkedBoxes}>
         {filterChoices.map(({ name, number, value }) => (
           <Form.Checkbox
             key={`${headerBasedId}${name}`}

--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -27,7 +27,7 @@ function CheckboxFilter({
   return (
     <Form.Group role="group" aria-labelledby={ariaLabel.current}>
       <FormLabel id={ariaLabel.current} className="pgn__checkbox-filter-label">{Header}</FormLabel>
-      <Form.CheckboxSet name={Header}>
+      <Form.CheckboxSet name={Header} value={filterValue || []}>
         {filterChoices.map(({ name, number, value }) => (
           <Form.Checkbox
             key={`${headerBasedId}${name}`}

--- a/src/DataTable/filters/tests/CheckboxFilter.test.jsx
+++ b/src/DataTable/filters/tests/CheckboxFilter.test.jsx
@@ -75,4 +75,12 @@ describe('<CheckboxFilter />', () => {
     const badge = screen.queryByText(String(palomino.number));
     expect(badge).toBeNull();
   });
+
+  it('renders unchecked checkboxes when filterValue is null', () => {
+    render(<CheckboxFilter column={{ ...props.column, filterValue: null }} />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    checkboxes.forEach(checkbox => {
+      expect(checkbox).not.toBeChecked();
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixed logic for clearing selected filters (checkboxes) in the DataTable component.

Issue: https://github.com/openedx/paragon/issues/3211

Before:

https://github.com/user-attachments/assets/9920db34-5209-4d09-b8be-a9855cfc7fb3

After fix:

https://github.com/user-attachments/assets/f41a05b8-a5f3-473b-bcc6-bf11930857ca

### Deploy Preview

https://deploy-preview-3639--paragon-openedx-v22.netlify.app/insights/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
