### PR TITLE
fix: Added missing filtersTitle prop for DataTableLayout

### DIFF
--- a/src/DataTable/DropdownFilters.jsx
+++ b/src/DataTable/DropdownFilters.jsx
@@ -11,7 +11,7 @@ function DropdownFilters() {
   const intl = useIntl();
   const { width } = useWindowSize();
   const {
-    columns, numBreakoutFilters, filtersTitle, showFiltersInSidebar,
+    columns, numBreakoutFilters, filtersTitle,
   } = useContext(DataTableContext);
 
   const [breakoutFilters, otherFilters] = useMemo(() => {
@@ -30,8 +30,7 @@ function DropdownFilters() {
     return [boFilters, dropdownFilters];
   }, [columns, width, numBreakoutFilters]);
 
-  const dropdownTitle = filtersTitle && !showFiltersInSidebar
-    ? filtersTitle : intl.formatMessage(messages.filtersDropdownTitle);
+  const dropdownTitle = filtersTitle || intl.formatMessage(messages.filtersDropdownTitle);
 
   return (
     <div className="pgn__data-table-filters">

--- a/src/DataTable/DropdownFilters.jsx
+++ b/src/DataTable/DropdownFilters.jsx
@@ -1,13 +1,18 @@
 import React, { useContext, useMemo } from 'react';
+import { useIntl } from 'react-intl';
 import DataTableContext from './DataTableContext';
 import { DropdownButton } from '../Dropdown';
 import useWindowSize from '../hooks/useWindowSizeHook';
 import breakpoints from '../utils/breakpoints';
+import messages from './messages';
 
 /** The first filter will be as an input, additional filters will be available in a dropdown.  */
 function DropdownFilters() {
+  const intl = useIntl();
   const { width } = useWindowSize();
-  const { columns, numBreakoutFilters } = useContext(DataTableContext);
+  const {
+    columns, numBreakoutFilters, filtersTitle, showFiltersInSidebar,
+  } = useContext(DataTableContext);
 
   const [breakoutFilters, otherFilters] = useMemo(() => {
     if (!columns) {
@@ -25,6 +30,9 @@ function DropdownFilters() {
     return [boFilters, dropdownFilters];
   }, [columns, width, numBreakoutFilters]);
 
+  const dropdownTitle = filtersTitle && !showFiltersInSidebar
+    ? filtersTitle : intl.formatMessage(messages.filtersDropdownTitle);
+
   return (
     <div className="pgn__data-table-filters">
       {breakoutFilters.length > 0 && breakoutFilters.map((column) => (
@@ -33,7 +41,7 @@ function DropdownFilters() {
         </div>
       ))}
       {otherFilters.length > 0 && (
-        <DropdownButton variant="outline-primary" id="table-filters-dropdown" title="Filters">
+        <DropdownButton variant="outline-primary" id="table-filters-dropdown" title={dropdownTitle}>
           {otherFilters.map((column) => (
             <div
               key={column.Header}

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -176,7 +176,7 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
       producer: 'Isao Takahata',
       release_date: 1986,
       rt_score: 95,
-    }, 
+    },
     {
       id: '12cfb892-aac0-4c5b-94af-521852e46d6a',
       title: 'Grave of the Fireflies',
@@ -567,7 +567,7 @@ Can be used to show the loading state when ``DataTable`` is asynchronously fetch
     },
   ];
   {/* end example state */}
-  
+
   return (
     <>
       {/* start example form block */}
@@ -634,7 +634,7 @@ You can pass a function to render custom components for bulk actions and table a
       Enroll
     </Button>
   );
-  
+
   const EnrollAction = ({ selectedFlatRows, ...rest }) => (
     // Here is access to the selectedFlatRows, isEntireTableSelected, tableInstance
     <Button variant="danger" onClick={() => console.log('Enroll', selectedFlatRows, rest)}>
@@ -647,13 +647,13 @@ You can pass a function to render custom components for bulk actions and table a
       Assign
     </Button>
   );
-  
+
   const ExtraAction = ({ text, selectedFlatRows, ...rest }) => (
     <Button onClick={() => console.log(`Extra Action ${text}`, selectedFlatRows, rest)}>
       {`Extra Action ${text}`}
     </Button>
   );
-  
+
   return (
     <DataTable
       isSelectable
@@ -734,7 +734,7 @@ You can pass a function to render custom components for bulk actions and table a
     </DataTable>
   )
 }
-  
+
 ```
 
 #### Actions with Data view toggle enabled
@@ -889,7 +889,7 @@ a responsive grid of cards.
       Clear Selection
     </Component>
   );
-  
+
   return (
     <DataTable
       isFilterable
@@ -1103,7 +1103,7 @@ Use `columnSizes` prop of `CardView` component to define how many `Cards` are sh
 
   const ExampleCard = ({ className, original }) => {
     const { name, color, famous_for: famousFor } = original;
-		
+
     return (
       <Card className={className}>
         <Card.ImageCap src="https://picsum.photos/360/200/" srcAlt="Card image" />
@@ -1195,7 +1195,7 @@ You can also display `Cards` with horizontal view. If the table is selectable co
           <Card.Header title={name} />
           <Card.Section>
             <dl>
-              <dt>Color</dt>								
+              <dt>Color</dt>
               <dd>{color}</dd>
               <dt>Famous For</dt>
               <dd>{famousFor}</dd>
@@ -1217,7 +1217,7 @@ You can also display `Cards` with horizontal view. If the table is selectable co
           name: 'Lil Bub',
           color: 'brown tabby',
           famous_for: 'weird tongue',
-        }, 
+        },
         {
           name: 'Grumpy Cat',
           color: 'siamese',
@@ -1258,6 +1258,7 @@ For a more desktop friendly view, you can move filters into a sidebar by providi
 ```jsx live
   <DataTable
     showFiltersInSidebar
+    filtersTitle="Color filters"
     isFilterable
     isSortable
     defaultColumnValues={{ Filter: TextFilter }}
@@ -1330,17 +1331,17 @@ For a more desktop friendly view, you can move filters into a sidebar by providi
 ```
 
 ## Expandable rows
-`DataTable` supports expandable rows which once expanded render additional content under the row. Displayed content 
+`DataTable` supports expandable rows which once expanded render additional content under the row. Displayed content
 is controlled by the `renderRowSubComponent` prop, which is a function that receives `row` as its single prop and renders expanded view, you also
 need to pass `isEpandable` prop to `DataTable` to indicate that it should support expand behavior for rows.
-Finally, an additional column is required to be included into `columns` prop which will contain handlers for expand / collapse behavior, see examples below. 
+Finally, an additional column is required to be included into `columns` prop which will contain handlers for expand / collapse behavior, see examples below.
 
 ### Default view
 
 Here we use default expander column offered by Paragon and for each row render value of the `name` attribute as its subcomponent.
 
 ```jsx live
-<DataTable 
+<DataTable
   isExpandable
   itemCount={7}
   renderRowSubComponent={({ row }) => <div className='text-center'>{row.values.name}</div>}
@@ -1457,10 +1458,10 @@ You can create your own custom expander column and use it, see code example belo
       </DataTable>
     </div>
   )
-	
+
   return (
     <DataTable
-      isExpandable 
+      isExpandable
       renderRowSubComponent={renderSubComponent}
       itemCount={3}
       data={[
@@ -1481,7 +1482,7 @@ You can create your own custom expander column and use it, see code example belo
           reason: 'Felt like it',
         },
         {
-          name: 'Smoothie', 
+          name: 'Smoothie',
           color: 'orange tabby',
           famous_for: 'modeling',
           date_modified: currentDate,
@@ -1527,7 +1528,7 @@ You can create your own cell content by passing the `Cell` property to a specifi
     newColors[index] = cellColors[index] < 3 ? cellColors[index] + 1 : 0;
     setCellColors(newColors);
   };
-  
+
   return (
     <DataTable
       isExpandable
@@ -1544,7 +1545,7 @@ You can create your own cell content by passing the `Cell` property to a specifi
           famous_for: 'serving moods',
         },
         {
-          name: 'Smoothie', 
+          name: 'Smoothie',
           color: 'orange tabby',
           famous_for: 'modeling',
         },

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -49,6 +49,8 @@ function DataTable({
   EmptyTableComponent,
   manualSelectColumn,
   showFiltersInSidebar,
+  filtersTitle,
+  dataTableLayoutClassName,
   dataViewToggleOptions,
   disableElevation,
   isLoading,
@@ -222,7 +224,7 @@ function DataTable({
 
   return (
     <DataTableContext.Provider value={enhancedInstance}>
-      <DataTableLayout>
+      <DataTableLayout filtersTitle={filtersTitle} className={dataTableLayoutClassName}>
         <div className={classNames('pgn__data-table-wrapper', {
           'hide-shadow': !!disableElevation,
         })}
@@ -264,6 +266,8 @@ DataTable.defaultProps = {
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
   showFiltersInSidebar: false,
+  filtersTitle: undefined,
+  dataTableLayoutClassName: undefined,
   dataViewToggleOptions: {
     isDataViewToggleEnabled: false,
     onDataViewToggle: () => {},
@@ -425,6 +429,10 @@ DataTable.propTypes = {
   children: PropTypes.node,
   /** If true filters will be shown on sidebar instead */
   showFiltersInSidebar: PropTypes.bool,
+  /** Title of the filters section */
+  filtersTitle: PropTypes.string,
+  /** Class name for the data table layout */
+  dataTableLayoutClassName: PropTypes.string,
   /** options for data view toggle */
   dataViewToggleOptions: PropTypes.shape({
     /** Whether to show a toggle button group which allows view switching between card and table views */

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -50,7 +50,6 @@ function DataTable({
   manualSelectColumn,
   showFiltersInSidebar,
   filtersTitle,
-  dataTableLayoutClassName,
   dataViewToggleOptions,
   disableElevation,
   isLoading,
@@ -217,6 +216,7 @@ function DataTable({
     manualSelectColumn,
     maxSelectedRows,
     onMaxSelectedRows,
+    filtersTitle,
     ...selectionProps,
     ...selectionActions,
     ...props,
@@ -224,7 +224,7 @@ function DataTable({
 
   return (
     <DataTableContext.Provider value={enhancedInstance}>
-      <DataTableLayout filtersTitle={filtersTitle} className={dataTableLayoutClassName}>
+      <DataTableLayout filtersTitle={filtersTitle}>
         <div className={classNames('pgn__data-table-wrapper', {
           'hide-shadow': !!disableElevation,
         })}
@@ -267,7 +267,6 @@ DataTable.defaultProps = {
   RowStatusComponent: RowStatus,
   showFiltersInSidebar: false,
   filtersTitle: undefined,
-  dataTableLayoutClassName: undefined,
   dataViewToggleOptions: {
     isDataViewToggleEnabled: false,
     onDataViewToggle: () => {},
@@ -431,8 +430,6 @@ DataTable.propTypes = {
   showFiltersInSidebar: PropTypes.bool,
   /** Title of the filters section */
   filtersTitle: PropTypes.string,
-  /** Class name for the data table layout */
-  dataTableLayoutClassName: PropTypes.string,
   /** options for data view toggle */
   dataViewToggleOptions: PropTypes.shape({
     /** Whether to show a toggle button group which allows view switching between card and table views */

--- a/src/DataTable/messages.js
+++ b/src/DataTable/messages.js
@@ -6,6 +6,11 @@ const messages = defineMessages({
     defaultMessage: 'table pagination',
     description: 'Accessibile name for the navigation element of a pagination component',
   },
+  filtersDropdownTitle: {
+    id: 'pgn.DataTable.filtersDropdownTitle',
+    defaultMessage: 'Filters',
+    description: 'Title of the filters dropdown',
+  },
 });
 
 export default messages;

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -8,6 +8,7 @@ import DataTable from '..';
 import DataTableContext from '../DataTableContext';
 import { TextFilter } from '../..';
 import { SELECT_ALL_TEST_ID } from '../selection/data/constants';
+import messages from '../messages';
 
 const additionalColumns = [
   {
@@ -163,17 +164,52 @@ describe('<DataTable />', () => {
     expect(screen.getByText('More')).toBeInTheDocument();
   });
 
-  it('displays the filters in the sidebar', () => {
+  it('displays the custom filters title in the sidebar', () => {
+    render(
+      <DataTableWrapper
+        showFiltersInSidebar
+        filtersTitle="Refine Your Search"
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
+        {...props}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: 'Refine Your Search' })).toBeInTheDocument();
+  });
+
+  it('displays the default filters title in the sidebar', () => {
     render(
       <DataTableWrapper
         showFiltersInSidebar
         isFilterable
         defaultColumnValues={{ Filter: TextFilter }}
-        filtersTitle="Refine Your Search"
         {...props}
       />,
     );
-    expect(screen.getByText('Refine Your Search')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: messages.filtersDropdownTitle.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('displays the custom filters title in the filters dropdown', () => {
+    render(
+      <DataTableWrapper
+        filtersTitle="Refine Your Search"
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
+        {...props}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Refine Your Search' })).toBeInTheDocument();
+  });
+
+  it('displays the default filters title in the filters dropdown', () => {
+    render(
+      <DataTableWrapper
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
+        {...props}
+      />,
+    );
+    expect(screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage })).toBeInTheDocument();
   });
 
   it('calls useTable with the data and columns', () => {
@@ -227,7 +263,7 @@ describe('<DataTable />', () => {
       fetchData: jest.fn(),
     };
     render(<DataTableWrapper {...propsWithSelection} />);
-    const filtersButton = screen.getByRole('button', { name: 'Filters' });
+    const filtersButton = screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage });
 
     await userEvent.click(filtersButton);
 

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -162,6 +162,20 @@ describe('<DataTable />', () => {
     expect(screen.getByText('Action')).toBeInTheDocument();
     expect(screen.getByText('More')).toBeInTheDocument();
   });
+
+  it('displays the filters in the sidebar', () => {
+    render(
+      <DataTableWrapper
+        showFiltersInSidebar
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
+        filtersTitle="Refine Your Search"
+        {...props}
+      />,
+    );
+    expect(screen.getByText('Refine Your Search')).toBeInTheDocument();
+  });
+
   it('calls useTable with the data and columns', () => {
     const spy = jest.spyOn(reactTable, 'useTable');
     render(<DataTableWrapper {...props} />);

--- a/src/DataTable/tests/DropdownFilters.test.jsx
+++ b/src/DataTable/tests/DropdownFilters.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
 
 import DropdownFilters from '../DropdownFilters';
 import { useWindowSize } from '../..';
 import DataTableContext from '../DataTableContext';
+import messages from '../messages';
 
 jest.mock('../../hooks/useWindowSizeHook');
 
@@ -31,9 +33,11 @@ const instance = {
 // eslint-disable-next-line react/prop-types
 function DropdownFiltersWrapper({ value = instance, props }) {
   return (
-    <DataTableContext.Provider value={value}>
-      <DropdownFilters {...props} />
-    </DataTableContext.Provider>
+    <IntlProvider locale="en">
+      <DataTableContext.Provider value={value}>
+        <DropdownFilters {...props} />
+      </DataTableContext.Provider>
+    </IntlProvider>
   );
 }
 
@@ -56,7 +60,7 @@ describe('<DropdownFilters />', () => {
       // filter should be rendered in the dropdown, so should not be present before
       // clicking the button.
       expect(screen.queryByText('Occupation filter')).toBeNull();
-      const filtersButton = screen.getByRole('button', { name: /Filters/i });
+      const filtersButton = screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage });
       await userEvent.click(filtersButton);
       expect(screen.getByText('Occupation filter')).toBeInTheDocument();
     });
@@ -65,7 +69,7 @@ describe('<DropdownFilters />', () => {
       useWindowSize.mockReturnValue({ width: 800 });
       render(<DropdownFiltersWrapper />);
       expect(screen.queryByText('DOB filter')).toBeNull();
-      const filtersButton = screen.getByRole('button', { name: /Filters/i });
+      const filtersButton = screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage });
       await userEvent.click(filtersButton);
       expect(screen.queryByText('DOB filter')).toBeNull();
     });
@@ -74,7 +78,7 @@ describe('<DropdownFilters />', () => {
       useWindowSize.mockReturnValue({ width: 800 });
       render(<DropdownFiltersWrapper value={{ columns: [instance.columns[1]] }} />);
       expect(screen.getByText('Occupation filter')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /Filters/i })).toBeNull();
+      expect(screen.queryByRole('button', { name: messages.filtersDropdownTitle.defaultMessage })).toBeNull();
     });
   });
 
@@ -88,7 +92,7 @@ describe('<DropdownFilters />', () => {
     it('renders all filters in the dropdown', async () => {
       useWindowSize.mockReturnValue({ width: 500 });
       render(<DropdownFiltersWrapper />);
-      const filtersButton = screen.getByRole('button', { name: /Filters/i });
+      const filtersButton = screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage });
       await userEvent.click(filtersButton);
       expect(screen.getByText('Bears filter')).toBeInTheDocument();
       expect(screen.getByText('Occupation filter')).toBeInTheDocument();


### PR DESCRIPTION
## Description

Added missing `filtersTitle` prop for `DataTableLayout` component.

`DataTableLayout` component expects `filtersTitle` prop, but the value of this prop is never passed.

**Issue:** https://github.com/openedx/paragon/issues/3711

### Deploy Preview

https://deploy-preview-3705--paragon-openedx-v22.netlify.app/components/datatable/#sidebar-filter

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
