### PR TITLE
fix: add missing forwardRefs

### DIFF
--- a/src/ProductTour/CheckpointActionRow.jsx
+++ b/src/ProductTour/CheckpointActionRow.jsx
@@ -13,10 +13,10 @@ const CheckpointActionRow = React.forwardRef(({
   onBack,
   onEnd,
   index,
-}) => {
+}, ref) => {
   const isFirstCheckpoint = index === 0;
   return (
-    <ActionRow className="pgn__checkpoint-action-row">
+    <ActionRow className="pgn__checkpoint-action-row" ref={ref}>
       {!isFirstCheckpoint && (
         <Button
           className="pgn__checkpoint-button-back"

--- a/src/ProductTour/CheckpointHeader.jsx
+++ b/src/ProductTour/CheckpointHeader.jsx
@@ -10,14 +10,14 @@ import messages from './messages';
 
 const CheckpointHeader = React.forwardRef(({
   dismissAltText, index, onDismiss, title, totalCheckpoints,
-}) => {
+}, ref) => {
   const intl = useIntl();
   const oneBasedIndex = index + 1;
   const altText = (dismissAltText && typeof dismissAltText === 'string') ? dismissAltText : intl.formatMessage(messages.closeAltText);
 
   return (
     <>
-      <header className="pgn__checkpoint-header">
+      <header className="pgn__checkpoint-header" ref={ref}>
         <span className="pgn__checkpoint-page-index">
           <FormattedMessage
             {...messages.pageIndexText}


### PR DESCRIPTION
A couple of components were wrapped with `React.forwardRef()` but never actually used the `ref`, making the function call not only pointless but causing noise in console logs:

```
console.error
  Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```
