### PR TITLE
feat: add label colors

### DIFF
--- a/styles/css/themes/light/utility-classes.css
+++ b/styles/css/themes/light/utility-classes.css
@@ -2451,3 +2451,2163 @@ a.text-dark:focus {
   border-color: var(--pgn-color-dark-base) !important;
 }
 
+.bg-label-a-100 {
+  background-color: var(--pgn-color-label-a-100) !important;
+}
+
+a.bg-label-a-100:hover,
+a.bg-label-a-100:focus,
+button.bg-label-a-100:hover,
+button.bg-label-a-100:focus {
+  background-color: var(--pgn-color-action-default-label-a-100) !important;
+}
+
+.text-label-a-100 {
+  color: var(--pgn-color-label-a-100) !important;
+}
+
+a.text-label-a-100:hover,
+a.text-label-a-100:focus {
+  color: var(--pgn-color-action-default-label-a-100) !important;
+}
+
+.border-label-a-100 {
+  border-color: var(--pgn-color-label-a-100) !important;
+}
+
+.bg-label-a-200 {
+  background-color: var(--pgn-color-label-a-200) !important;
+}
+
+a.bg-label-a-200:hover,
+a.bg-label-a-200:focus,
+button.bg-label-a-200:hover,
+button.bg-label-a-200:focus {
+  background-color: var(--pgn-color-action-default-label-a-200) !important;
+}
+
+.text-label-a-200 {
+  color: var(--pgn-color-label-a-200) !important;
+}
+
+a.text-label-a-200:hover,
+a.text-label-a-200:focus {
+  color: var(--pgn-color-action-default-label-a-200) !important;
+}
+
+.border-label-a-200 {
+  border-color: var(--pgn-color-label-a-200) !important;
+}
+
+.bg-label-a-300 {
+  background-color: var(--pgn-color-label-a-300) !important;
+}
+
+a.bg-label-a-300:hover,
+a.bg-label-a-300:focus,
+button.bg-label-a-300:hover,
+button.bg-label-a-300:focus {
+  background-color: var(--pgn-color-action-default-label-a-300) !important;
+}
+
+.text-label-a-300 {
+  color: var(--pgn-color-label-a-300) !important;
+}
+
+a.text-label-a-300:hover,
+a.text-label-a-300:focus {
+  color: var(--pgn-color-action-default-label-a-300) !important;
+}
+
+.border-label-a-300 {
+  border-color: var(--pgn-color-label-a-300) !important;
+}
+
+.bg-label-a-400 {
+  background-color: var(--pgn-color-label-a-400) !important;
+}
+
+a.bg-label-a-400:hover,
+a.bg-label-a-400:focus,
+button.bg-label-a-400:hover,
+button.bg-label-a-400:focus {
+  background-color: var(--pgn-color-action-default-label-a-400) !important;
+}
+
+.text-label-a-400 {
+  color: var(--pgn-color-label-a-400) !important;
+}
+
+a.text-label-a-400:hover,
+a.text-label-a-400:focus {
+  color: var(--pgn-color-action-default-label-a-400) !important;
+}
+
+.border-label-a-400 {
+  border-color: var(--pgn-color-label-a-400) !important;
+}
+
+.bg-label-a-500 {
+  background-color: var(--pgn-color-label-a-500) !important;
+}
+
+a.bg-label-a-500:hover,
+a.bg-label-a-500:focus,
+button.bg-label-a-500:hover,
+button.bg-label-a-500:focus {
+  background-color: var(--pgn-color-action-default-label-a-500) !important;
+}
+
+.text-label-a-500 {
+  color: var(--pgn-color-label-a-500) !important;
+}
+
+a.text-label-a-500:hover,
+a.text-label-a-500:focus {
+  color: var(--pgn-color-action-default-label-a-500) !important;
+}
+
+.border-label-a-500 {
+  border-color: var(--pgn-color-label-a-500) !important;
+}
+
+.bg-label-a-600 {
+  background-color: var(--pgn-color-label-a-600) !important;
+}
+
+a.bg-label-a-600:hover,
+a.bg-label-a-600:focus,
+button.bg-label-a-600:hover,
+button.bg-label-a-600:focus {
+  background-color: var(--pgn-color-action-default-label-a-600) !important;
+}
+
+.text-label-a-600 {
+  color: var(--pgn-color-label-a-600) !important;
+}
+
+a.text-label-a-600:hover,
+a.text-label-a-600:focus {
+  color: var(--pgn-color-action-default-label-a-600) !important;
+}
+
+.border-label-a-600 {
+  border-color: var(--pgn-color-label-a-600) !important;
+}
+
+.bg-label-a-700 {
+  background-color: var(--pgn-color-label-a-700) !important;
+}
+
+a.bg-label-a-700:hover,
+a.bg-label-a-700:focus,
+button.bg-label-a-700:hover,
+button.bg-label-a-700:focus {
+  background-color: var(--pgn-color-action-default-label-a-700) !important;
+}
+
+.text-label-a-700 {
+  color: var(--pgn-color-label-a-700) !important;
+}
+
+a.text-label-a-700:hover,
+a.text-label-a-700:focus {
+  color: var(--pgn-color-action-default-label-a-700) !important;
+}
+
+.border-label-a-700 {
+  border-color: var(--pgn-color-label-a-700) !important;
+}
+
+.bg-label-a-800 {
+  background-color: var(--pgn-color-label-a-800) !important;
+}
+
+a.bg-label-a-800:hover,
+a.bg-label-a-800:focus,
+button.bg-label-a-800:hover,
+button.bg-label-a-800:focus {
+  background-color: var(--pgn-color-action-default-label-a-800) !important;
+}
+
+.text-label-a-800 {
+  color: var(--pgn-color-label-a-800) !important;
+}
+
+a.text-label-a-800:hover,
+a.text-label-a-800:focus {
+  color: var(--pgn-color-action-default-label-a-800) !important;
+}
+
+.border-label-a-800 {
+  border-color: var(--pgn-color-label-a-800) !important;
+}
+
+.bg-label-a-900 {
+  background-color: var(--pgn-color-label-a-900) !important;
+}
+
+a.bg-label-a-900:hover,
+a.bg-label-a-900:focus,
+button.bg-label-a-900:hover,
+button.bg-label-a-900:focus {
+  background-color: var(--pgn-color-action-default-label-a-900) !important;
+}
+
+.text-label-a-900 {
+  color: var(--pgn-color-label-a-900) !important;
+}
+
+a.text-label-a-900:hover,
+a.text-label-a-900:focus {
+  color: var(--pgn-color-action-default-label-a-900) !important;
+}
+
+.border-label-a-900 {
+  border-color: var(--pgn-color-label-a-900) !important;
+}
+
+.bg-label-a {
+  background-color: var(--pgn-color-label-a-base) !important;
+}
+
+a.bg-label-a:hover,
+a.bg-label-a:focus,
+button.bg-label-a:hover,
+button.bg-label-a:focus {
+  background-color: var(--pgn-color-action-default-label-a-base) !important;
+}
+
+.text-label-a {
+  color: var(--pgn-color-label-a-base) !important;
+}
+
+a.text-label-a:hover,
+a.text-label-a:focus {
+  color: var(--pgn-color-action-default-label-a-base) !important;
+}
+
+.border-label-a {
+  border-color: var(--pgn-color-label-a-base) !important;
+}
+
+.bg-label-b-100 {
+  background-color: var(--pgn-color-label-b-100) !important;
+}
+
+a.bg-label-b-100:hover,
+a.bg-label-b-100:focus,
+button.bg-label-b-100:hover,
+button.bg-label-b-100:focus {
+  background-color: var(--pgn-color-action-default-label-b-100) !important;
+}
+
+.text-label-b-100 {
+  color: var(--pgn-color-label-b-100) !important;
+}
+
+a.text-label-b-100:hover,
+a.text-label-b-100:focus {
+  color: var(--pgn-color-action-default-label-b-100) !important;
+}
+
+.border-label-b-100 {
+  border-color: var(--pgn-color-label-b-100) !important;
+}
+
+.bg-label-b-200 {
+  background-color: var(--pgn-color-label-b-200) !important;
+}
+
+a.bg-label-b-200:hover,
+a.bg-label-b-200:focus,
+button.bg-label-b-200:hover,
+button.bg-label-b-200:focus {
+  background-color: var(--pgn-color-action-default-label-b-200) !important;
+}
+
+.text-label-b-200 {
+  color: var(--pgn-color-label-b-200) !important;
+}
+
+a.text-label-b-200:hover,
+a.text-label-b-200:focus {
+  color: var(--pgn-color-action-default-label-b-200) !important;
+}
+
+.border-label-b-200 {
+  border-color: var(--pgn-color-label-b-200) !important;
+}
+
+.bg-label-b-300 {
+  background-color: var(--pgn-color-label-b-300) !important;
+}
+
+a.bg-label-b-300:hover,
+a.bg-label-b-300:focus,
+button.bg-label-b-300:hover,
+button.bg-label-b-300:focus {
+  background-color: var(--pgn-color-action-default-label-b-300) !important;
+}
+
+.text-label-b-300 {
+  color: var(--pgn-color-label-b-300) !important;
+}
+
+a.text-label-b-300:hover,
+a.text-label-b-300:focus {
+  color: var(--pgn-color-action-default-label-b-300) !important;
+}
+
+.border-label-b-300 {
+  border-color: var(--pgn-color-label-b-300) !important;
+}
+
+.bg-label-b-400 {
+  background-color: var(--pgn-color-label-b-400) !important;
+}
+
+a.bg-label-b-400:hover,
+a.bg-label-b-400:focus,
+button.bg-label-b-400:hover,
+button.bg-label-b-400:focus {
+  background-color: var(--pgn-color-action-default-label-b-400) !important;
+}
+
+.text-label-b-400 {
+  color: var(--pgn-color-label-b-400) !important;
+}
+
+a.text-label-b-400:hover,
+a.text-label-b-400:focus {
+  color: var(--pgn-color-action-default-label-b-400) !important;
+}
+
+.border-label-b-400 {
+  border-color: var(--pgn-color-label-b-400) !important;
+}
+
+.bg-label-b-500 {
+  background-color: var(--pgn-color-label-b-500) !important;
+}
+
+a.bg-label-b-500:hover,
+a.bg-label-b-500:focus,
+button.bg-label-b-500:hover,
+button.bg-label-b-500:focus {
+  background-color: var(--pgn-color-action-default-label-b-500) !important;
+}
+
+.text-label-b-500 {
+  color: var(--pgn-color-label-b-500) !important;
+}
+
+a.text-label-b-500:hover,
+a.text-label-b-500:focus {
+  color: var(--pgn-color-action-default-label-b-500) !important;
+}
+
+.border-label-b-500 {
+  border-color: var(--pgn-color-label-b-500) !important;
+}
+
+.bg-label-b-600 {
+  background-color: var(--pgn-color-label-b-600) !important;
+}
+
+a.bg-label-b-600:hover,
+a.bg-label-b-600:focus,
+button.bg-label-b-600:hover,
+button.bg-label-b-600:focus {
+  background-color: var(--pgn-color-action-default-label-b-600) !important;
+}
+
+.text-label-b-600 {
+  color: var(--pgn-color-label-b-600) !important;
+}
+
+a.text-label-b-600:hover,
+a.text-label-b-600:focus {
+  color: var(--pgn-color-action-default-label-b-600) !important;
+}
+
+.border-label-b-600 {
+  border-color: var(--pgn-color-label-b-600) !important;
+}
+
+.bg-label-b-700 {
+  background-color: var(--pgn-color-label-b-700) !important;
+}
+
+a.bg-label-b-700:hover,
+a.bg-label-b-700:focus,
+button.bg-label-b-700:hover,
+button.bg-label-b-700:focus {
+  background-color: var(--pgn-color-action-default-label-b-700) !important;
+}
+
+.text-label-b-700 {
+  color: var(--pgn-color-label-b-700) !important;
+}
+
+a.text-label-b-700:hover,
+a.text-label-b-700:focus {
+  color: var(--pgn-color-action-default-label-b-700) !important;
+}
+
+.border-label-b-700 {
+  border-color: var(--pgn-color-label-b-700) !important;
+}
+
+.bg-label-b-800 {
+  background-color: var(--pgn-color-label-b-800) !important;
+}
+
+a.bg-label-b-800:hover,
+a.bg-label-b-800:focus,
+button.bg-label-b-800:hover,
+button.bg-label-b-800:focus {
+  background-color: var(--pgn-color-action-default-label-b-800) !important;
+}
+
+.text-label-b-800 {
+  color: var(--pgn-color-label-b-800) !important;
+}
+
+a.text-label-b-800:hover,
+a.text-label-b-800:focus {
+  color: var(--pgn-color-action-default-label-b-800) !important;
+}
+
+.border-label-b-800 {
+  border-color: var(--pgn-color-label-b-800) !important;
+}
+
+.bg-label-b-900 {
+  background-color: var(--pgn-color-label-b-900) !important;
+}
+
+a.bg-label-b-900:hover,
+a.bg-label-b-900:focus,
+button.bg-label-b-900:hover,
+button.bg-label-b-900:focus {
+  background-color: var(--pgn-color-action-default-label-b-900) !important;
+}
+
+.text-label-b-900 {
+  color: var(--pgn-color-label-b-900) !important;
+}
+
+a.text-label-b-900:hover,
+a.text-label-b-900:focus {
+  color: var(--pgn-color-action-default-label-b-900) !important;
+}
+
+.border-label-b-900 {
+  border-color: var(--pgn-color-label-b-900) !important;
+}
+
+.bg-label-b {
+  background-color: var(--pgn-color-label-b-base) !important;
+}
+
+a.bg-label-b:hover,
+a.bg-label-b:focus,
+button.bg-label-b:hover,
+button.bg-label-b:focus {
+  background-color: var(--pgn-color-action-default-label-b-base) !important;
+}
+
+.text-label-b {
+  color: var(--pgn-color-label-b-base) !important;
+}
+
+a.text-label-b:hover,
+a.text-label-b:focus {
+  color: var(--pgn-color-action-default-label-b-base) !important;
+}
+
+.border-label-b {
+  border-color: var(--pgn-color-label-b-base) !important;
+}
+
+.bg-label-c-100 {
+  background-color: var(--pgn-color-label-c-100) !important;
+}
+
+a.bg-label-c-100:hover,
+a.bg-label-c-100:focus,
+button.bg-label-c-100:hover,
+button.bg-label-c-100:focus {
+  background-color: var(--pgn-color-action-default-label-c-100) !important;
+}
+
+.text-label-c-100 {
+  color: var(--pgn-color-label-c-100) !important;
+}
+
+a.text-label-c-100:hover,
+a.text-label-c-100:focus {
+  color: var(--pgn-color-action-default-label-c-100) !important;
+}
+
+.border-label-c-100 {
+  border-color: var(--pgn-color-label-c-100) !important;
+}
+
+.bg-label-c-200 {
+  background-color: var(--pgn-color-label-c-200) !important;
+}
+
+a.bg-label-c-200:hover,
+a.bg-label-c-200:focus,
+button.bg-label-c-200:hover,
+button.bg-label-c-200:focus {
+  background-color: var(--pgn-color-action-default-label-c-200) !important;
+}
+
+.text-label-c-200 {
+  color: var(--pgn-color-label-c-200) !important;
+}
+
+a.text-label-c-200:hover,
+a.text-label-c-200:focus {
+  color: var(--pgn-color-action-default-label-c-200) !important;
+}
+
+.border-label-c-200 {
+  border-color: var(--pgn-color-label-c-200) !important;
+}
+
+.bg-label-c-300 {
+  background-color: var(--pgn-color-label-c-300) !important;
+}
+
+a.bg-label-c-300:hover,
+a.bg-label-c-300:focus,
+button.bg-label-c-300:hover,
+button.bg-label-c-300:focus {
+  background-color: var(--pgn-color-action-default-label-c-300) !important;
+}
+
+.text-label-c-300 {
+  color: var(--pgn-color-label-c-300) !important;
+}
+
+a.text-label-c-300:hover,
+a.text-label-c-300:focus {
+  color: var(--pgn-color-action-default-label-c-300) !important;
+}
+
+.border-label-c-300 {
+  border-color: var(--pgn-color-label-c-300) !important;
+}
+
+.bg-label-c-400 {
+  background-color: var(--pgn-color-label-c-400) !important;
+}
+
+a.bg-label-c-400:hover,
+a.bg-label-c-400:focus,
+button.bg-label-c-400:hover,
+button.bg-label-c-400:focus {
+  background-color: var(--pgn-color-action-default-label-c-400) !important;
+}
+
+.text-label-c-400 {
+  color: var(--pgn-color-label-c-400) !important;
+}
+
+a.text-label-c-400:hover,
+a.text-label-c-400:focus {
+  color: var(--pgn-color-action-default-label-c-400) !important;
+}
+
+.border-label-c-400 {
+  border-color: var(--pgn-color-label-c-400) !important;
+}
+
+.bg-label-c-500 {
+  background-color: var(--pgn-color-label-c-500) !important;
+}
+
+a.bg-label-c-500:hover,
+a.bg-label-c-500:focus,
+button.bg-label-c-500:hover,
+button.bg-label-c-500:focus {
+  background-color: var(--pgn-color-action-default-label-c-500) !important;
+}
+
+.text-label-c-500 {
+  color: var(--pgn-color-label-c-500) !important;
+}
+
+a.text-label-c-500:hover,
+a.text-label-c-500:focus {
+  color: var(--pgn-color-action-default-label-c-500) !important;
+}
+
+.border-label-c-500 {
+  border-color: var(--pgn-color-label-c-500) !important;
+}
+
+.bg-label-c-600 {
+  background-color: var(--pgn-color-label-c-600) !important;
+}
+
+a.bg-label-c-600:hover,
+a.bg-label-c-600:focus,
+button.bg-label-c-600:hover,
+button.bg-label-c-600:focus {
+  background-color: var(--pgn-color-action-default-label-c-600) !important;
+}
+
+.text-label-c-600 {
+  color: var(--pgn-color-label-c-600) !important;
+}
+
+a.text-label-c-600:hover,
+a.text-label-c-600:focus {
+  color: var(--pgn-color-action-default-label-c-600) !important;
+}
+
+.border-label-c-600 {
+  border-color: var(--pgn-color-label-c-600) !important;
+}
+
+.bg-label-c-700 {
+  background-color: var(--pgn-color-label-c-700) !important;
+}
+
+a.bg-label-c-700:hover,
+a.bg-label-c-700:focus,
+button.bg-label-c-700:hover,
+button.bg-label-c-700:focus {
+  background-color: var(--pgn-color-action-default-label-c-700) !important;
+}
+
+.text-label-c-700 {
+  color: var(--pgn-color-label-c-700) !important;
+}
+
+a.text-label-c-700:hover,
+a.text-label-c-700:focus {
+  color: var(--pgn-color-action-default-label-c-700) !important;
+}
+
+.border-label-c-700 {
+  border-color: var(--pgn-color-label-c-700) !important;
+}
+
+.bg-label-c-800 {
+  background-color: var(--pgn-color-label-c-800) !important;
+}
+
+a.bg-label-c-800:hover,
+a.bg-label-c-800:focus,
+button.bg-label-c-800:hover,
+button.bg-label-c-800:focus {
+  background-color: var(--pgn-color-action-default-label-c-800) !important;
+}
+
+.text-label-c-800 {
+  color: var(--pgn-color-label-c-800) !important;
+}
+
+a.text-label-c-800:hover,
+a.text-label-c-800:focus {
+  color: var(--pgn-color-action-default-label-c-800) !important;
+}
+
+.border-label-c-800 {
+  border-color: var(--pgn-color-label-c-800) !important;
+}
+
+.bg-label-c-900 {
+  background-color: var(--pgn-color-label-c-900) !important;
+}
+
+a.bg-label-c-900:hover,
+a.bg-label-c-900:focus,
+button.bg-label-c-900:hover,
+button.bg-label-c-900:focus {
+  background-color: var(--pgn-color-action-default-label-c-900) !important;
+}
+
+.text-label-c-900 {
+  color: var(--pgn-color-label-c-900) !important;
+}
+
+a.text-label-c-900:hover,
+a.text-label-c-900:focus {
+  color: var(--pgn-color-action-default-label-c-900) !important;
+}
+
+.border-label-c-900 {
+  border-color: var(--pgn-color-label-c-900) !important;
+}
+
+.bg-label-c {
+  background-color: var(--pgn-color-label-c-base) !important;
+}
+
+a.bg-label-c:hover,
+a.bg-label-c:focus,
+button.bg-label-c:hover,
+button.bg-label-c:focus {
+  background-color: var(--pgn-color-action-default-label-c-base) !important;
+}
+
+.text-label-c {
+  color: var(--pgn-color-label-c-base) !important;
+}
+
+a.text-label-c:hover,
+a.text-label-c:focus {
+  color: var(--pgn-color-action-default-label-c-base) !important;
+}
+
+.border-label-c {
+  border-color: var(--pgn-color-label-c-base) !important;
+}
+
+.bg-label-d-100 {
+  background-color: var(--pgn-color-label-d-100) !important;
+}
+
+a.bg-label-d-100:hover,
+a.bg-label-d-100:focus,
+button.bg-label-d-100:hover,
+button.bg-label-d-100:focus {
+  background-color: var(--pgn-color-action-default-label-d-100) !important;
+}
+
+.text-label-d-100 {
+  color: var(--pgn-color-label-d-100) !important;
+}
+
+a.text-label-d-100:hover,
+a.text-label-d-100:focus {
+  color: var(--pgn-color-action-default-label-d-100) !important;
+}
+
+.border-label-d-100 {
+  border-color: var(--pgn-color-label-d-100) !important;
+}
+
+.bg-label-d-200 {
+  background-color: var(--pgn-color-label-d-200) !important;
+}
+
+a.bg-label-d-200:hover,
+a.bg-label-d-200:focus,
+button.bg-label-d-200:hover,
+button.bg-label-d-200:focus {
+  background-color: var(--pgn-color-action-default-label-d-200) !important;
+}
+
+.text-label-d-200 {
+  color: var(--pgn-color-label-d-200) !important;
+}
+
+a.text-label-d-200:hover,
+a.text-label-d-200:focus {
+  color: var(--pgn-color-action-default-label-d-200) !important;
+}
+
+.border-label-d-200 {
+  border-color: var(--pgn-color-label-d-200) !important;
+}
+
+.bg-label-d-300 {
+  background-color: var(--pgn-color-label-d-300) !important;
+}
+
+a.bg-label-d-300:hover,
+a.bg-label-d-300:focus,
+button.bg-label-d-300:hover,
+button.bg-label-d-300:focus {
+  background-color: var(--pgn-color-action-default-label-d-300) !important;
+}
+
+.text-label-d-300 {
+  color: var(--pgn-color-label-d-300) !important;
+}
+
+a.text-label-d-300:hover,
+a.text-label-d-300:focus {
+  color: var(--pgn-color-action-default-label-d-300) !important;
+}
+
+.border-label-d-300 {
+  border-color: var(--pgn-color-label-d-300) !important;
+}
+
+.bg-label-d-400 {
+  background-color: var(--pgn-color-label-d-400) !important;
+}
+
+a.bg-label-d-400:hover,
+a.bg-label-d-400:focus,
+button.bg-label-d-400:hover,
+button.bg-label-d-400:focus {
+  background-color: var(--pgn-color-action-default-label-d-400) !important;
+}
+
+.text-label-d-400 {
+  color: var(--pgn-color-label-d-400) !important;
+}
+
+a.text-label-d-400:hover,
+a.text-label-d-400:focus {
+  color: var(--pgn-color-action-default-label-d-400) !important;
+}
+
+.border-label-d-400 {
+  border-color: var(--pgn-color-label-d-400) !important;
+}
+
+.bg-label-d-500 {
+  background-color: var(--pgn-color-label-d-500) !important;
+}
+
+a.bg-label-d-500:hover,
+a.bg-label-d-500:focus,
+button.bg-label-d-500:hover,
+button.bg-label-d-500:focus {
+  background-color: var(--pgn-color-action-default-label-d-500) !important;
+}
+
+.text-label-d-500 {
+  color: var(--pgn-color-label-d-500) !important;
+}
+
+a.text-label-d-500:hover,
+a.text-label-d-500:focus {
+  color: var(--pgn-color-action-default-label-d-500) !important;
+}
+
+.border-label-d-500 {
+  border-color: var(--pgn-color-label-d-500) !important;
+}
+
+.bg-label-d-600 {
+  background-color: var(--pgn-color-label-d-600) !important;
+}
+
+a.bg-label-d-600:hover,
+a.bg-label-d-600:focus,
+button.bg-label-d-600:hover,
+button.bg-label-d-600:focus {
+  background-color: var(--pgn-color-action-default-label-d-600) !important;
+}
+
+.text-label-d-600 {
+  color: var(--pgn-color-label-d-600) !important;
+}
+
+a.text-label-d-600:hover,
+a.text-label-d-600:focus {
+  color: var(--pgn-color-action-default-label-d-600) !important;
+}
+
+.border-label-d-600 {
+  border-color: var(--pgn-color-label-d-600) !important;
+}
+
+.bg-label-d-700 {
+  background-color: var(--pgn-color-label-d-700) !important;
+}
+
+a.bg-label-d-700:hover,
+a.bg-label-d-700:focus,
+button.bg-label-d-700:hover,
+button.bg-label-d-700:focus {
+  background-color: var(--pgn-color-action-default-label-d-700) !important;
+}
+
+.text-label-d-700 {
+  color: var(--pgn-color-label-d-700) !important;
+}
+
+a.text-label-d-700:hover,
+a.text-label-d-700:focus {
+  color: var(--pgn-color-action-default-label-d-700) !important;
+}
+
+.border-label-d-700 {
+  border-color: var(--pgn-color-label-d-700) !important;
+}
+
+.bg-label-d-800 {
+  background-color: var(--pgn-color-label-d-800) !important;
+}
+
+a.bg-label-d-800:hover,
+a.bg-label-d-800:focus,
+button.bg-label-d-800:hover,
+button.bg-label-d-800:focus {
+  background-color: var(--pgn-color-action-default-label-d-800) !important;
+}
+
+.text-label-d-800 {
+  color: var(--pgn-color-label-d-800) !important;
+}
+
+a.text-label-d-800:hover,
+a.text-label-d-800:focus {
+  color: var(--pgn-color-action-default-label-d-800) !important;
+}
+
+.border-label-d-800 {
+  border-color: var(--pgn-color-label-d-800) !important;
+}
+
+.bg-label-d-900 {
+  background-color: var(--pgn-color-label-d-900) !important;
+}
+
+a.bg-label-d-900:hover,
+a.bg-label-d-900:focus,
+button.bg-label-d-900:hover,
+button.bg-label-d-900:focus {
+  background-color: var(--pgn-color-action-default-label-d-900) !important;
+}
+
+.text-label-d-900 {
+  color: var(--pgn-color-label-d-900) !important;
+}
+
+a.text-label-d-900:hover,
+a.text-label-d-900:focus {
+  color: var(--pgn-color-action-default-label-d-900) !important;
+}
+
+.border-label-d-900 {
+  border-color: var(--pgn-color-label-d-900) !important;
+}
+
+.bg-label-d {
+  background-color: var(--pgn-color-label-d-base) !important;
+}
+
+a.bg-label-d:hover,
+a.bg-label-d:focus,
+button.bg-label-d:hover,
+button.bg-label-d:focus {
+  background-color: var(--pgn-color-action-default-label-d-base) !important;
+}
+
+.text-label-d {
+  color: var(--pgn-color-label-d-base) !important;
+}
+
+a.text-label-d:hover,
+a.text-label-d:focus {
+  color: var(--pgn-color-action-default-label-d-base) !important;
+}
+
+.border-label-d {
+  border-color: var(--pgn-color-label-d-base) !important;
+}
+
+.bg-label-e-100 {
+  background-color: var(--pgn-color-label-e-100) !important;
+}
+
+a.bg-label-e-100:hover,
+a.bg-label-e-100:focus,
+button.bg-label-e-100:hover,
+button.bg-label-e-100:focus {
+  background-color: var(--pgn-color-action-default-label-e-100) !important;
+}
+
+.text-label-e-100 {
+  color: var(--pgn-color-label-e-100) !important;
+}
+
+a.text-label-e-100:hover,
+a.text-label-e-100:focus {
+  color: var(--pgn-color-action-default-label-e-100) !important;
+}
+
+.border-label-e-100 {
+  border-color: var(--pgn-color-label-e-100) !important;
+}
+
+.bg-label-e-200 {
+  background-color: var(--pgn-color-label-e-200) !important;
+}
+
+a.bg-label-e-200:hover,
+a.bg-label-e-200:focus,
+button.bg-label-e-200:hover,
+button.bg-label-e-200:focus {
+  background-color: var(--pgn-color-action-default-label-e-200) !important;
+}
+
+.text-label-e-200 {
+  color: var(--pgn-color-label-e-200) !important;
+}
+
+a.text-label-e-200:hover,
+a.text-label-e-200:focus {
+  color: var(--pgn-color-action-default-label-e-200) !important;
+}
+
+.border-label-e-200 {
+  border-color: var(--pgn-color-label-e-200) !important;
+}
+
+.bg-label-e-300 {
+  background-color: var(--pgn-color-label-e-300) !important;
+}
+
+a.bg-label-e-300:hover,
+a.bg-label-e-300:focus,
+button.bg-label-e-300:hover,
+button.bg-label-e-300:focus {
+  background-color: var(--pgn-color-action-default-label-e-300) !important;
+}
+
+.text-label-e-300 {
+  color: var(--pgn-color-label-e-300) !important;
+}
+
+a.text-label-e-300:hover,
+a.text-label-e-300:focus {
+  color: var(--pgn-color-action-default-label-e-300) !important;
+}
+
+.border-label-e-300 {
+  border-color: var(--pgn-color-label-e-300) !important;
+}
+
+.bg-label-e-400 {
+  background-color: var(--pgn-color-label-e-400) !important;
+}
+
+a.bg-label-e-400:hover,
+a.bg-label-e-400:focus,
+button.bg-label-e-400:hover,
+button.bg-label-e-400:focus {
+  background-color: var(--pgn-color-action-default-label-e-400) !important;
+}
+
+.text-label-e-400 {
+  color: var(--pgn-color-label-e-400) !important;
+}
+
+a.text-label-e-400:hover,
+a.text-label-e-400:focus {
+  color: var(--pgn-color-action-default-label-e-400) !important;
+}
+
+.border-label-e-400 {
+  border-color: var(--pgn-color-label-e-400) !important;
+}
+
+.bg-label-e-500 {
+  background-color: var(--pgn-color-label-e-500) !important;
+}
+
+a.bg-label-e-500:hover,
+a.bg-label-e-500:focus,
+button.bg-label-e-500:hover,
+button.bg-label-e-500:focus {
+  background-color: var(--pgn-color-action-default-label-e-500) !important;
+}
+
+.text-label-e-500 {
+  color: var(--pgn-color-label-e-500) !important;
+}
+
+a.text-label-e-500:hover,
+a.text-label-e-500:focus {
+  color: var(--pgn-color-action-default-label-e-500) !important;
+}
+
+.border-label-e-500 {
+  border-color: var(--pgn-color-label-e-500) !important;
+}
+
+.bg-label-e-600 {
+  background-color: var(--pgn-color-label-e-600) !important;
+}
+
+a.bg-label-e-600:hover,
+a.bg-label-e-600:focus,
+button.bg-label-e-600:hover,
+button.bg-label-e-600:focus {
+  background-color: var(--pgn-color-action-default-label-e-600) !important;
+}
+
+.text-label-e-600 {
+  color: var(--pgn-color-label-e-600) !important;
+}
+
+a.text-label-e-600:hover,
+a.text-label-e-600:focus {
+  color: var(--pgn-color-action-default-label-e-600) !important;
+}
+
+.border-label-e-600 {
+  border-color: var(--pgn-color-label-e-600) !important;
+}
+
+.bg-label-e-700 {
+  background-color: var(--pgn-color-label-e-700) !important;
+}
+
+a.bg-label-e-700:hover,
+a.bg-label-e-700:focus,
+button.bg-label-e-700:hover,
+button.bg-label-e-700:focus {
+  background-color: var(--pgn-color-action-default-label-e-700) !important;
+}
+
+.text-label-e-700 {
+  color: var(--pgn-color-label-e-700) !important;
+}
+
+a.text-label-e-700:hover,
+a.text-label-e-700:focus {
+  color: var(--pgn-color-action-default-label-e-700) !important;
+}
+
+.border-label-e-700 {
+  border-color: var(--pgn-color-label-e-700) !important;
+}
+
+.bg-label-e-800 {
+  background-color: var(--pgn-color-label-e-800) !important;
+}
+
+a.bg-label-e-800:hover,
+a.bg-label-e-800:focus,
+button.bg-label-e-800:hover,
+button.bg-label-e-800:focus {
+  background-color: var(--pgn-color-action-default-label-e-800) !important;
+}
+
+.text-label-e-800 {
+  color: var(--pgn-color-label-e-800) !important;
+}
+
+a.text-label-e-800:hover,
+a.text-label-e-800:focus {
+  color: var(--pgn-color-action-default-label-e-800) !important;
+}
+
+.border-label-e-800 {
+  border-color: var(--pgn-color-label-e-800) !important;
+}
+
+.bg-label-e-900 {
+  background-color: var(--pgn-color-label-e-900) !important;
+}
+
+a.bg-label-e-900:hover,
+a.bg-label-e-900:focus,
+button.bg-label-e-900:hover,
+button.bg-label-e-900:focus {
+  background-color: var(--pgn-color-action-default-label-e-900) !important;
+}
+
+.text-label-e-900 {
+  color: var(--pgn-color-label-e-900) !important;
+}
+
+a.text-label-e-900:hover,
+a.text-label-e-900:focus {
+  color: var(--pgn-color-action-default-label-e-900) !important;
+}
+
+.border-label-e-900 {
+  border-color: var(--pgn-color-label-e-900) !important;
+}
+
+.bg-label-e {
+  background-color: var(--pgn-color-label-e-base) !important;
+}
+
+a.bg-label-e:hover,
+a.bg-label-e:focus,
+button.bg-label-e:hover,
+button.bg-label-e:focus {
+  background-color: var(--pgn-color-action-default-label-e-base) !important;
+}
+
+.text-label-e {
+  color: var(--pgn-color-label-e-base) !important;
+}
+
+a.text-label-e:hover,
+a.text-label-e:focus {
+  color: var(--pgn-color-action-default-label-e-base) !important;
+}
+
+.border-label-e {
+  border-color: var(--pgn-color-label-e-base) !important;
+}
+
+.bg-label-f-100 {
+  background-color: var(--pgn-color-label-f-100) !important;
+}
+
+a.bg-label-f-100:hover,
+a.bg-label-f-100:focus,
+button.bg-label-f-100:hover,
+button.bg-label-f-100:focus {
+  background-color: var(--pgn-color-action-default-label-f-100) !important;
+}
+
+.text-label-f-100 {
+  color: var(--pgn-color-label-f-100) !important;
+}
+
+a.text-label-f-100:hover,
+a.text-label-f-100:focus {
+  color: var(--pgn-color-action-default-label-f-100) !important;
+}
+
+.border-label-f-100 {
+  border-color: var(--pgn-color-label-f-100) !important;
+}
+
+.bg-label-f-200 {
+  background-color: var(--pgn-color-label-f-200) !important;
+}
+
+a.bg-label-f-200:hover,
+a.bg-label-f-200:focus,
+button.bg-label-f-200:hover,
+button.bg-label-f-200:focus {
+  background-color: var(--pgn-color-action-default-label-f-200) !important;
+}
+
+.text-label-f-200 {
+  color: var(--pgn-color-label-f-200) !important;
+}
+
+a.text-label-f-200:hover,
+a.text-label-f-200:focus {
+  color: var(--pgn-color-action-default-label-f-200) !important;
+}
+
+.border-label-f-200 {
+  border-color: var(--pgn-color-label-f-200) !important;
+}
+
+.bg-label-f-300 {
+  background-color: var(--pgn-color-label-f-300) !important;
+}
+
+a.bg-label-f-300:hover,
+a.bg-label-f-300:focus,
+button.bg-label-f-300:hover,
+button.bg-label-f-300:focus {
+  background-color: var(--pgn-color-action-default-label-f-300) !important;
+}
+
+.text-label-f-300 {
+  color: var(--pgn-color-label-f-300) !important;
+}
+
+a.text-label-f-300:hover,
+a.text-label-f-300:focus {
+  color: var(--pgn-color-action-default-label-f-300) !important;
+}
+
+.border-label-f-300 {
+  border-color: var(--pgn-color-label-f-300) !important;
+}
+
+.bg-label-f-400 {
+  background-color: var(--pgn-color-label-f-400) !important;
+}
+
+a.bg-label-f-400:hover,
+a.bg-label-f-400:focus,
+button.bg-label-f-400:hover,
+button.bg-label-f-400:focus {
+  background-color: var(--pgn-color-action-default-label-f-400) !important;
+}
+
+.text-label-f-400 {
+  color: var(--pgn-color-label-f-400) !important;
+}
+
+a.text-label-f-400:hover,
+a.text-label-f-400:focus {
+  color: var(--pgn-color-action-default-label-f-400) !important;
+}
+
+.border-label-f-400 {
+  border-color: var(--pgn-color-label-f-400) !important;
+}
+
+.bg-label-f-500 {
+  background-color: var(--pgn-color-label-f-500) !important;
+}
+
+a.bg-label-f-500:hover,
+a.bg-label-f-500:focus,
+button.bg-label-f-500:hover,
+button.bg-label-f-500:focus {
+  background-color: var(--pgn-color-action-default-label-f-500) !important;
+}
+
+.text-label-f-500 {
+  color: var(--pgn-color-label-f-500) !important;
+}
+
+a.text-label-f-500:hover,
+a.text-label-f-500:focus {
+  color: var(--pgn-color-action-default-label-f-500) !important;
+}
+
+.border-label-f-500 {
+  border-color: var(--pgn-color-label-f-500) !important;
+}
+
+.bg-label-f-600 {
+  background-color: var(--pgn-color-label-f-600) !important;
+}
+
+a.bg-label-f-600:hover,
+a.bg-label-f-600:focus,
+button.bg-label-f-600:hover,
+button.bg-label-f-600:focus {
+  background-color: var(--pgn-color-action-default-label-f-600) !important;
+}
+
+.text-label-f-600 {
+  color: var(--pgn-color-label-f-600) !important;
+}
+
+a.text-label-f-600:hover,
+a.text-label-f-600:focus {
+  color: var(--pgn-color-action-default-label-f-600) !important;
+}
+
+.border-label-f-600 {
+  border-color: var(--pgn-color-label-f-600) !important;
+}
+
+.bg-label-f-700 {
+  background-color: var(--pgn-color-label-f-700) !important;
+}
+
+a.bg-label-f-700:hover,
+a.bg-label-f-700:focus,
+button.bg-label-f-700:hover,
+button.bg-label-f-700:focus {
+  background-color: var(--pgn-color-action-default-label-f-700) !important;
+}
+
+.text-label-f-700 {
+  color: var(--pgn-color-label-f-700) !important;
+}
+
+a.text-label-f-700:hover,
+a.text-label-f-700:focus {
+  color: var(--pgn-color-action-default-label-f-700) !important;
+}
+
+.border-label-f-700 {
+  border-color: var(--pgn-color-label-f-700) !important;
+}
+
+.bg-label-f-800 {
+  background-color: var(--pgn-color-label-f-800) !important;
+}
+
+a.bg-label-f-800:hover,
+a.bg-label-f-800:focus,
+button.bg-label-f-800:hover,
+button.bg-label-f-800:focus {
+  background-color: var(--pgn-color-action-default-label-f-800) !important;
+}
+
+.text-label-f-800 {
+  color: var(--pgn-color-label-f-800) !important;
+}
+
+a.text-label-f-800:hover,
+a.text-label-f-800:focus {
+  color: var(--pgn-color-action-default-label-f-800) !important;
+}
+
+.border-label-f-800 {
+  border-color: var(--pgn-color-label-f-800) !important;
+}
+
+.bg-label-f-900 {
+  background-color: var(--pgn-color-label-f-900) !important;
+}
+
+a.bg-label-f-900:hover,
+a.bg-label-f-900:focus,
+button.bg-label-f-900:hover,
+button.bg-label-f-900:focus {
+  background-color: var(--pgn-color-action-default-label-f-900) !important;
+}
+
+.text-label-f-900 {
+  color: var(--pgn-color-label-f-900) !important;
+}
+
+a.text-label-f-900:hover,
+a.text-label-f-900:focus {
+  color: var(--pgn-color-action-default-label-f-900) !important;
+}
+
+.border-label-f-900 {
+  border-color: var(--pgn-color-label-f-900) !important;
+}
+
+.bg-label-f {
+  background-color: var(--pgn-color-label-f-base) !important;
+}
+
+a.bg-label-f:hover,
+a.bg-label-f:focus,
+button.bg-label-f:hover,
+button.bg-label-f:focus {
+  background-color: var(--pgn-color-action-default-label-f-base) !important;
+}
+
+.text-label-f {
+  color: var(--pgn-color-label-f-base) !important;
+}
+
+a.text-label-f:hover,
+a.text-label-f:focus {
+  color: var(--pgn-color-action-default-label-f-base) !important;
+}
+
+.border-label-f {
+  border-color: var(--pgn-color-label-f-base) !important;
+}
+
+.bg-label-g-100 {
+  background-color: var(--pgn-color-label-g-100) !important;
+}
+
+a.bg-label-g-100:hover,
+a.bg-label-g-100:focus,
+button.bg-label-g-100:hover,
+button.bg-label-g-100:focus {
+  background-color: var(--pgn-color-action-default-label-g-100) !important;
+}
+
+.text-label-g-100 {
+  color: var(--pgn-color-label-g-100) !important;
+}
+
+a.text-label-g-100:hover,
+a.text-label-g-100:focus {
+  color: var(--pgn-color-action-default-label-g-100) !important;
+}
+
+.border-label-g-100 {
+  border-color: var(--pgn-color-label-g-100) !important;
+}
+
+.bg-label-g-200 {
+  background-color: var(--pgn-color-label-g-200) !important;
+}
+
+a.bg-label-g-200:hover,
+a.bg-label-g-200:focus,
+button.bg-label-g-200:hover,
+button.bg-label-g-200:focus {
+  background-color: var(--pgn-color-action-default-label-g-200) !important;
+}
+
+.text-label-g-200 {
+  color: var(--pgn-color-label-g-200) !important;
+}
+
+a.text-label-g-200:hover,
+a.text-label-g-200:focus {
+  color: var(--pgn-color-action-default-label-g-200) !important;
+}
+
+.border-label-g-200 {
+  border-color: var(--pgn-color-label-g-200) !important;
+}
+
+.bg-label-g-300 {
+  background-color: var(--pgn-color-label-g-300) !important;
+}
+
+a.bg-label-g-300:hover,
+a.bg-label-g-300:focus,
+button.bg-label-g-300:hover,
+button.bg-label-g-300:focus {
+  background-color: var(--pgn-color-action-default-label-g-300) !important;
+}
+
+.text-label-g-300 {
+  color: var(--pgn-color-label-g-300) !important;
+}
+
+a.text-label-g-300:hover,
+a.text-label-g-300:focus {
+  color: var(--pgn-color-action-default-label-g-300) !important;
+}
+
+.border-label-g-300 {
+  border-color: var(--pgn-color-label-g-300) !important;
+}
+
+.bg-label-g-400 {
+  background-color: var(--pgn-color-label-g-400) !important;
+}
+
+a.bg-label-g-400:hover,
+a.bg-label-g-400:focus,
+button.bg-label-g-400:hover,
+button.bg-label-g-400:focus {
+  background-color: var(--pgn-color-action-default-label-g-400) !important;
+}
+
+.text-label-g-400 {
+  color: var(--pgn-color-label-g-400) !important;
+}
+
+a.text-label-g-400:hover,
+a.text-label-g-400:focus {
+  color: var(--pgn-color-action-default-label-g-400) !important;
+}
+
+.border-label-g-400 {
+  border-color: var(--pgn-color-label-g-400) !important;
+}
+
+.bg-label-g-500 {
+  background-color: var(--pgn-color-label-g-500) !important;
+}
+
+a.bg-label-g-500:hover,
+a.bg-label-g-500:focus,
+button.bg-label-g-500:hover,
+button.bg-label-g-500:focus {
+  background-color: var(--pgn-color-action-default-label-g-500) !important;
+}
+
+.text-label-g-500 {
+  color: var(--pgn-color-label-g-500) !important;
+}
+
+a.text-label-g-500:hover,
+a.text-label-g-500:focus {
+  color: var(--pgn-color-action-default-label-g-500) !important;
+}
+
+.border-label-g-500 {
+  border-color: var(--pgn-color-label-g-500) !important;
+}
+
+.bg-label-g-600 {
+  background-color: var(--pgn-color-label-g-600) !important;
+}
+
+a.bg-label-g-600:hover,
+a.bg-label-g-600:focus,
+button.bg-label-g-600:hover,
+button.bg-label-g-600:focus {
+  background-color: var(--pgn-color-action-default-label-g-600) !important;
+}
+
+.text-label-g-600 {
+  color: var(--pgn-color-label-g-600) !important;
+}
+
+a.text-label-g-600:hover,
+a.text-label-g-600:focus {
+  color: var(--pgn-color-action-default-label-g-600) !important;
+}
+
+.border-label-g-600 {
+  border-color: var(--pgn-color-label-g-600) !important;
+}
+
+.bg-label-g-700 {
+  background-color: var(--pgn-color-label-g-700) !important;
+}
+
+a.bg-label-g-700:hover,
+a.bg-label-g-700:focus,
+button.bg-label-g-700:hover,
+button.bg-label-g-700:focus {
+  background-color: var(--pgn-color-action-default-label-g-700) !important;
+}
+
+.text-label-g-700 {
+  color: var(--pgn-color-label-g-700) !important;
+}
+
+a.text-label-g-700:hover,
+a.text-label-g-700:focus {
+  color: var(--pgn-color-action-default-label-g-700) !important;
+}
+
+.border-label-g-700 {
+  border-color: var(--pgn-color-label-g-700) !important;
+}
+
+.bg-label-g-800 {
+  background-color: var(--pgn-color-label-g-800) !important;
+}
+
+a.bg-label-g-800:hover,
+a.bg-label-g-800:focus,
+button.bg-label-g-800:hover,
+button.bg-label-g-800:focus {
+  background-color: var(--pgn-color-action-default-label-g-800) !important;
+}
+
+.text-label-g-800 {
+  color: var(--pgn-color-label-g-800) !important;
+}
+
+a.text-label-g-800:hover,
+a.text-label-g-800:focus {
+  color: var(--pgn-color-action-default-label-g-800) !important;
+}
+
+.border-label-g-800 {
+  border-color: var(--pgn-color-label-g-800) !important;
+}
+
+.bg-label-g-900 {
+  background-color: var(--pgn-color-label-g-900) !important;
+}
+
+a.bg-label-g-900:hover,
+a.bg-label-g-900:focus,
+button.bg-label-g-900:hover,
+button.bg-label-g-900:focus {
+  background-color: var(--pgn-color-action-default-label-g-900) !important;
+}
+
+.text-label-g-900 {
+  color: var(--pgn-color-label-g-900) !important;
+}
+
+a.text-label-g-900:hover,
+a.text-label-g-900:focus {
+  color: var(--pgn-color-action-default-label-g-900) !important;
+}
+
+.border-label-g-900 {
+  border-color: var(--pgn-color-label-g-900) !important;
+}
+
+.bg-label-g {
+  background-color: var(--pgn-color-label-g-base) !important;
+}
+
+a.bg-label-g:hover,
+a.bg-label-g:focus,
+button.bg-label-g:hover,
+button.bg-label-g:focus {
+  background-color: var(--pgn-color-action-default-label-g-base) !important;
+}
+
+.text-label-g {
+  color: var(--pgn-color-label-g-base) !important;
+}
+
+a.text-label-g:hover,
+a.text-label-g:focus {
+  color: var(--pgn-color-action-default-label-g-base) !important;
+}
+
+.border-label-g {
+  border-color: var(--pgn-color-label-g-base) !important;
+}
+
+.bg-label-h-100 {
+  background-color: var(--pgn-color-label-h-100) !important;
+}
+
+a.bg-label-h-100:hover,
+a.bg-label-h-100:focus,
+button.bg-label-h-100:hover,
+button.bg-label-h-100:focus {
+  background-color: var(--pgn-color-action-default-label-h-100) !important;
+}
+
+.text-label-h-100 {
+  color: var(--pgn-color-label-h-100) !important;
+}
+
+a.text-label-h-100:hover,
+a.text-label-h-100:focus {
+  color: var(--pgn-color-action-default-label-h-100) !important;
+}
+
+.border-label-h-100 {
+  border-color: var(--pgn-color-label-h-100) !important;
+}
+
+.bg-label-h-200 {
+  background-color: var(--pgn-color-label-h-200) !important;
+}
+
+a.bg-label-h-200:hover,
+a.bg-label-h-200:focus,
+button.bg-label-h-200:hover,
+button.bg-label-h-200:focus {
+  background-color: var(--pgn-color-action-default-label-h-200) !important;
+}
+
+.text-label-h-200 {
+  color: var(--pgn-color-label-h-200) !important;
+}
+
+a.text-label-h-200:hover,
+a.text-label-h-200:focus {
+  color: var(--pgn-color-action-default-label-h-200) !important;
+}
+
+.border-label-h-200 {
+  border-color: var(--pgn-color-label-h-200) !important;
+}
+
+.bg-label-h-300 {
+  background-color: var(--pgn-color-label-h-300) !important;
+}
+
+a.bg-label-h-300:hover,
+a.bg-label-h-300:focus,
+button.bg-label-h-300:hover,
+button.bg-label-h-300:focus {
+  background-color: var(--pgn-color-action-default-label-h-300) !important;
+}
+
+.text-label-h-300 {
+  color: var(--pgn-color-label-h-300) !important;
+}
+
+a.text-label-h-300:hover,
+a.text-label-h-300:focus {
+  color: var(--pgn-color-action-default-label-h-300) !important;
+}
+
+.border-label-h-300 {
+  border-color: var(--pgn-color-label-h-300) !important;
+}
+
+.bg-label-h-400 {
+  background-color: var(--pgn-color-label-h-400) !important;
+}
+
+a.bg-label-h-400:hover,
+a.bg-label-h-400:focus,
+button.bg-label-h-400:hover,
+button.bg-label-h-400:focus {
+  background-color: var(--pgn-color-action-default-label-h-400) !important;
+}
+
+.text-label-h-400 {
+  color: var(--pgn-color-label-h-400) !important;
+}
+
+a.text-label-h-400:hover,
+a.text-label-h-400:focus {
+  color: var(--pgn-color-action-default-label-h-400) !important;
+}
+
+.border-label-h-400 {
+  border-color: var(--pgn-color-label-h-400) !important;
+}
+
+.bg-label-h-500 {
+  background-color: var(--pgn-color-label-h-500) !important;
+}
+
+a.bg-label-h-500:hover,
+a.bg-label-h-500:focus,
+button.bg-label-h-500:hover,
+button.bg-label-h-500:focus {
+  background-color: var(--pgn-color-action-default-label-h-500) !important;
+}
+
+.text-label-h-500 {
+  color: var(--pgn-color-label-h-500) !important;
+}
+
+a.text-label-h-500:hover,
+a.text-label-h-500:focus {
+  color: var(--pgn-color-action-default-label-h-500) !important;
+}
+
+.border-label-h-500 {
+  border-color: var(--pgn-color-label-h-500) !important;
+}
+
+.bg-label-h-600 {
+  background-color: var(--pgn-color-label-h-600) !important;
+}
+
+a.bg-label-h-600:hover,
+a.bg-label-h-600:focus,
+button.bg-label-h-600:hover,
+button.bg-label-h-600:focus {
+  background-color: var(--pgn-color-action-default-label-h-600) !important;
+}
+
+.text-label-h-600 {
+  color: var(--pgn-color-label-h-600) !important;
+}
+
+a.text-label-h-600:hover,
+a.text-label-h-600:focus {
+  color: var(--pgn-color-action-default-label-h-600) !important;
+}
+
+.border-label-h-600 {
+  border-color: var(--pgn-color-label-h-600) !important;
+}
+
+.bg-label-h-700 {
+  background-color: var(--pgn-color-label-h-700) !important;
+}
+
+a.bg-label-h-700:hover,
+a.bg-label-h-700:focus,
+button.bg-label-h-700:hover,
+button.bg-label-h-700:focus {
+  background-color: var(--pgn-color-action-default-label-h-700) !important;
+}
+
+.text-label-h-700 {
+  color: var(--pgn-color-label-h-700) !important;
+}
+
+a.text-label-h-700:hover,
+a.text-label-h-700:focus {
+  color: var(--pgn-color-action-default-label-h-700) !important;
+}
+
+.border-label-h-700 {
+  border-color: var(--pgn-color-label-h-700) !important;
+}
+
+.bg-label-h-800 {
+  background-color: var(--pgn-color-label-h-800) !important;
+}
+
+a.bg-label-h-800:hover,
+a.bg-label-h-800:focus,
+button.bg-label-h-800:hover,
+button.bg-label-h-800:focus {
+  background-color: var(--pgn-color-action-default-label-h-800) !important;
+}
+
+.text-label-h-800 {
+  color: var(--pgn-color-label-h-800) !important;
+}
+
+a.text-label-h-800:hover,
+a.text-label-h-800:focus {
+  color: var(--pgn-color-action-default-label-h-800) !important;
+}
+
+.border-label-h-800 {
+  border-color: var(--pgn-color-label-h-800) !important;
+}
+
+.bg-label-h-900 {
+  background-color: var(--pgn-color-label-h-900) !important;
+}
+
+a.bg-label-h-900:hover,
+a.bg-label-h-900:focus,
+button.bg-label-h-900:hover,
+button.bg-label-h-900:focus {
+  background-color: var(--pgn-color-action-default-label-h-900) !important;
+}
+
+.text-label-h-900 {
+  color: var(--pgn-color-label-h-900) !important;
+}
+
+a.text-label-h-900:hover,
+a.text-label-h-900:focus {
+  color: var(--pgn-color-action-default-label-h-900) !important;
+}
+
+.border-label-h-900 {
+  border-color: var(--pgn-color-label-h-900) !important;
+}
+
+.bg-label-h {
+  background-color: var(--pgn-color-label-h-base) !important;
+}
+
+a.bg-label-h:hover,
+a.bg-label-h:focus,
+button.bg-label-h:hover,
+button.bg-label-h:focus {
+  background-color: var(--pgn-color-action-default-label-h-base) !important;
+}
+
+.text-label-h {
+  color: var(--pgn-color-label-h-base) !important;
+}
+
+a.text-label-h:hover,
+a.text-label-h:focus {
+  color: var(--pgn-color-action-default-label-h-base) !important;
+}
+
+.border-label-h {
+  border-color: var(--pgn-color-label-h-base) !important;
+}
+
+.bg-label-i-100 {
+  background-color: var(--pgn-color-label-i-100) !important;
+}
+
+a.bg-label-i-100:hover,
+a.bg-label-i-100:focus,
+button.bg-label-i-100:hover,
+button.bg-label-i-100:focus {
+  background-color: var(--pgn-color-action-default-label-i-100) !important;
+}
+
+.text-label-i-100 {
+  color: var(--pgn-color-label-i-100) !important;
+}
+
+a.text-label-i-100:hover,
+a.text-label-i-100:focus {
+  color: var(--pgn-color-action-default-label-i-100) !important;
+}
+
+.border-label-i-100 {
+  border-color: var(--pgn-color-label-i-100) !important;
+}
+
+.bg-label-i-200 {
+  background-color: var(--pgn-color-label-i-200) !important;
+}
+
+a.bg-label-i-200:hover,
+a.bg-label-i-200:focus,
+button.bg-label-i-200:hover,
+button.bg-label-i-200:focus {
+  background-color: var(--pgn-color-action-default-label-i-200) !important;
+}
+
+.text-label-i-200 {
+  color: var(--pgn-color-label-i-200) !important;
+}
+
+a.text-label-i-200:hover,
+a.text-label-i-200:focus {
+  color: var(--pgn-color-action-default-label-i-200) !important;
+}
+
+.border-label-i-200 {
+  border-color: var(--pgn-color-label-i-200) !important;
+}
+
+.bg-label-i-300 {
+  background-color: var(--pgn-color-label-i-300) !important;
+}
+
+a.bg-label-i-300:hover,
+a.bg-label-i-300:focus,
+button.bg-label-i-300:hover,
+button.bg-label-i-300:focus {
+  background-color: var(--pgn-color-action-default-label-i-300) !important;
+}
+
+.text-label-i-300 {
+  color: var(--pgn-color-label-i-300) !important;
+}
+
+a.text-label-i-300:hover,
+a.text-label-i-300:focus {
+  color: var(--pgn-color-action-default-label-i-300) !important;
+}
+
+.border-label-i-300 {
+  border-color: var(--pgn-color-label-i-300) !important;
+}
+
+.bg-label-i-400 {
+  background-color: var(--pgn-color-label-i-400) !important;
+}
+
+a.bg-label-i-400:hover,
+a.bg-label-i-400:focus,
+button.bg-label-i-400:hover,
+button.bg-label-i-400:focus {
+  background-color: var(--pgn-color-action-default-label-i-400) !important;
+}
+
+.text-label-i-400 {
+  color: var(--pgn-color-label-i-400) !important;
+}
+
+a.text-label-i-400:hover,
+a.text-label-i-400:focus {
+  color: var(--pgn-color-action-default-label-i-400) !important;
+}
+
+.border-label-i-400 {
+  border-color: var(--pgn-color-label-i-400) !important;
+}
+
+.bg-label-i-500 {
+  background-color: var(--pgn-color-label-i-500) !important;
+}
+
+a.bg-label-i-500:hover,
+a.bg-label-i-500:focus,
+button.bg-label-i-500:hover,
+button.bg-label-i-500:focus {
+  background-color: var(--pgn-color-action-default-label-i-500) !important;
+}
+
+.text-label-i-500 {
+  color: var(--pgn-color-label-i-500) !important;
+}
+
+a.text-label-i-500:hover,
+a.text-label-i-500:focus {
+  color: var(--pgn-color-action-default-label-i-500) !important;
+}
+
+.border-label-i-500 {
+  border-color: var(--pgn-color-label-i-500) !important;
+}
+
+.bg-label-i-600 {
+  background-color: var(--pgn-color-label-i-600) !important;
+}
+
+a.bg-label-i-600:hover,
+a.bg-label-i-600:focus,
+button.bg-label-i-600:hover,
+button.bg-label-i-600:focus {
+  background-color: var(--pgn-color-action-default-label-i-600) !important;
+}
+
+.text-label-i-600 {
+  color: var(--pgn-color-label-i-600) !important;
+}
+
+a.text-label-i-600:hover,
+a.text-label-i-600:focus {
+  color: var(--pgn-color-action-default-label-i-600) !important;
+}
+
+.border-label-i-600 {
+  border-color: var(--pgn-color-label-i-600) !important;
+}
+
+.bg-label-i-700 {
+  background-color: var(--pgn-color-label-i-700) !important;
+}
+
+a.bg-label-i-700:hover,
+a.bg-label-i-700:focus,
+button.bg-label-i-700:hover,
+button.bg-label-i-700:focus {
+  background-color: var(--pgn-color-action-default-label-i-700) !important;
+}
+
+.text-label-i-700 {
+  color: var(--pgn-color-label-i-700) !important;
+}
+
+a.text-label-i-700:hover,
+a.text-label-i-700:focus {
+  color: var(--pgn-color-action-default-label-i-700) !important;
+}
+
+.border-label-i-700 {
+  border-color: var(--pgn-color-label-i-700) !important;
+}
+
+.bg-label-i-800 {
+  background-color: var(--pgn-color-label-i-800) !important;
+}
+
+a.bg-label-i-800:hover,
+a.bg-label-i-800:focus,
+button.bg-label-i-800:hover,
+button.bg-label-i-800:focus {
+  background-color: var(--pgn-color-action-default-label-i-800) !important;
+}
+
+.text-label-i-800 {
+  color: var(--pgn-color-label-i-800) !important;
+}
+
+a.text-label-i-800:hover,
+a.text-label-i-800:focus {
+  color: var(--pgn-color-action-default-label-i-800) !important;
+}
+
+.border-label-i-800 {
+  border-color: var(--pgn-color-label-i-800) !important;
+}
+
+.bg-label-i-900 {
+  background-color: var(--pgn-color-label-i-900) !important;
+}
+
+a.bg-label-i-900:hover,
+a.bg-label-i-900:focus,
+button.bg-label-i-900:hover,
+button.bg-label-i-900:focus {
+  background-color: var(--pgn-color-action-default-label-i-900) !important;
+}
+
+.text-label-i-900 {
+  color: var(--pgn-color-label-i-900) !important;
+}
+
+a.text-label-i-900:hover,
+a.text-label-i-900:focus {
+  color: var(--pgn-color-action-default-label-i-900) !important;
+}
+
+.border-label-i-900 {
+  border-color: var(--pgn-color-label-i-900) !important;
+}
+
+.bg-label-i {
+  background-color: var(--pgn-color-label-i-base) !important;
+}
+
+a.bg-label-i:hover,
+a.bg-label-i:focus,
+button.bg-label-i:hover,
+button.bg-label-i:focus {
+  background-color: var(--pgn-color-action-default-label-i-base) !important;
+}
+
+.text-label-i {
+  color: var(--pgn-color-label-i-base) !important;
+}
+
+a.text-label-i:hover,
+a.text-label-i:focus {
+  color: var(--pgn-color-action-default-label-i-base) !important;
+}
+
+.border-label-i {
+  border-color: var(--pgn-color-label-i-base) !important;
+}
+

--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -654,6 +654,87 @@
   --pgn-color-brand-base: #9D0054FF; /* Basic brand color. */
   --pgn-color-light-base: #E1DDDBFF; /* Basic light color. */
   --pgn-color-dark-base: #273F2FFF; /* Basic dark color. */
+  --pgn-color-label-a-100: #F9E6E6FF; /* Label color A of level 100. */
+  --pgn-color-label-a-200: #EFBDBDFF; /* Label color A of level 200. */
+  --pgn-color-label-a-300: #E69898FF; /* Label color A of level 300. */
+  --pgn-color-label-a-400: #DA6363FF; /* Label color A of level 400. */
+  --pgn-color-label-a-600: #B92C2CFF; /* Label color A of level 600. */
+  --pgn-color-label-a-700: #942323FF; /* Label color A of level 700. */
+  --pgn-color-label-a-800: #731C1CFF; /* Label color A of level 800. */
+  --pgn-color-label-a-900: #521414FF; /* Label color A of level 900. */
+  --pgn-color-label-a-base: #D24242FF; /* Base color of Label color A. */
+  --pgn-color-label-b-100: #F6F9F1FF; /* Label color B of level 100. */
+  --pgn-color-label-b-200: #D9E4C4FF; /* Label color B of level 200. */
+  --pgn-color-label-b-300: #B3C888FF; /* Label color B of level 300. */
+  --pgn-color-label-b-400: #96B35BFF; /* Label color B of level 400. */
+  --pgn-color-label-b-600: #677E3AFF; /* Label color B of level 600. */
+  --pgn-color-label-b-700: #5C7033FF; /* Label color B of level 700. */
+  --pgn-color-label-b-800: #4A5B2AFF; /* Label color B of level 800. */
+  --pgn-color-label-b-900: #394620FF; /* Label color B of level 900. */
+  --pgn-color-label-b-base: #7B9645FF; /* Base color of Label color B. */
+  --pgn-color-label-c-100: #E6E6F9FF; /* Label color C of level 100. */
+  --pgn-color-label-c-200: #C5C5F1FF; /* Label color C of level 200. */
+  --pgn-color-label-c-300: #A4A4E9FF; /* Label color C of level 300. */
+  --pgn-color-label-c-400: #7F7FE1FF; /* Label color C of level 400. */
+  --pgn-color-label-c-600: #3131CEFF; /* Label color C of level 600. */
+  --pgn-color-label-c-700: #2727A5FF; /* Label color C of level 700. */
+  --pgn-color-label-c-800: #1D1D7CFF; /* Label color C of level 800. */
+  --pgn-color-label-c-900: #141452FF; /* Label color C of level 900. */
+  --pgn-color-label-c-base: #5A5AD8FF; /* Base color of Label color C. */
+  --pgn-color-label-d-100: #FAF5EBFF; /* Label color D of level 100. */
+  --pgn-color-label-d-200: #EEDCBAFF; /* Label color D of level 200. */
+  --pgn-color-label-d-300: #DDBA74FF; /* Label color D of level 300. */
+  --pgn-color-label-d-400: #CF9F3FFF; /* Label color D of level 400. */
+  --pgn-color-label-d-600: #936E25FF; /* Label color D of level 600. */
+  --pgn-color-label-d-700: #7F5F1FFF; /* Label color D of level 700. */
+  --pgn-color-label-d-800: #6A501AFF; /* Label color D of level 800. */
+  --pgn-color-label-d-900: #523D14FF; /* Label color D of level 900. */
+  --pgn-color-label-d-base: #B0842CFF; /* Base color of Label color D. */
+  --pgn-color-label-e-100: #E6F3F9FF; /* Label color E of level 100. */
+  --pgn-color-label-e-200: #B5DBEDFF; /* Label color E of level 200. */
+  --pgn-color-label-e-300: #7FC0E1FF; /* Label color E of level 300. */
+  --pgn-color-label-e-400: #52AAD6FF; /* Label color E of level 400. */
+  --pgn-color-label-e-600: #277BA5FF; /* Label color E of level 600. */
+  --pgn-color-label-e-700: #21688CFF; /* Label color E of level 700. */
+  --pgn-color-label-e-800: #1B536FFF; /* Label color E of level 800. */
+  --pgn-color-label-e-900: #143D52FF; /* Label color E of level 900. */
+  --pgn-color-label-e-base: #2E90C2FF; /* Base color of Label color E. */
+  --pgn-color-label-f-100: #FAEAF2FF; /* Label color F of level 100. */
+  --pgn-color-label-f-200: #EBADCCFF; /* Label color F of level 200. */
+  --pgn-color-label-f-300: #E283B2FF; /* Label color F of level 300. */
+  --pgn-color-label-f-400: #DA639EFF; /* Label color F of level 400. */
+  --pgn-color-label-f-600: #B92C73FF; /* Label color F of level 600. */
+  --pgn-color-label-f-700: #94235CFF; /* Label color F of level 700. */
+  --pgn-color-label-f-800: #731C47FF; /* Label color F of level 800. */
+  --pgn-color-label-f-900: #521433FF; /* Label color F of level 900. */
+  --pgn-color-label-f-base: #D13F88FF; /* Base color of Label color F. */
+  --pgn-color-label-g-100: #F0FAF6FF; /* Label color G of level 100. */
+  --pgn-color-label-g-200: #BEE9DBFF; /* Label color G of level 200. */
+  --pgn-color-label-g-300: #7DD4B7FF; /* Label color G of level 300. */
+  --pgn-color-label-g-400: #4BC39BFF; /* Label color G of level 400. */
+  --pgn-color-label-g-600: #2B8265FF; /* Label color G of level 600. */
+  --pgn-color-label-g-700: #267359FF; /* Label color G of level 700. */
+  --pgn-color-label-g-800: #20604AFF; /* Label color G of level 800. */
+  --pgn-color-label-g-900: #1A4C3CFF; /* Label color G of level 900. */
+  --pgn-color-label-g-base: #36A17DFF; /* Base color of Label color G. */
+  --pgn-color-label-h-100: #F3E6F9FF; /* Label color H of level 100. */
+  --pgn-color-label-h-200: #E3C5F1FF; /* Label color H of level 200. */
+  --pgn-color-label-h-300: #D2A4E9FF; /* Label color H of level 300. */
+  --pgn-color-label-h-400: #C07FE1FF; /* Label color H of level 400. */
+  --pgn-color-label-h-600: #9A31CEFF; /* Label color H of level 600. */
+  --pgn-color-label-h-700: #7B27A5FF; /* Label color H of level 700. */
+  --pgn-color-label-h-800: #5C1D7CFF; /* Label color H of level 800. */
+  --pgn-color-label-h-900: #3D1452FF; /* Label color H of level 900. */
+  --pgn-color-label-h-base: #AE5AD8FF; /* Base color of Label color H. */
+  --pgn-color-label-i-100: #ECF8ECFF; /* Label color I of level 100. */
+  --pgn-color-label-i-200: #C0E8C0FF; /* Label color I of level 200. */
+  --pgn-color-label-i-300: #80D080FF; /* Label color I of level 300. */
+  --pgn-color-label-i-400: #50BE50FF; /* Label color I of level 400. */
+  --pgn-color-label-i-600: #328632FF; /* Label color I of level 600. */
+  --pgn-color-label-i-700: #2B732BFF; /* Label color I of level 700. */
+  --pgn-color-label-i-800: #246124FF; /* Label color I of level 800. */
+  --pgn-color-label-i-900: #1C4A1CFF; /* Label color I of level 900. */
+  --pgn-color-label-i-base: #3BA03BFF; /* Base color of Label color I. */
   --pgn-border-color-nav-tabs-link-border-hover-top: transparent;
   --pgn-border-color-nav-tabs-link-border-hover-right: transparent;
   --pgn-border-color-nav-tabs-link-border-hover-left: transparent;
@@ -995,6 +1076,15 @@
   --pgn-color-dark-700: #1F3226FF; /* Info color of level 700. */
   --pgn-color-dark-800: #1D2F23FF; /* Dark color of level 800. */
   --pgn-color-dark-900: #1B2C21FF; /* Dark color of level 900. */
+  --pgn-color-label-a-500: var(--pgn-color-label-a-base); /* Label color A of level 500. */
+  --pgn-color-label-b-500: var(--pgn-color-label-b-base); /* Label color B of level 500. */
+  --pgn-color-label-c-500: var(--pgn-color-label-c-base); /* Label color C of level 500. */
+  --pgn-color-label-d-500: var(--pgn-color-label-d-base); /* Label color D of level 500. */
+  --pgn-color-label-e-500: var(--pgn-color-label-e-base); /* Label color E of level 500. */
+  --pgn-color-label-f-500: var(--pgn-color-label-f-base); /* Label color F of level 500. */
+  --pgn-color-label-g-500: var(--pgn-color-label-g-base); /* Label color G of level 500. */
+  --pgn-color-label-h-500: var(--pgn-color-label-h-base); /* Label color H of level 500. */
+  --pgn-color-label-i-500: var(--pgn-color-label-i-base); /* Label color I of level 500. */
   --pgn-color-action-default-gray-100: #D2D2D2FF;
   --pgn-color-action-default-gray-200: #B3B3B3FF;
   --pgn-color-action-default-gray-300: #949494FF;
@@ -1008,6 +1098,87 @@
   --pgn-color-action-default-brand-base: #6A0039FF;
   --pgn-color-action-default-light-base: #CAC3BFFF;
   --pgn-color-action-default-dark-base: #142018FF;
+  --pgn-color-action-default-label-a-100: #EFBDBDFF;
+  --pgn-color-action-default-label-a-200: #E59494FF;
+  --pgn-color-action-default-label-a-300: #DC6F6FFF;
+  --pgn-color-action-default-label-a-400: #D03A3AFF;
+  --pgn-color-action-default-label-a-600: #902222FF;
+  --pgn-color-action-default-label-a-700: #6B1919FF;
+  --pgn-color-action-default-label-a-800: #4A1212FF;
+  --pgn-color-action-default-label-a-900: #290A0AFF;
+  --pgn-color-action-default-label-a-base: #B62B2BFF;
+  --pgn-color-action-default-label-b-100: #DFEACDFF;
+  --pgn-color-action-default-label-b-200: #C2D4A1FF;
+  --pgn-color-action-default-label-b-300: #9DB865FF;
+  --pgn-color-action-default-label-b-400: #7B9645FF;
+  --pgn-color-action-default-label-b-600: #4A5B2AFF;
+  --pgn-color-action-default-label-b-700: #3F4D23FF;
+  --pgn-color-action-default-label-b-800: #2E381AFF;
+  --pgn-color-action-default-label-b-900: #1D2310FF;
+  --pgn-color-action-default-label-b-base: #5E7335FF;
+  --pgn-color-action-default-label-c-100: #BDBDEFFF;
+  --pgn-color-action-default-label-c-200: #9C9CE7FF;
+  --pgn-color-action-default-label-c-300: #7B7BDFFF;
+  --pgn-color-action-default-label-c-400: #5656D7FF;
+  --pgn-color-action-default-label-c-600: #2727A5FF;
+  --pgn-color-action-default-label-c-700: #1D1D7CFF;
+  --pgn-color-action-default-label-c-800: #131353FF;
+  --pgn-color-action-default-label-c-900: #0A0A29FF;
+  --pgn-color-action-default-label-c-base: #3131CEFF;
+  --pgn-color-action-default-label-d-100: #F0E1C2FF;
+  --pgn-color-action-default-label-d-200: #E4C791FF;
+  --pgn-color-action-default-label-d-300: #D3A64BFF;
+  --pgn-color-action-default-label-d-400: #AF832CFF;
+  --pgn-color-action-default-label-d-600: #6A501BFF;
+  --pgn-color-action-default-label-d-700: #564015FF;
+  --pgn-color-action-default-label-d-800: #413110FF;
+  --pgn-color-action-default-label-d-900: #291E0AFF;
+  --pgn-color-action-default-label-d-base: #876522FF;
+  --pgn-color-action-default-label-e-100: #BDDFEFFF;
+  --pgn-color-action-default-label-e-200: #8CC7E3FF;
+  --pgn-color-action-default-label-e-300: #56ACD7FF;
+  --pgn-color-action-default-label-e-400: #2F94C6FF;
+  --pgn-color-action-default-label-e-600: #1D5C7CFF;
+  --pgn-color-action-default-label-e-700: #174963FF;
+  --pgn-color-action-default-label-e-800: #113446FF;
+  --pgn-color-action-default-label-e-900: #0A1E29FF;
+  --pgn-color-action-default-label-e-base: #247199FF;
+  --pgn-color-action-default-label-f-100: #F0C1D9FF;
+  --pgn-color-action-default-label-f-200: #E184B3FF;
+  --pgn-color-action-default-label-f-300: #D85A98FF;
+  --pgn-color-action-default-label-f-400: #D03A84FF;
+  --pgn-color-action-default-label-f-600: #902259FF;
+  --pgn-color-action-default-label-f-700: #6B1942FF;
+  --pgn-color-action-default-label-f-800: #4A122EFF;
+  --pgn-color-action-default-label-f-900: #290A1AFF;
+  --pgn-color-action-default-label-f-base: #B22B6FFF;
+  --pgn-color-action-default-label-g-100: #CAEDDFFF;
+  --pgn-color-action-default-label-g-200: #98DCC6FF;
+  --pgn-color-action-default-label-g-300: #57C7A2FF;
+  --pgn-color-action-default-label-g-400: #37A480FF;
+  --pgn-color-action-default-label-g-600: #1E5C47FF;
+  --pgn-color-action-default-label-g-700: #194D3BFF;
+  --pgn-color-action-default-label-g-800: #133A2DFF;
+  --pgn-color-action-default-label-g-900: #0D261EFF;
+  --pgn-color-action-default-label-g-base: #297B5FFF;
+  --pgn-color-action-default-label-h-100: #DFBDEFFF;
+  --pgn-color-action-default-label-h-200: #CF9CE7FF;
+  --pgn-color-action-default-label-h-300: #BE7BDFFF;
+  --pgn-color-action-default-label-h-400: #AC56D7FF;
+  --pgn-color-action-default-label-h-600: #7B27A5FF;
+  --pgn-color-action-default-label-h-700: #5C1D7CFF;
+  --pgn-color-action-default-label-h-800: #3D1353FF;
+  --pgn-color-action-default-label-h-900: #1E0A29FF;
+  --pgn-color-action-default-label-h-base: #9A31CEFF;
+  --pgn-color-action-default-label-i-100: #C7EAC7FF;
+  --pgn-color-action-default-label-i-200: #9BDA9BFF;
+  --pgn-color-action-default-label-i-300: #5BC25BFF;
+  --pgn-color-action-default-label-i-400: #3BA03BFF;
+  --pgn-color-action-default-label-i-600: #246124FF;
+  --pgn-color-action-default-label-i-700: #1D4E1DFF;
+  --pgn-color-action-default-label-i-800: #163C16FF;
+  --pgn-color-action-default-label-i-900: #0E250EFF;
+  --pgn-color-action-default-label-i-base: #2D7B2DFF;
   --pgn-color-action-default-accent-a: #0095C6FF;
   --pgn-color-action-default-accent-b: #FFE755FF;
   --pgn-elevation-dropzone-active-color: var(--pgn-color-primary-500);
@@ -1546,6 +1717,15 @@
   --pgn-color-action-default-dark-700: #0B130EFF;
   --pgn-color-action-default-dark-800: #0A0F0CFF;
   --pgn-color-action-default-dark-900: #080C09FF;
+  --pgn-color-action-default-label-a-500: #B62B2BFF;
+  --pgn-color-action-default-label-b-500: #5E7335FF;
+  --pgn-color-action-default-label-c-500: #3131CEFF;
+  --pgn-color-action-default-label-d-500: #876522FF;
+  --pgn-color-action-default-label-e-500: #247199FF;
+  --pgn-color-action-default-label-f-500: #B22B6FFF;
+  --pgn-color-action-default-label-g-500: #297B5FFF;
+  --pgn-color-action-default-label-h-500: #9A31CEFF;
+  --pgn-color-action-default-label-i-500: #2D7B2DFF;
   --pgn-content-carousel-control-bg-prev-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e");
   --pgn-content-carousel-control-bg-next-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e");
   --pgn-content-navbar-toggler-dark-icon-bg: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%23FFFFFF80' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");

--- a/tokens/src/core/utilities/color.json
+++ b/tokens/src/core/utilities/color.json
@@ -16,6 +16,15 @@
           "danger",
           "light",
           "dark",
+          "label-a",
+          "label-b",
+          "label-c",
+          "label-d",
+          "label-e",
+          "label-f",
+          "label-g",
+          "label-h",
+          "label-i",
           "accent"
         ],
         "item": [

--- a/tokens/src/themes/light/global/color.json
+++ b/tokens/src/themes/light/global/color.json
@@ -1336,6 +1336,654 @@
         "$description": "Basic dark color."
       }
     },
+    "label-a": {
+      "100": {
+        "$value": "#F9E6E6",
+        "$description": "Label color A of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-a.100}"
+        }
+      },
+      "200": {
+        "$value": "#EFBDBD",
+        "$description": "Label color A of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-a.200}"
+        }
+      },
+      "300": {
+        "$value": "#E69898",
+        "$description": "Label color A of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-a.300}"
+        }
+      },
+      "400": {
+        "$value": "#DA6363",
+        "$description": "Label color A of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-a.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-a.base}",
+        "$description": "Label color A of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-a.500}"
+        }
+      },
+      "600": {
+        "$value": "#B92C2C",
+        "$description": "Label color A of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-a.600}"
+        }
+      },
+      "700": {
+        "$value": "#942323",
+        "$description": "Label color A of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-a.700}"
+        }
+      },
+      "800": {
+        "$value": "#731C1C",
+        "$description": "Label color A of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-a.800}"
+        }
+      },
+      "900": {
+        "$value": "#521414",
+        "$description": "Label color A of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-a.900}"
+        }
+      },
+      "base": {
+        "$value": "#D24242",
+        "$description": "Base color of Label color A.",
+        "actions": {
+          "default": "{color.action.default.label-a.base}"
+        }
+      }
+    },
+    "label-b": {
+      "100": {
+        "$value": "#F6F9F1",
+        "$description": "Label color B of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-b.100}"
+        }
+      },
+      "200": {
+        "$value": "#D9E4C4",
+        "$description": "Label color B of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-b.200}"
+        }
+      },
+      "300": {
+        "$value": "#B3C888",
+        "$description": "Label color B of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-b.300}"
+        }
+      },
+      "400": {
+        "$value": "#96B35B",
+        "$description": "Label color B of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-b.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-b.base}",
+        "$description": "Label color B of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-b.500}"
+        }
+      },
+      "600": {
+        "$value": "#677E3A",
+        "$description": "Label color B of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-b.600}"
+        }
+      },
+      "700": {
+        "$value": "#5C7033",
+        "$description": "Label color B of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-b.700}"
+        }
+      },
+      "800": {
+        "$value": "#4A5B2A",
+        "$description": "Label color B of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-b.800}"
+        }
+      },
+      "900": {
+        "$value": "#394620",
+        "$description": "Label color B of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-b.900}"
+        }
+      },
+      "base": {
+        "$value": "#7B9645",
+        "$description": "Base color of Label color B.",
+        "actions": {
+          "default": "{color.action.default.label-b.base}"
+        }
+      }
+    },
+    "label-c": {
+      "100": {
+        "$value": "#E6E6F9",
+        "$description": "Label color C of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-c.100}"
+        }
+      },
+      "200": {
+        "$value": "#C5C5F1",
+        "$description": "Label color C of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-c.200}"
+        }
+      },
+      "300": {
+        "$value": "#A4A4E9",
+        "$description": "Label color C of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-c.300}"
+        }
+      },
+      "400": {
+        "$value": "#7F7FE1",
+        "$description": "Label color C of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-c.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-c.base}",
+        "$description": "Label color C of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-c.500}"
+        }
+      },
+      "600": {
+        "$value": "#3131CE",
+        "$description": "Label color C of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-c.600}"
+        }
+      },
+      "700": {
+        "$value": "#2727A5",
+        "$description": "Label color C of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-c.700}"
+        }
+      },
+      "800": {
+        "$value": "#1D1D7C",
+        "$description": "Label color C of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-c.800}"
+        }
+      },
+      "900": {
+        "$value": "#141452",
+        "$description": "Label color C of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-c.900}"
+        }
+      },
+      "base": {
+        "$value": "#5A5AD8",
+        "$description": "Base color of Label color C.",
+        "actions": {
+          "default": "{color.action.default.label-c.base}"
+        }
+      }
+    },
+    "label-d": {
+      "100": {
+        "$value": "#FAF5EB",
+        "$description": "Label color D of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-d.100}"
+        }
+      },
+      "200": {
+        "$value": "#EEDCBA",
+        "$description": "Label color D of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-d.200}"
+        }
+      },
+      "300": {
+        "$value": "#DDBA74",
+        "$description": "Label color D of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-d.300}"
+        }
+      },
+      "400": {
+        "$value": "#CF9F3F",
+        "$description": "Label color D of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-d.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-d.base}",
+        "$description": "Label color D of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-d.500}"
+        }
+      },
+      "600": {
+        "$value": "#936E25",
+        "$description": "Label color D of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-d.600}"
+        }
+      },
+      "700": {
+        "$value": "#7F5F1F",
+        "$description": "Label color D of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-d.700}"
+        }
+      },
+      "800": {
+        "$value": "#6A501A",
+        "$description": "Label color D of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-d.800}"
+        }
+      },
+      "900": {
+        "$value": "#523D14",
+        "$description": "Label color D of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-d.900}"
+        }
+      },
+      "base": {
+        "$value": "#B0842C",
+        "$description": "Base color of Label color D.",
+        "actions": {
+          "default": "{color.action.default.label-d.base}"
+        }
+      }
+    },
+    "label-e": {
+      "100": {
+        "$value": "#E6F3F9",
+        "$description": "Label color E of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-e.100}"
+        }
+      },
+      "200": {
+        "$value": "#B5DBED",
+        "$description": "Label color E of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-e.200}"
+        }
+      },
+      "300": {
+        "$value": "#7FC0E1",
+        "$description": "Label color E of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-e.300}"
+        }
+      },
+      "400": {
+        "$value": "#52AAD6",
+        "$description": "Label color E of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-e.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-e.base}",
+        "$description": "Label color E of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-e.500}"
+        }
+      },
+      "600": {
+        "$value": "#277BA5",
+        "$description": "Label color E of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-e.600}"
+        }
+      },
+      "700": {
+        "$value": "#21688C",
+        "$description": "Label color E of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-e.700}"
+        }
+      },
+      "800": {
+        "$value": "#1B536F",
+        "$description": "Label color E of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-e.800}"
+        }
+      },
+      "900": {
+        "$value": "#143D52",
+        "$description": "Label color E of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-e.900}"
+        }
+      },
+      "base": {
+        "$value": "#2E90C2",
+        "$description": "Base color of Label color E.",
+        "actions": {
+          "default": "{color.action.default.label-e.base}"
+        }
+      }
+    },
+    "label-f": {
+      "100": {
+        "$value": "#FAEAF2",
+        "$description": "Label color F of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-f.100}"
+        }
+      },
+      "200": {
+        "$value": "#EBADCC",
+        "$description": "Label color F of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-f.200}"
+        }
+      },
+      "300": {
+        "$value": "#E283B2",
+        "$description": "Label color F of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-f.300}"
+        }
+      },
+      "400": {
+        "$value": "#DA639E",
+        "$description": "Label color F of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-f.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-f.base}",
+        "$description": "Label color F of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-f.500}"
+        }
+      },
+      "600": {
+        "$value": "#B92C73",
+        "$description": "Label color F of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-f.600}"
+        }
+      },
+      "700": {
+        "$value": "#94235C",
+        "$description": "Label color F of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-f.700}"
+        }
+      },
+      "800": {
+        "$value": "#731C47",
+        "$description": "Label color F of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-f.800}"
+        }
+      },
+      "900": {
+        "$value": "#521433",
+        "$description": "Label color F of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-f.900}"
+        }
+      },
+      "base": {
+        "$value": "#D13F88",
+        "$description": "Base color of Label color F.",
+        "actions": {
+          "default": "{color.action.default.label-f.base}"
+        }
+      }
+    },
+    "label-g": {
+      "100": {
+        "$value": "#F0FAF6",
+        "$description": "Label color G of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-g.100}"
+        }
+      },
+      "200": {
+        "$value": "#BEE9DB",
+        "$description": "Label color G of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-g.200}"
+        }
+      },
+      "300": {
+        "$value": "#7DD4B7",
+        "$description": "Label color G of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-g.300}"
+        }
+      },
+      "400": {
+        "$value": "#4BC39B",
+        "$description": "Label color G of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-g.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-g.base}",
+        "$description": "Label color G of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-g.500}"
+        }
+      },
+      "600": {
+        "$value": "#2B8265",
+        "$description": "Label color G of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-g.600}"
+        }
+      },
+      "700": {
+        "$value": "#267359",
+        "$description": "Label color G of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-g.700}"
+        }
+      },
+      "800": {
+        "$value": "#20604A",
+        "$description": "Label color G of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-g.800}"
+        }
+      },
+      "900": {
+        "$value": "#1A4C3C",
+        "$description": "Label color G of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-g.900}"
+        }
+      },
+      "base": {
+        "$value": "#36A17D",
+        "$description": "Base color of Label color G.",
+        "actions": {
+          "default": "{color.action.default.label-g.base}"
+        }
+      }
+    },
+    "label-h": {
+      "100": {
+        "$value": "#F3E6F9",
+        "$description": "Label color H of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-h.100}"
+        }
+      },
+      "200": {
+        "$value": "#E3C5F1",
+        "$description": "Label color H of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-h.200}"
+        }
+      },
+      "300": {
+        "$value": "#D2A4E9",
+        "$description": "Label color H of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-h.300}"
+        }
+      },
+      "400": {
+        "$value": "#C07FE1",
+        "$description": "Label color H of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-h.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-h.base}",
+        "$description": "Label color H of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-h.500}"
+        }
+      },
+      "600": {
+        "$value": "#9A31CE",
+        "$description": "Label color H of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-h.600}"
+        }
+      },
+      "700": {
+        "$value": "#7B27A5",
+        "$description": "Label color H of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-h.700}"
+        }
+      },
+      "800": {
+        "$value": "#5C1D7C",
+        "$description": "Label color H of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-h.800}"
+        }
+      },
+      "900": {
+        "$value": "#3D1452",
+        "$description": "Label color H of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-h.900}"
+        }
+      },
+      "base": {
+        "$value": "#AE5AD8",
+        "$description": "Base color of Label color H.",
+        "actions": {
+          "default": "{color.action.default.label-h.base}"
+        }
+      }
+    },
+    "label-i": {
+      "100": {
+        "$value": "#ECF8EC",
+        "$description": "Label color I of level 100.",
+        "actions": {
+          "default": "{color.action.default.label-i.100}"
+        }
+      },
+      "200": {
+        "$value": "#C0E8C0",
+        "$description": "Label color I of level 200.",
+        "actions": {
+          "default": "{color.action.default.label-i.200}"
+        }
+      },
+      "300": {
+        "$value": "#80D080",
+        "$description": "Label color I of level 300.",
+        "actions": {
+          "default": "{color.action.default.label-i.300}"
+        }
+      },
+      "400": {
+        "$value": "#50BE50",
+        "$description": "Label color I of level 400.",
+        "actions": {
+          "default": "{color.action.default.label-i.400}"
+        }
+      },
+      "500": {
+        "$value": "{color.label-i.base}",
+        "$description": "Label color I of level 500.",
+        "actions": {
+          "default": "{color.action.default.label-i.500}"
+        }
+      },
+      "600": {
+        "$value": "#328632",
+        "$description": "Label color I of level 600.",
+        "actions": {
+          "default": "{color.action.default.label-i.600}"
+        }
+      },
+      "700": {
+        "$value": "#2B732B",
+        "$description": "Label color I of level 700.",
+        "actions": {
+          "default": "{color.action.default.label-i.700}"
+        }
+      },
+      "800": {
+        "$value": "#246124",
+        "$description": "Label color I of level 800.",
+        "actions": {
+          "default": "{color.action.default.label-i.800}"
+        }
+      },
+      "900": {
+        "$value": "#1C4A1C",
+        "$description": "Label color I of level 900.",
+        "actions": {
+          "default": "{color.action.default.label-i.900}"
+        }
+      },
+      "base": {
+        "$value": "#3BA03B",
+        "$description": "Base color of Label color I.",
+        "actions": {
+          "default": "{color.action.default.label-i.base}"
+        }
+      }
+    },
     "action": {
       "default": {
         "gray": {
@@ -2358,6 +3006,924 @@
             "$value": "{color.dark.base}"
           }
         },
+        "label-a": {
+          "100": {
+            "source": "$action-default-label-a-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.100}"
+          },
+          "200": {
+            "source": "$action-default-label-a-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.200}"
+          },
+          "300": {
+            "source": "$action-default-label-a-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.300}"
+          },
+          "400": {
+            "source": "$action-default-label-a-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.400}"
+          },
+          "500": {
+            "source": "$action-default-label-a-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.500}"
+          },
+          "600": {
+            "source": "$action-default-label-a-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.600}"
+          },
+          "700": {
+            "source": "$action-default-label-a-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.700}"
+          },
+          "800": {
+            "source": "$action-default-label-a-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.800}"
+          },
+          "900": {
+            "source": "$action-default-label-a-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.900}"
+          },
+          "base": {
+            "source": "$action-default-label-a-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-a.base}"
+          }
+        },
+        "label-b": {
+          "100": {
+            "source": "$action-default-label-b-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.100}"
+          },
+          "200": {
+            "source": "$action-default-label-b-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.200}"
+          },
+          "300": {
+            "source": "$action-default-label-b-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.300}"
+          },
+          "400": {
+            "source": "$action-default-label-b-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.400}"
+          },
+          "500": {
+            "source": "$action-default-label-b-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.500}"
+          },
+          "600": {
+            "source": "$action-default-label-b-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.600}"
+          },
+          "700": {
+            "source": "$action-default-label-b-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.700}"
+          },
+          "800": {
+            "source": "$action-default-label-b-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.800}"
+          },
+          "900": {
+            "source": "$action-default-label-b-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.900}"
+          },
+          "base": {
+            "source": "$action-default-label-b-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-b.base}"
+          }
+        },
+        "label-c": {
+          "100": {
+            "source": "$action-default-label-c-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.100}"
+          },
+          "200": {
+            "source": "$action-default-label-c-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.200}"
+          },
+          "300": {
+            "source": "$action-default-label-c-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.300}"
+          },
+          "400": {
+            "source": "$action-default-label-c-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.400}"
+          },
+          "500": {
+            "source": "$action-default-label-c-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.500}"
+          },
+          "600": {
+            "source": "$action-default-label-c-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.600}"
+          },
+          "700": {
+            "source": "$action-default-label-c-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.700}"
+          },
+          "800": {
+            "source": "$action-default-label-c-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.800}"
+          },
+          "900": {
+            "source": "$action-default-label-c-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.900}"
+          },
+          "base": {
+            "source": "$action-default-label-c-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-c.base}"
+          }
+        },
+        "label-d": {
+          "100": {
+            "source": "$action-default-label-d-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.100}"
+          },
+          "200": {
+            "source": "$action-default-label-d-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.200}"
+          },
+          "300": {
+            "source": "$action-default-label-d-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.300}"
+          },
+          "400": {
+            "source": "$action-default-label-d-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.400}"
+          },
+          "500": {
+            "source": "$action-default-label-d-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.500}"
+          },
+          "600": {
+            "source": "$action-default-label-d-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.600}"
+          },
+          "700": {
+            "source": "$action-default-label-d-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.700}"
+          },
+          "800": {
+            "source": "$action-default-label-d-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.800}"
+          },
+          "900": {
+            "source": "$action-default-label-d-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.900}"
+          },
+          "base": {
+            "source": "$action-default-label-d-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-d.base}"
+          }
+        },
+        "label-e": {
+          "100": {
+            "source": "$action-default-label-e-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.100}"
+          },
+          "200": {
+            "source": "$action-default-label-e-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.200}"
+          },
+          "300": {
+            "source": "$action-default-label-e-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.300}"
+          },
+          "400": {
+            "source": "$action-default-label-e-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.400}"
+          },
+          "500": {
+            "source": "$action-default-label-e-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.500}"
+          },
+          "600": {
+            "source": "$action-default-label-e-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.600}"
+          },
+          "700": {
+            "source": "$action-default-label-e-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.700}"
+          },
+          "800": {
+            "source": "$action-default-label-e-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.800}"
+          },
+          "900": {
+            "source": "$action-default-label-e-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.900}"
+          },
+          "base": {
+            "source": "$action-default-label-e-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-e.base}"
+          }
+        },
+        "label-f": {
+          "100": {
+            "source": "$action-default-label-f-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.100}"
+          },
+          "200": {
+            "source": "$action-default-label-f-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.200}"
+          },
+          "300": {
+            "source": "$action-default-label-f-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.300}"
+          },
+          "400": {
+            "source": "$action-default-label-f-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.400}"
+          },
+          "500": {
+            "source": "$action-default-label-f-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.500}"
+          },
+          "600": {
+            "source": "$action-default-label-f-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.600}"
+          },
+          "700": {
+            "source": "$action-default-label-f-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.700}"
+          },
+          "800": {
+            "source": "$action-default-label-f-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.800}"
+          },
+          "900": {
+            "source": "$action-default-label-f-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.900}"
+          },
+          "base": {
+            "source": "$action-default-label-f-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-f.base}"
+          }
+        },
+        "label-g": {
+          "100": {
+            "source": "$action-default-label-g-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.100}"
+          },
+          "200": {
+            "source": "$action-default-label-g-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.200}"
+          },
+          "300": {
+            "source": "$action-default-label-g-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.300}"
+          },
+          "400": {
+            "source": "$action-default-label-g-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.400}"
+          },
+          "500": {
+            "source": "$action-default-label-g-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.500}"
+          },
+          "600": {
+            "source": "$action-default-label-g-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.600}"
+          },
+          "700": {
+            "source": "$action-default-label-g-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.700}"
+          },
+          "800": {
+            "source": "$action-default-label-g-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.800}"
+          },
+          "900": {
+            "source": "$action-default-label-g-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.900}"
+          },
+          "base": {
+            "source": "$action-default-label-g-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-g.base}"
+          }
+        },
+        "label-h": {
+          "100": {
+            "source": "$action-default-label-h-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.100}"
+          },
+          "200": {
+            "source": "$action-default-label-h-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.200}"
+          },
+          "300": {
+            "source": "$action-default-label-h-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.300}"
+          },
+          "400": {
+            "source": "$action-default-label-h-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.400}"
+          },
+          "500": {
+            "source": "$action-default-label-h-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.500}"
+          },
+          "600": {
+            "source": "$action-default-label-h-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.600}"
+          },
+          "700": {
+            "source": "$action-default-label-h-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.700}"
+          },
+          "800": {
+            "source": "$action-default-label-h-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.800}"
+          },
+          "900": {
+            "source": "$action-default-label-h-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.900}"
+          },
+          "base": {
+            "source": "$action-default-label-h-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-h.base}"
+          }
+        },
+        "label-i": {
+          "100": {
+            "source": "$action-default-label-i-100",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.100}"
+          },
+          "200": {
+            "source": "$action-default-label-i-200",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.200}"
+          },
+          "300": {
+            "source": "$action-default-label-i-300",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.300}"
+          },
+          "400": {
+            "source": "$action-default-label-i-400",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.400}"
+          },
+          "500": {
+            "source": "$action-default-label-i-500",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.500}"
+          },
+          "600": {
+            "source": "$action-default-label-i-600",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.600}"
+          },
+          "700": {
+            "source": "$action-default-label-i-700",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.700}"
+          },
+          "800": {
+            "source": "$action-default-label-i-800",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.800}"
+          },
+          "900": {
+            "source": "$action-default-label-i-900",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.900}"
+          },
+          "base": {
+            "source": "$action-default-label-i-base",
+            "modify": [
+              {
+                "type": "darken",
+                "amount": "0.1"
+              }
+            ],
+            "$value": "{color.label-i.base}"
+          }
+        },
         "accent": {
           "a": {
             "source": "$action-default-accent-a",
@@ -2381,386 +3947,6 @@
           }
         }
       }
-    }
-    "label": {
-      "a": {
-        "100": {
-          "$value": "#F9E6E6",
-          "$description": "Label color A of level 100."
-        },
-        "200": {
-          "$value": "#EFBDBD",
-          "$description": "Label color A of level 200."
-        },
-        "300": {
-          "$value": "#E69898",
-          "$description": "Label color A of level 300."
-        },
-        "400": {
-          "$value": "#DA6363",
-          "$description": "Label color A of level 400."
-        },
-        "500": {
-          "$value": "{color.label.a.base}",
-          "$description": "Label color A of level 500."
-        },
-        "600": {
-          "$value": "#B92C2C",
-          "$description": "Label color A of level 600."
-        },
-        "700": {
-          "$value": "#942323",
-          "$description": "Label color A of level 700."
-        },
-        "800": {
-          "$value": "#731C1C",
-          "$description": "Label color A of level 800."
-        },
-        "900": {
-          "$value": "#521414",
-          "$description": "Label color A of level 900."
-        },
-        "base": {
-          "$value": "#D24242",
-          "$description": "Base color of Label color A."
-        }
-      },  
-      "b": {
-        "100": {
-          "$value": "#F6F9F1",
-          "$description": "Label color B of level 100."
-        },
-        "200": {
-          "$value": "#D9E4C4",
-          "$description": "Label color B of level 200."
-        },
-        "300": {
-          "$value": "#B3C888",
-          "$description": "Label color B of level 300."
-        },
-        "400": {
-          "$value": "#96B35B",
-          "$description": "Label color B of level 400."
-        },
-        "500": {
-          "$value": "{color.label.b.base}",
-          "$description": "Label color B of level 500."
-        },
-        "600": {
-          "$value": "#677E3A",
-          "$description": "Label color B of level 600."
-        },
-        "700": {
-          "$value": "#5C7033",
-          "$description": "Label color B of level 700."
-        },
-        "800": {
-          "$value": "#4A5B2A",
-          "$description": "Label color B of level 800."
-        },
-        "900": {
-          "$value": "#394620",
-          "$description": "Label color B of level 900."
-        },
-        "base": {
-          "$value": "#7B9645",
-          "$description": "Base color of Label color B."
-        }
-      },  
-      "c": {
-        "100": {
-          "$value": "#E6E6F9",
-          "$description": "Label color C of level 100."
-        },
-        "200": {
-          "$value": "#C5C5F1",
-          "$description": "Label color C of level 200."
-        },
-        "300": {
-          "$value": "#A4A4E9",
-          "$description": "Label color C of level 300."
-        },
-        "400": {
-          "$value": "#7F7FE1",
-          "$description": "Label color C of level 400."
-        },
-        "500": {
-          "$value": "{color.label.c.base}",
-          "$description": "Label color C of level 500."
-        },
-        "600": {
-          "$value": "#3131CE",
-          "$description": "Label color C of level 600."
-        },
-        "700": {
-          "$value": "#2727A5",
-          "$description": "Label color C of level 700."
-        },
-        "800": {
-          "$value": "#1D1D7C",
-          "$description": "Label color C of level 800."
-        },
-        "900": {
-          "$value": "#141452",
-          "$description": "Label color C of level 900."
-        },
-        "base": {
-          "$value": "#5A5AD8",
-          "$description": "Base color of Label color C."
-        }
-      }, 
-      "d": {
-        "100": {
-          "$value": "#FAF5EB",
-          "$description": "Label color D of level 100."
-        },
-        "200": {
-          "$value": "#EEDCBA",
-          "$description": "Label color D of level 200."
-        },
-        "300": {
-          "$value": "#DDBA74",
-          "$description": "Label color D of level 300."
-        },
-        "400": {
-          "$value": "#CF9F3F",
-          "$description": "Label color D of level 400."
-        },
-        "500": {
-          "$value": "{color.label.d.base}",
-          "$description": "Label color D of level 500."
-        },
-        "600": {
-          "$value": "#936E25",
-          "$description": "Label color D of level 600."
-        },
-        "700": {
-          "$value": "#7F5F1F",
-          "$description": "Label color D of level 700."
-        },
-        "800": {
-          "$value": "#6A501A",
-          "$description": "Label color D of level 800."
-        },
-        "900": {
-          "$value": "#523D14",
-          "$description": "Label color D of level 900."
-        },
-        "base": {
-          "$value": "#B0842C",
-          "$description": "Base color of Label color D."
-        }
-      },   
-      "e": {
-        "100": {
-          "$value": "#E6F3F9",
-          "$description": "Label color E of level 100."
-        },
-        "200": {
-          "$value": "#B5DBED",
-          "$description": "Label color E of level 200."
-        },
-        "300": {
-          "$value": "#7FC0E1",
-          "$description": "Label color E of level 300."
-        },
-        "400": {
-          "$value": "#52AAD6",
-          "$description": "Label color E of level 400."
-        },
-        "500": {
-          "$value": "{color.label.e.base}",
-          "$description": "Label color E of level 500."
-        },
-        "600": {
-          "$value": "#277BA5",
-          "$description": "Label color E of level 600."
-        },
-        "700": {
-          "$value": "#21688C",
-          "$description": "Label color E of level 700."
-        },
-        "800": {
-          "$value": "#1B536F",
-          "$description": "Label color E of level 800."
-        },
-        "900": {
-          "$value": "#143D52",
-          "$description": "Label color E of level 900."
-        },
-        "base": {
-          "$value": "#2E90C2",
-          "$description": "Base color of Label color E."
-        }
-      }, 
-      "f": {
-        "100": {
-          "$value": "#FAEAF2",
-          "$description": "Label color F of level 100."
-        },
-        "200": {
-          "$value": "#EBADCC",
-          "$description": "Label color F of level 200."
-        },
-        "300": {
-          "$value": "#E283B2",
-          "$description": "Label color F of level 300."
-        },
-        "400": {
-          "$value": "#DA639E",
-          "$description": "Label color F of level 400."
-        },
-        "500": {
-          "$value": "{color.label.f.base}",
-          "$description": "Label color F of level 500."
-        },
-        "600": {
-          "$value": "#B92C73",
-          "$description": "Label color F of level 600."
-        },
-        "700": {
-          "$value": "#94235C",
-          "$description": "Label color F of level 700."
-        },
-        "800": {
-          "$value": "#731C47",
-          "$description": "Label color F of level 800."
-        },
-        "900": {
-          "$value": "#521433",
-          "$description": "Label color F of level 900."
-        },
-        "base": {
-          "$value": "#D13F88",
-          "$description": "Base color of Label color F."
-        }
-      }, 
-      "g": {
-        "100": {
-          "$value": "#F0FAF6",
-          "$description": "Label color G of level 100."
-        },
-        "200": {
-          "$value": "#BEE9DB",
-          "$description": "Label color G of level 200."
-        },
-        "300": {
-          "$value": "#7DD4B7",
-          "$description": "Label color G of level 300."
-        },
-        "400": {
-          "$value": "#4BC39B",
-          "$description": "Label color G of level 400."
-        },
-        "500": {
-          "$value": "{color.label.g.base}",
-          "$description": "Label color G of level 500."
-        },
-        "600": {
-          "$value": "#2B8265",
-          "$description": "Label color G of level 600."
-        },
-        "700": {
-          "$value": "#267359",
-          "$description": "Label color G of level 700."
-        },
-        "800": {
-          "$value": "#20604A",
-          "$description": "Label color G of level 800."
-        },
-        "900": {
-          "$value": "#1A4C3C",
-          "$description": "Label color G of level 900."
-        },
-        "base": {
-          "$value": "#36A17D",
-          "$description": "Base color of Label color G."
-        }
-      }, 
-      "h": {
-        "100": {
-          "$value": "#F3E6F9",
-          "$description": "Label color H of level 100."
-        },
-        "200": {
-          "$value": "#E3C5F1",
-          "$description": "Label color H of level 200."
-        },
-        "300": {
-          "$value": "#D2A4E9",
-          "$description": "Label color H of level 300."
-        },
-        "400": {
-          "$value": "#C07FE1",
-          "$description": "Label color H of level 400."
-        },
-        "500": {
-          "$value": "{color.label.h.base}",
-          "$description": "Label color H of level 500."
-        },
-        "600": {
-          "$value": "#9A31CE",
-          "$description": "Label color H of level 600."
-        },
-        "700": {
-          "$value": "#7B27A5",
-          "$description": "Label color H of level 700."
-        },
-        "800": {
-          "$value": "#5C1D7C",
-          "$description": "Label color H of level 800."
-        },
-        "900": {
-          "$value": "#3D1452",
-          "$description": "Label color H of level 900."
-        },
-        "base": {
-          "$value": "#AE5AD8",
-          "$description": "Base color of Label color H."
-        }
-      }, 
-      "i": {
-        "100": {
-          "$value": "#ECF8EC",
-          "$description": "Label color I of level 100."
-        },
-        "200": {
-          "$value": "#C0E8C0",
-          "$description": "Label color I of level 200."
-        },
-        "300": {
-          "$value": "#80D080",
-          "$description": "Label color I of level 300."
-        },
-        "400": {
-          "$value": "#50BE50",
-          "$description": "Label color I of level 400."
-        },
-        "500": {
-          "$value": "{color.label.i.base}",
-          "$description": "Label color I of level 500."
-        },
-        "600": {
-          "$value": "#328632",
-          "$description": "Label color I of level 600."
-        },
-        "700": {
-          "$value": "#2B732B",
-          "$description": "Label color I of level 700."
-        },
-        "800": {
-          "$value": "#246124",
-          "$description": "Label color I of level 800."
-        },
-        "900": {
-          "$value": "#1C4A1C",
-          "$description": "Label color I of level 900."
-        },
-        "base": {
-          "$value": "#3BA03B",
-          "$description": "Base color of Label color I."
-        }
-      } 
     }
   }
 }

--- a/tokens/src/themes/light/global/color.json
+++ b/tokens/src/themes/light/global/color.json
@@ -2382,5 +2382,385 @@
         }
       }
     }
+    "label": {
+      "a": {
+        "100": {
+          "$value": "#F9E6E6",
+          "$description": "Label color A of level 100."
+        },
+        "200": {
+          "$value": "#EFBDBD",
+          "$description": "Label color A of level 200."
+        },
+        "300": {
+          "$value": "#E69898",
+          "$description": "Label color A of level 300."
+        },
+        "400": {
+          "$value": "#DA6363",
+          "$description": "Label color A of level 400."
+        },
+        "500": {
+          "$value": "{color.label.a.base}",
+          "$description": "Label color A of level 500."
+        },
+        "600": {
+          "$value": "#B92C2C",
+          "$description": "Label color A of level 600."
+        },
+        "700": {
+          "$value": "#942323",
+          "$description": "Label color A of level 700."
+        },
+        "800": {
+          "$value": "#731C1C",
+          "$description": "Label color A of level 800."
+        },
+        "900": {
+          "$value": "#521414",
+          "$description": "Label color A of level 900."
+        },
+        "base": {
+          "$value": "#D24242",
+          "$description": "Base color of Label color A."
+        }
+      },  
+      "b": {
+        "100": {
+          "$value": "#F6F9F1",
+          "$description": "Label color B of level 100."
+        },
+        "200": {
+          "$value": "#D9E4C4",
+          "$description": "Label color B of level 200."
+        },
+        "300": {
+          "$value": "#B3C888",
+          "$description": "Label color B of level 300."
+        },
+        "400": {
+          "$value": "#96B35B",
+          "$description": "Label color B of level 400."
+        },
+        "500": {
+          "$value": "{color.label.b.base}",
+          "$description": "Label color B of level 500."
+        },
+        "600": {
+          "$value": "#677E3A",
+          "$description": "Label color B of level 600."
+        },
+        "700": {
+          "$value": "#5C7033",
+          "$description": "Label color B of level 700."
+        },
+        "800": {
+          "$value": "#4A5B2A",
+          "$description": "Label color B of level 800."
+        },
+        "900": {
+          "$value": "#394620",
+          "$description": "Label color B of level 900."
+        },
+        "base": {
+          "$value": "#7B9645",
+          "$description": "Base color of Label color B."
+        }
+      },  
+      "c": {
+        "100": {
+          "$value": "#E6E6F9",
+          "$description": "Label color C of level 100."
+        },
+        "200": {
+          "$value": "#C5C5F1",
+          "$description": "Label color C of level 200."
+        },
+        "300": {
+          "$value": "#A4A4E9",
+          "$description": "Label color C of level 300."
+        },
+        "400": {
+          "$value": "#7F7FE1",
+          "$description": "Label color C of level 400."
+        },
+        "500": {
+          "$value": "{color.label.c.base}",
+          "$description": "Label color C of level 500."
+        },
+        "600": {
+          "$value": "#3131CE",
+          "$description": "Label color C of level 600."
+        },
+        "700": {
+          "$value": "#2727A5",
+          "$description": "Label color C of level 700."
+        },
+        "800": {
+          "$value": "#1D1D7C",
+          "$description": "Label color C of level 800."
+        },
+        "900": {
+          "$value": "#141452",
+          "$description": "Label color C of level 900."
+        },
+        "base": {
+          "$value": "#5A5AD8",
+          "$description": "Base color of Label color C."
+        }
+      }, 
+      "d": {
+        "100": {
+          "$value": "#FAF5EB",
+          "$description": "Label color D of level 100."
+        },
+        "200": {
+          "$value": "#EEDCBA",
+          "$description": "Label color D of level 200."
+        },
+        "300": {
+          "$value": "#DDBA74",
+          "$description": "Label color D of level 300."
+        },
+        "400": {
+          "$value": "#CF9F3F",
+          "$description": "Label color D of level 400."
+        },
+        "500": {
+          "$value": "{color.label.d.base}",
+          "$description": "Label color D of level 500."
+        },
+        "600": {
+          "$value": "#936E25",
+          "$description": "Label color D of level 600."
+        },
+        "700": {
+          "$value": "#7F5F1F",
+          "$description": "Label color D of level 700."
+        },
+        "800": {
+          "$value": "#6A501A",
+          "$description": "Label color D of level 800."
+        },
+        "900": {
+          "$value": "#523D14",
+          "$description": "Label color D of level 900."
+        },
+        "base": {
+          "$value": "#B0842C",
+          "$description": "Base color of Label color D."
+        }
+      },   
+      "e": {
+        "100": {
+          "$value": "#E6F3F9",
+          "$description": "Label color E of level 100."
+        },
+        "200": {
+          "$value": "#B5DBED",
+          "$description": "Label color E of level 200."
+        },
+        "300": {
+          "$value": "#7FC0E1",
+          "$description": "Label color E of level 300."
+        },
+        "400": {
+          "$value": "#52AAD6",
+          "$description": "Label color E of level 400."
+        },
+        "500": {
+          "$value": "{color.label.e.base}",
+          "$description": "Label color E of level 500."
+        },
+        "600": {
+          "$value": "#277BA5",
+          "$description": "Label color E of level 600."
+        },
+        "700": {
+          "$value": "#21688C",
+          "$description": "Label color E of level 700."
+        },
+        "800": {
+          "$value": "#1B536F",
+          "$description": "Label color E of level 800."
+        },
+        "900": {
+          "$value": "#143D52",
+          "$description": "Label color E of level 900."
+        },
+        "base": {
+          "$value": "#2E90C2",
+          "$description": "Base color of Label color E."
+        }
+      }, 
+      "f": {
+        "100": {
+          "$value": "#FAEAF2",
+          "$description": "Label color F of level 100."
+        },
+        "200": {
+          "$value": "#EBADCC",
+          "$description": "Label color F of level 200."
+        },
+        "300": {
+          "$value": "#E283B2",
+          "$description": "Label color F of level 300."
+        },
+        "400": {
+          "$value": "#DA639E",
+          "$description": "Label color F of level 400."
+        },
+        "500": {
+          "$value": "{color.label.f.base}",
+          "$description": "Label color F of level 500."
+        },
+        "600": {
+          "$value": "#B92C73",
+          "$description": "Label color F of level 600."
+        },
+        "700": {
+          "$value": "#94235C",
+          "$description": "Label color F of level 700."
+        },
+        "800": {
+          "$value": "#731C47",
+          "$description": "Label color F of level 800."
+        },
+        "900": {
+          "$value": "#521433",
+          "$description": "Label color F of level 900."
+        },
+        "base": {
+          "$value": "#D13F88",
+          "$description": "Base color of Label color F."
+        }
+      }, 
+      "g": {
+        "100": {
+          "$value": "#F0FAF6",
+          "$description": "Label color G of level 100."
+        },
+        "200": {
+          "$value": "#BEE9DB",
+          "$description": "Label color G of level 200."
+        },
+        "300": {
+          "$value": "#7DD4B7",
+          "$description": "Label color G of level 300."
+        },
+        "400": {
+          "$value": "#4BC39B",
+          "$description": "Label color G of level 400."
+        },
+        "500": {
+          "$value": "{color.label.g.base}",
+          "$description": "Label color G of level 500."
+        },
+        "600": {
+          "$value": "#2B8265",
+          "$description": "Label color G of level 600."
+        },
+        "700": {
+          "$value": "#267359",
+          "$description": "Label color G of level 700."
+        },
+        "800": {
+          "$value": "#20604A",
+          "$description": "Label color G of level 800."
+        },
+        "900": {
+          "$value": "#1A4C3C",
+          "$description": "Label color G of level 900."
+        },
+        "base": {
+          "$value": "#36A17D",
+          "$description": "Base color of Label color G."
+        }
+      }, 
+      "h": {
+        "100": {
+          "$value": "#F3E6F9",
+          "$description": "Label color H of level 100."
+        },
+        "200": {
+          "$value": "#E3C5F1",
+          "$description": "Label color H of level 200."
+        },
+        "300": {
+          "$value": "#D2A4E9",
+          "$description": "Label color H of level 300."
+        },
+        "400": {
+          "$value": "#C07FE1",
+          "$description": "Label color H of level 400."
+        },
+        "500": {
+          "$value": "{color.label.h.base}",
+          "$description": "Label color H of level 500."
+        },
+        "600": {
+          "$value": "#9A31CE",
+          "$description": "Label color H of level 600."
+        },
+        "700": {
+          "$value": "#7B27A5",
+          "$description": "Label color H of level 700."
+        },
+        "800": {
+          "$value": "#5C1D7C",
+          "$description": "Label color H of level 800."
+        },
+        "900": {
+          "$value": "#3D1452",
+          "$description": "Label color H of level 900."
+        },
+        "base": {
+          "$value": "#AE5AD8",
+          "$description": "Base color of Label color H."
+        }
+      }, 
+      "i": {
+        "100": {
+          "$value": "#ECF8EC",
+          "$description": "Label color I of level 100."
+        },
+        "200": {
+          "$value": "#C0E8C0",
+          "$description": "Label color I of level 200."
+        },
+        "300": {
+          "$value": "#80D080",
+          "$description": "Label color I of level 300."
+        },
+        "400": {
+          "$value": "#50BE50",
+          "$description": "Label color I of level 400."
+        },
+        "500": {
+          "$value": "{color.label.i.base}",
+          "$description": "Label color I of level 500."
+        },
+        "600": {
+          "$value": "#328632",
+          "$description": "Label color I of level 600."
+        },
+        "700": {
+          "$value": "#2B732B",
+          "$description": "Label color I of level 700."
+        },
+        "800": {
+          "$value": "#246124",
+          "$description": "Label color I of level 800."
+        },
+        "900": {
+          "$value": "#1C4A1C",
+          "$description": "Label color I of level 900."
+        },
+        "base": {
+          "$value": "#3BA03B",
+          "$description": "Base color of Label color I."
+        }
+      } 
+    }
   }
 }

--- a/www/src/components/PropType.tsx
+++ b/www/src/components/PropType.tsx
@@ -37,7 +37,9 @@ function PropType({
         raw={raw}
       />
     );
-  } else if (name) {
+  }
+
+  if (name) {
     // For TypeScript types, we simply display the type as a string.
     return (
       <span>
@@ -45,9 +47,9 @@ function PropType({
         <RequiredBadge isRequired={required} />
       </span>
     );
-  } else {
-    return <>unknown type</>;
   }
+
+  return <>unknown type</>;
 }
 
 export interface ISimplePropType {

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -39,7 +39,7 @@ export interface IColorsWithVariants extends IColorsBase {
 
 export type IColors = IColorsWithUnusedLevels | IColorsWithVariants;
 
-const colors: IColors[] = [
+const semanticColors: IColors[] = [
   { themeName: 'gray' },
   { themeName: 'primary' },
   { themeName: 'brand' },
@@ -49,6 +49,21 @@ const colors: IColors[] = [
   { themeName: 'info' },
   { themeName: 'danger' },
   { themeName: 'warning' },
+];
+
+const labelColors: IColors[] = [
+  { themeName: 'label-a' },
+  { themeName: 'label-b' },
+  { themeName: 'label-c' },
+  { themeName: 'label-d' },
+  { themeName: 'label-e' },
+  { themeName: 'label-f' },
+  { themeName: 'label-g' },
+  { themeName: 'label-h' },
+  { themeName: 'label-i' },
+];
+
+const otherColors: IColors[] = [
   {
     themeName: 'accent',
     variants: [
@@ -56,6 +71,12 @@ const colors: IColors[] = [
       { name: 'b', hasLevels: false },
     ],
   },
+];
+
+const colors: IColors[] = [
+  ...semanticColors,
+  ...labelColors,
+  ...otherColors,
 ];
 
 const levels = [100, 200, 300, 400, 500, 600, 700, 800, 900];
@@ -219,8 +240,20 @@ export default function ColorsPage({ data, pageContext }: IColorsPage) {
       <SEO title="Colors" />
       <Container size={settings.containerWidth} className="py-5">
         <h1>Colors</h1>
+
+        <h3>Semantic Colors</h3>
         <div className="color-palette mb-3">
-          {colors.map((colorArgs) => renderColorRamp({ ...colorArgs, styles }))}
+          {semanticColors.map((colorArgs) => renderColorRamp({ ...colorArgs, styles }))}
+        </div>
+
+        <h3>Label Colors</h3>
+        <div className="color-palette mb-3">
+          {labelColors.map((colorArgs) => renderColorRamp({ ...colorArgs, styles }))}
+        </div>
+
+        <h3>Other Colors</h3>
+        <div className="color-palette mb-3">
+          {otherColors.map((colorArgs) => renderColorRamp({ ...colorArgs, styles }))}
         </div>
 
         <h3>CSS Color Usage</h3>
@@ -381,7 +414,7 @@ export default function ColorsPage({ data, pageContext }: IColorsPage) {
             </div>
           </div>
           {colors.map(({ themeName }) => {
-            if (themeName === 'warning') { return null; }
+            if (themeName === 'warning' || themeName === 'accent') { return null; }
             return (
               <div key={themeName} className="d-flex rounded overflow-hidden mb-3">
                 <div


### PR DESCRIPTION
> [!NOTE]
> ### This will stay in draft until a final decision on what colors to add is made.

## Description

This is a continuation of https://github.com/openedx/paragon/pull/3703

@PKulkoRaccoonGang I've requested your review on this because I'm wondering if you have any ideas on how to do this with a bit less copy/pasting. I was also originally hoping to be able to add the label colors using nesting, so instead of
```json
    "label-a": {
      "100": {
        "$value": "#F9E6E6",
        "$description": "Label color A of level 100.",
        [...]
```
we could have
```json
    "label": {
      "a": {
        "100": {
          "$value": "#F9E6E6",
          "$description": "Label color A of level 100.",
          [...]
```
but I ran into issues with some colors using item for level and others using sub-item, so any thoughts on how possible that'd be would be great!

@kblemel for some reason it's not letting me request a review from you so I'm just tagging you here in the description.

### Deploy Preview

https://deploy-preview-3706--paragon-openedx-v23.netlify.app/foundations/colors/