### PR TITLE
Documentation Site: Update Component Props to work with pure TypeScript (remove propTypes)

### DIFF
--- a/src/Alert/Alert.test.tsx
+++ b/src/Alert/Alert.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import renderer, { act } from 'react-test-renderer';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Context as ResponsiveContext } from 'react-responsive';
 import { Info } from '../../icons';
@@ -111,5 +111,18 @@ describe('<Alert />', () => {
       )).toJSON();
     });
     expect(tree).toMatchSnapshot();
+  });
+  it('renders with headings and links', async () => {
+    render(
+      <AlertWrapper>
+        <Alert.Heading>This is the heading</Alert.Heading>
+        And <Alert.Link href="#">here is a link</Alert.Link>.
+      </AlertWrapper>,
+    );
+    const alertDiv = screen.getByRole('alert');
+    const heading = within(alertDiv).getByText(/This is the heading/);
+    expect(heading).toHaveClass('alert-heading', 'h4');
+    const link = within(alertDiv).getByRole('link', { name: 'here is a link' });
+    expect(link).toHaveClass('alert-link');
   });
 });

--- a/src/Alert/index.tsx
+++ b/src/Alert/index.tsx
@@ -11,12 +11,12 @@ import React, {
   RefAttributes,
   cloneElement,
 } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
   Alert as BaseAlert,
   AlertProps as BaseAlertProps,
 } from 'react-bootstrap';
+import { type TransitionComponent } from 'react-bootstrap/helpers';
 import divWithClassName from 'react-bootstrap/divWithClassName';
 import { FormattedMessage } from 'react-intl';
 import { useMediaQuery } from 'react-responsive';
@@ -33,29 +33,51 @@ export type AlertVariant = 'primary' | 'secondary' | 'success' | 'danger' | 'war
 export type BaseProps = Omit<BaseAlertProps, 'children' | 'variant' | 'closeLabel'>;
 
 export interface AlertProps extends BaseProps {
+  /** Specifies class name to append to the base element */
   className?: string;
+  /** Overrides underlying component base CSS class name */
   bsPrefix?: string;
+  /** Specifies variant to use. */
   variant?: AlertVariant;
+  /**
+   * Animate the entering and exiting of the Alert. `true` will use the `<Fade>` transition,
+   * more detailed customization is also provided.
+   */
+  transition?: boolean | TransitionComponent;
   children?: ReactNode;
+  /** Icon that will be shown in the alert */
   icon?: React.ComponentType<IconProps>;
+  /** Whether the alert is shown. */
   show?: boolean;
+  /** Whether the alert is dismissible. Defaults to false. */
   dismissible?: boolean;
+  /** Optional callback function for when the alert it dismissed. */
   onClose?: () => void;
+  /** Optional list of action elements. May include, at most, 2 actions, or 1 if dismissible is true. */
   actions?: React.ReactElement[];
+  /** Position of the dismiss and call-to-action buttons. Defaults to `false`. */
   stacked?: boolean;
+  /** Sets the text for alert close button, defaults to 'Dismiss'. */
   closeLabel?: string | ReactNode;
 }
 
 export interface AlertHeadingProps {
+  /** Specifies the base element */
   as?: ElementType;
+  /** Overrides underlying component base CSS class name */
   bsPrefix?: string;
+  // eslint-disable-next-line react/no-unused-prop-types
   children?: ReactNode;
 }
 
 export interface AlertLinkProps {
+  /** Specifies the base element */
   as?: ElementType;
+  /** Overrides underlying component base CSS class name */
   bsPrefix?: string;
+  // eslint-disable-next-line react/no-unused-prop-types
   children?: ReactNode;
+  // eslint-disable-next-line react/no-unused-prop-types
   href?: string;
 }
 
@@ -64,16 +86,17 @@ export interface AlertComponent extends ForwardRefExoticComponent<AlertProps & R
   Link: FC<AlertLinkProps>;
 }
 
-const Alert = forwardRef<HTMLDivElement, AlertProps>(({
+const Alert = forwardRef(({
   children,
   icon,
   actions,
-  dismissible,
-  onClose,
+  dismissible = false,
+  onClose = () => {},
   closeLabel,
-  stacked,
+  stacked = false,
+  show = true,
   ...props
-}, ref) => {
+}: AlertProps, ref: React.ForwardedRef<HTMLDivElement>) => {
   const [isStacked, setIsStacked] = useState(stacked);
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
   const actionButtonSize = 'sm';
@@ -98,6 +121,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(({
     <BaseAlert
       {...props}
       className={classNames('alert-content', props.className)}
+      show={show}
       ref={ref}
     >
       {icon && <Icon src={icon} className="alert-icon" />}
@@ -142,96 +166,21 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(({
 const DivStyledAsH4 = divWithClassName('h4');
 DivStyledAsH4.displayName = 'DivStyledAsH4';
 
-function AlertHeading(props: AlertHeadingProps): JSX.Element {
-  return <BaseAlert.Heading {...props} />;
+function AlertHeading({
+  as = DivStyledAsH4,
+  bsPrefix = 'alert-heading',
+  ...props
+}: AlertHeadingProps): JSX.Element {
+  return <BaseAlert.Heading {...{ as, bsPrefix, ...props }} />;
 }
 
-function AlertLink(props: AlertLinkProps): JSX.Element {
-  return <BaseAlert.Link {...props} />;
+function AlertLink({
+  as = 'a',
+  bsPrefix = 'alert-link',
+  ...props
+}: AlertLinkProps): JSX.Element {
+  return <BaseAlert.Link {...{ as, bsPrefix, ...props }} />;
 }
-
-AlertLink.propTypes = {
-  /** Specifies the base element */
-  as: PropTypes.elementType as PropTypes.Validator<ElementType>,
-  /** Overrides underlying component base CSS class name */
-  bsPrefix: PropTypes.string,
-};
-
-AlertHeading.propTypes = {
-  /** Specifies the base element */
-  as: PropTypes.elementType as PropTypes.Validator<ElementType>,
-  /** Overrides underlying component base CSS class name */
-  bsPrefix: PropTypes.string,
-};
-
-AlertLink.defaultProps = {
-  as: 'a' as ElementType,
-  bsPrefix: 'alert-link',
-};
-
-AlertHeading.defaultProps = {
-  as: DivStyledAsH4,
-  bsPrefix: 'alert-heading',
-};
-
-Alert.propTypes = {
-  ...BaseAlert.propTypes,
-  /** Specifies class name to append to the base element */
-  className: PropTypes.string,
-  /** Overrides underlying component base CSS class name */
-  bsPrefix: PropTypes.string,
-  /** Specifies variant to use. */
-  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark', 'light'] as AlertVariant[]),
-  /**
-   * Animate the entering and exiting of the Alert. `true` will use the `<Fade>` transition,
-   * more detailed customization is also provided.
-   */
-  transition: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.shape({
-      in: PropTypes.bool,
-      appear: PropTypes.bool,
-      children: PropTypes.node,
-      onEnter: PropTypes.func,
-      onEntered: PropTypes.func,
-      onEntering: PropTypes.func,
-      onExit: PropTypes.func,
-      onExited: PropTypes.func,
-      onExiting: PropTypes.func,
-    }),
-  ]) as PropTypes.Validator<BaseAlertProps['transition']>,
-  /** Docstring for the children prop */
-  children: PropTypes.node as PropTypes.Validator<ReactNode>,
-  /** Docstring for the icon prop... Icon that will be shown in the alert */
-  icon: PropTypes.func,
-  /** Whether the alert is shown. */
-  show: PropTypes.bool,
-  /** Whether the alert is dismissible. Defaults to true. */
-  dismissible: PropTypes.bool,
-  /** Optional callback function for when the alert it dismissed. */
-  onClose: PropTypes.func,
-  /** Optional list of action elements. May include, at most, 2 actions, or 1 if dismissible is true. */
-  actions: PropTypes.arrayOf(PropTypes.element) as PropTypes.Validator<React.ReactElement[]>,
-  /** Position of the dismiss and call-to-action buttons. Defaults to ``false``. */
-  stacked: PropTypes.bool,
-  /** Sets the text for alert close button, defaults to 'Dismiss'. */
-  closeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-};
-
-Alert.defaultProps = {
-  ...BaseAlert.defaultProps,
-  children: undefined,
-  icon: undefined,
-  actions: undefined,
-  dismissible: false,
-  onClose: () => {},
-  closeLabel: undefined,
-  show: true,
-  stacked: false,
-  className: undefined,
-  bsPrefix: undefined,
-  variant: undefined,
-};
 
 Alert.Heading = AlertHeading;
 Alert.Link = AlertLink;

--- a/www/src/components/PropType.tsx
+++ b/www/src/components/PropType.tsx
@@ -37,14 +37,17 @@ function PropType({
         raw={raw}
       />
     );
+  } else if (name) {
+    // For TypeScript types, we simply display the type as a string.
+    return (
+      <span>
+        <code>{name}</code>
+        <RequiredBadge isRequired={required} />
+      </span>
+    );
+  } else {
+    return <>unknown type</>;
   }
-  // For TypeScript types, we simply display the type as a string.
-  return (
-    <span>
-      <code>{name}</code>
-      <RequiredBadge isRequired={required} />
-    </span>
-  );
 }
 
 export interface ISimplePropType {

--- a/www/src/components/PropType.tsx
+++ b/www/src/components/PropType.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Badge } from '~paragon-react';
 
 export type RequiredBadgeTypes = {
   isRequired?: boolean,
 };
 
-function RequiredBadge({ isRequired }: RequiredBadgeTypes) {
+function RequiredBadge({ isRequired = false }: RequiredBadgeTypes) {
   if (!isRequired) { return null; }
   return (
     <>
@@ -16,23 +15,15 @@ function RequiredBadge({ isRequired }: RequiredBadgeTypes) {
   );
 }
 
-RequiredBadge.propTypes = {
-  isRequired: PropTypes.bool,
-};
-
-RequiredBadge.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropType {
-  name: string,
-  value?: any,
-  raw?: string,
-  required?: boolean,
+  name: string;
+  value?: any;
+  raw?: string;
+  required?: boolean;
 }
 
 function PropType({
-  name, value, required, raw,
+  name, value = null, required = false, raw = '',
 }: IPropType) {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const PropTypeComponent = PROP_TYPE_COMPONENTS[name];
@@ -47,49 +38,21 @@ function PropType({
       />
     );
   }
-
-  return <>unknown type</>;
+  // For TypeScript types, we simply display the type as a string.
+  return (
+    <span>
+      <code>{name}</code>
+      <RequiredBadge isRequired={required} />
+    </span>
+  );
 }
-
-PropType.propTypes = {
-  name: PropTypes.oneOf([
-    'arrayOf',
-    'custom',
-    'enum',
-    'array',
-    'bool',
-    'func',
-    'number',
-    'object',
-    'string',
-    'any',
-    'element',
-    'node',
-    'symbol',
-    'objectOf',
-    'shape',
-    'exact',
-    'union',
-    'elementType',
-  ]),
-  value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-  raw: PropTypes.string,
-  required: PropTypes.bool,
-};
-
-PropType.defaultProps = {
-  name: 'any',
-  value: null,
-  raw: '',
-  required: false,
-};
 
 export interface ISimplePropType {
   name: string,
   isRequired?: boolean,
 }
 
-function SimplePropType({ name, isRequired }: ISimplePropType) {
+function SimplePropType({ name, isRequired = false }: ISimplePropType) {
   return (
     <span>
       <code>{name}</code>
@@ -98,22 +61,13 @@ function SimplePropType({ name, isRequired }: ISimplePropType) {
   );
 }
 
-SimplePropType.propTypes = {
-  isRequired: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-};
-
-SimplePropType.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeEnum {
-  name: string,
-  value: Array<any>,
-  isRequired?: boolean,
+  name: string;
+  value: any[];
+  isRequired?: boolean;
 }
 
-function PropTypeEnum({ name, value: enumValue, isRequired }: IPropTypeEnum) {
+function PropTypeEnum({ name, value: enumValue, isRequired = false }: IPropTypeEnum) {
   return (
     <span>
       <code>{name}</code>
@@ -127,48 +81,28 @@ function PropTypeEnum({ name, value: enumValue, isRequired }: IPropTypeEnum) {
   );
 }
 
-PropTypeEnum.propTypes = {
-  isRequired: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-  value: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-};
-
-PropTypeEnum.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeUnion {
-  value: any,
-  isRequired?: boolean,
+  value: IPropType[];
+  isRequired?: boolean;
 }
 
-function PropTypeUnion({ value, isRequired }: IPropTypeUnion) {
+function PropTypeUnion({ value, isRequired = false }: IPropTypeUnion) {
   return (
     <span>
       {value
         .map((propType: { name: string }) => <PropType key={propType.name} {...propType} />)
-        .reduce((prev: Element, curr: Element) => [prev, ' | ', curr])}
+        .reduce((prev, curr) => <>{prev} | {curr}</>)}
       <RequiredBadge isRequired={isRequired} />
     </span>
   );
 }
 
-PropTypeUnion.propTypes = {
-  isRequired: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-  value: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-};
-
-PropTypeUnion.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeInstanceOf {
-  isRequired?: boolean,
-  value: string,
+  isRequired?: boolean;
+  value: string;
 }
 
-function PropTypeInstanceOf({ value, isRequired }: IPropTypeInstanceOf) {
+function PropTypeInstanceOf({ value, isRequired = false }: IPropTypeInstanceOf) {
   return (
     <span>
       <code>{value}</code>
@@ -177,21 +111,12 @@ function PropTypeInstanceOf({ value, isRequired }: IPropTypeInstanceOf) {
   );
 }
 
-PropTypeInstanceOf.propTypes = {
-  isRequired: PropTypes.bool,
-  value: PropTypes.string.isRequired,
-};
-
-PropTypeInstanceOf.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeArrayOf {
-  isRequired?: boolean,
-  value: Array<{}>,
+  isRequired?: boolean;
+  value: IPropType;
 }
 
-function PropTypeArrayOf({ value, isRequired }: IPropTypeArrayOf) {
+function PropTypeArrayOf({ value, isRequired = false }: IPropTypeArrayOf) {
   return (
     <span>
       <PropType {...value} />
@@ -201,21 +126,12 @@ function PropTypeArrayOf({ value, isRequired }: IPropTypeArrayOf) {
   );
 }
 
-PropTypeArrayOf.propTypes = {
-  isRequired: PropTypes.bool,
-  value: PropTypes.shape({}).isRequired,
-};
-
-PropTypeArrayOf.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeObjectOf {
-  value: Array<{}>,
-  isRequired?: boolean,
+  value: IPropType;
+  isRequired?: boolean;
 }
 
-function PropTypeObjectOf({ value, isRequired }: IPropTypeObjectOf) {
+function PropTypeObjectOf({ value, isRequired = false }: IPropTypeObjectOf) {
   return (
     <span>
       <code>
@@ -228,22 +144,13 @@ function PropTypeObjectOf({ value, isRequired }: IPropTypeObjectOf) {
   );
 }
 
-PropTypeObjectOf.propTypes = {
-  isRequired: PropTypes.bool,
-  value: PropTypes.shape({}).isRequired,
-};
-
-PropTypeObjectOf.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeShape {
-  isRequired?: boolean,
-  name: string,
-  value: Array<{}>,
+  isRequired?: boolean;
+  name: string;
+  value: IPropType[];
 }
 
-function PropTypeShape({ name, value, isRequired }: IPropTypeShape) {
+function PropTypeShape({ name, value, isRequired = false }: IPropTypeShape) {
   return (
     <span className="small">
       <code>{name}</code>
@@ -259,25 +166,15 @@ function PropTypeShape({ name, value, isRequired }: IPropTypeShape) {
   );
 }
 
-PropTypeShape.propTypes = {
-  isRequired: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-  value: PropTypes.shape({}).isRequired,
-};
-
-PropTypeShape.defaultProps = {
-  isRequired: false,
-};
-
 export interface IPropTypeExact {
-  isRequired?: boolean,
-  name: string,
+  isRequired?: boolean;
+  name: string;
   value: {
-    propType: JSX.Element,
-  },
+    propType: IPropType;
+  };
 }
 
-function PropTypeExact({ name, value, isRequired }: IPropTypeExact) {
+function PropTypeExact({ name, value, isRequired = false }: IPropTypeExact) {
   return (
     <span className="small">
       <code>{name}</code>
@@ -293,22 +190,12 @@ function PropTypeExact({ name, value, isRequired }: IPropTypeExact) {
   );
 }
 
-PropTypeExact.propTypes = {
-  isRequired: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-  value: PropTypes.shape({}).isRequired,
-};
-
-PropTypeExact.defaultProps = {
-  isRequired: false,
-};
-
 export interface ICustomPropType {
-  isRequired?: boolean,
-  raw?: string
+  isRequired?: boolean;
+  raw?: string;
 }
 
-function CustomPropType({ raw, isRequired }: ICustomPropType) {
+function CustomPropType({ raw = '', isRequired = false }: ICustomPropType) {
   return (
     <span>
       <code>{raw}</code>
@@ -317,21 +204,17 @@ function CustomPropType({ raw, isRequired }: ICustomPropType) {
   );
 }
 
-CustomPropType.propTypes = {
-  isRequired: PropTypes.bool,
-  raw: PropTypes.string,
-};
-
-CustomPropType.defaultProps = {
-  isRequired: false,
-  raw: '',
-};
-
 export type PropTypeComponentsTypes = {
-  [key: string]: Function,
+  [key: string]: (...args: any[]) => JSX.Element,
 };
 
+/**
+ * Maps the deprecated propType names to components. These aren't needed for
+ * TypeScript types since their string representation is already useful as is.
+ */
 const PROP_TYPE_COMPONENTS: PropTypeComponentsTypes = {
+  // Other than 'string', 'any', and 'object', these are all legacy propTypes types
+  // and won't be used once the components are converted to TypeScript definitions.
   array: SimplePropType,
   bool: SimplePropType,
   func: SimplePropType,

--- a/www/src/components/PropsTable.tsx
+++ b/www/src/components/PropsTable.tsx
@@ -48,17 +48,17 @@ DefaultValue.defaultProps = {
 };
 
 export interface IProp {
-  name: string,
-  type?: {},
-  required?: boolean,
-  defaultValue: {},
+  name: string;
+  type: { name: string, value?: any, raw?: string, required?: boolean };
+  required?: boolean;
+  defaultValue: {};
   description: {
     text: string;
   };
 }
 
 function Prop({
-  name, type, required, defaultValue, description,
+  name, type, required = false, defaultValue, description,
 }: IProp) {
   return (
     <li className="px-4 border-top border-light-300">
@@ -85,25 +85,10 @@ function Prop({
   );
 }
 
-Prop.propTypes = {
-  name: PropTypes.string.isRequired,
-  type: PropTypes.shape({}).isRequired,
-  required: PropTypes.bool,
-  defaultValue: PropTypes.shape({}),
-  description: PropTypes.shape({
-    text: PropTypes.string,
-  }),
-};
-Prop.defaultProps = {
-  required: false,
-  defaultValue: {},
-  description: undefined,
-};
-
 export interface IPropsTable {
-  props: Array<Function>,
-  displayName: string,
-  content: string,
+  props: IProp[];
+  displayName: string;
+  content: string;
 }
 
 function PropsTable({ props: componentProps, displayName, content }: IPropsTable) {
@@ -131,17 +116,5 @@ function PropsTable({ props: componentProps, displayName, content }: IPropsTable
     </Card>
   );
 }
-
-PropsTable.propTypes = {
-  props: PropTypes.arrayOf(PropTypes.shape({})),
-  content: PropTypes.string,
-  displayName: PropTypes.string,
-};
-
-PropsTable.defaultProps = {
-  props: [],
-  content: undefined,
-  displayName: undefined,
-};
 
 export default PropsTable;

--- a/www/src/templates/component-page-template.tsx
+++ b/www/src/templates/component-page-template.tsx
@@ -11,7 +11,7 @@ import {
 } from '~paragon-react';
 import { SettingsContext } from '../context/SettingsContext';
 import CodeBlock from '../components/CodeBlock';
-import GenericPropsTable from '../components/PropsTable';
+import GenericPropsTable, { IPropsTable } from '../components/PropsTable';
 import Layout from '../components/PageLayout';
 import SEO from '../components/SEO';
 import LinkedHeading from '../components/LinkedHeading';
@@ -170,7 +170,7 @@ export default function PageTemplate({
           </h2>
         )}
         {typeof sortedComponentNames !== 'string' && sortedComponentNames?.map((componentName: string | number) => {
-          const node: { displayName: string } = components[componentName];
+          const node: { displayName: string } & IPropsTable = components[componentName] as any;
           if (!node) {
             return null;
           }


### PR DESCRIPTION
## Description

Using `propTypes` and `defaultProps` in React 18 generates a lot of deprecation warnings in the console, so we want to remove them and replace them with TypeScript types. (TypeScript types are also more specific and can be checked at build-time or code-time, not just runtime.)

This PR makes some required tweaks to the documentation site so that it can create the same "Props" documentation details whether components are using `propTypes` or pure TypesScript types.

### Deploy Preview

https://deploy-preview-3695--paragon-openedx-v23.netlify.app/

### How to review

I've completely removed the `propTypes` and `defaultProps` for the `Alert` component only. Compare [`Alert` (this PR)](https://deploy-preview-3695--paragon-openedx-v23.netlify.app/components/alert/#props-api) with [`Alert` (existing docs)](https://paragon-openedx.netlify.app/components/alert/#props-api) and confirm the newer docs from this PR are better / more complete.

Check through a few other components (comparing the deploy preview with the existing docs site) to ensure there are no significant regressions.

### Merge Checklist

n/a

### Screenshots

#### Before

<img width="966" height="484" alt="Screenshot 2025-07-14 at 5 22 34 PM" src="https://github.com/user-attachments/assets/7d741906-971b-4607-b3a6-dc03893b3b17" />

#### After

<img width="965" height="341" alt="Screenshot 2025-07-14 at 5 23 00 PM" src="https://github.com/user-attachments/assets/c1c836b2-15b5-421d-b9b4-e1c926dbe1f7" />
