### PR TITLE
fix: Provided missing className for DataTableLayout

### DIFF
--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -52,7 +52,7 @@ function DataTable({
   filtersTitle,
   dataViewToggleOptions,
   disableElevation,
-  dataTableLayoutClassName,
+  className,
   isLoading,
   children,
   onSelectedRowsChanged,
@@ -225,7 +225,7 @@ function DataTable({
 
   return (
     <DataTableContext.Provider value={enhancedInstance}>
-      <DataTableLayout filtersTitle={filtersTitle} className={dataTableLayoutClassName}>
+      <DataTableLayout filtersTitle={filtersTitle} className={className}>
         <div className={classNames('pgn__data-table-wrapper', {
           'hide-shadow': !!disableElevation,
         })}
@@ -276,7 +276,7 @@ DataTable.defaultProps = {
   },
   disableElevation: false,
   renderRowSubComponent: undefined,
-  dataTableLayoutClassName: undefined,
+  className: undefined,
   isExpandable: false,
   isLoading: false,
   onSelectedRowsChanged: undefined,
@@ -431,7 +431,7 @@ DataTable.propTypes = {
   /** If true filters will be shown on sidebar instead */
   showFiltersInSidebar: PropTypes.bool,
   /** Class name for the data table layout */
-  dataTableLayoutClassName: PropTypes.string,
+  className: PropTypes.string,
   /** Title of the filters section */
   filtersTitle: PropTypes.string,
   /** options for data view toggle */

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -51,6 +51,7 @@ function DataTable({
   showFiltersInSidebar,
   dataViewToggleOptions,
   disableElevation,
+  dataTableLayoutClassName,
   isLoading,
   children,
   onSelectedRowsChanged,
@@ -222,7 +223,7 @@ function DataTable({
 
   return (
     <DataTableContext.Provider value={enhancedInstance}>
-      <DataTableLayout>
+      <DataTableLayout className={dataTableLayoutClassName}>
         <div className={classNames('pgn__data-table-wrapper', {
           'hide-shadow': !!disableElevation,
         })}
@@ -272,6 +273,7 @@ DataTable.defaultProps = {
   },
   disableElevation: false,
   renderRowSubComponent: undefined,
+  dataTableLayoutClassName: undefined,
   isExpandable: false,
   isLoading: false,
   onSelectedRowsChanged: undefined,
@@ -425,6 +427,8 @@ DataTable.propTypes = {
   children: PropTypes.node,
   /** If true filters will be shown on sidebar instead */
   showFiltersInSidebar: PropTypes.bool,
+  /** Class name for the data table layout */
+  dataTableLayoutClassName: PropTypes.string,
   /** options for data view toggle */
   dataViewToggleOptions: PropTypes.shape({
     /** Whether to show a toggle button group which allows view switching between card and table views */


### PR DESCRIPTION
## Description

Currently, component [DataTableLayout](https://github.com/openedx/paragon/blob/release-22.x/src/DataTable/DataTableLayout.jsx#L10) has prop `className` but it is not passed to this component. In this PR, the ability to pass the required CSS `className` through the `DataTable` component has been added.

Issue: https://github.com/openedx/paragon/issues/3716

### Deploy Preview

https://deploy-preview-3715--paragon-openedx-v22.netlify.app/components/datatable/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
