### PR TITLE
fix: onBack functionality fix

### DIFF
--- a/src/ProductTour/ProductTour.test.jsx
+++ b/src/ProductTour/ProductTour.test.jsx
@@ -19,6 +19,8 @@ describe('<ProductTour />', () => {
       <div id="target-4">...</div>
     </>
   );
+  const handleAdvance = jest.fn();
+  const handleBack = jest.fn();
   const handleDismiss = jest.fn();
   const handleEnd = jest.fn();
   const handleEscape = jest.fn();
@@ -31,6 +33,8 @@ describe('<ProductTour />', () => {
     advanceButtonText: 'Next',
     enabled: false,
     endButtonText: 'Okay',
+    onAdvance: handleAdvance,
+    onBack: handleBack,
     onDismiss: handleDismiss,
     onEnd: handleEnd,
     tourId: 'disabledTour',
@@ -48,6 +52,8 @@ describe('<ProductTour />', () => {
     backButtonText: 'Back',
     enabled: true,
     endButtonText: 'Okay',
+    onAdvance: handleAdvance,
+    onBack: handleBack,
     onDismiss: handleDismiss,
     onEnd: handleEnd,
     tourId: 'enabledTour',
@@ -60,6 +66,7 @@ describe('<ProductTour />', () => {
       {
         body: 'Checkpoint 2',
         target: '#target-2',
+        onAdvance: customOnAdvance,
       },
       {
         body: 'Checkpoint 3',
@@ -82,6 +89,7 @@ describe('<ProductTour />', () => {
 
   afterEach(() => {
     popperMock.mockReset();
+    jest.resetAllMocks();
   });
 
   // eslint-disable-next-line react/prop-types
@@ -115,6 +123,38 @@ describe('<ProductTour />', () => {
 
         // Verify the second Checkpoint has rendered
         expect(screen.getByText('Checkpoint 2')).toBeInTheDocument();
+        expect(handleAdvance).toHaveBeenCalled();
+
+        await userEvent.click(advanceButton);
+        expect(screen.getByText('Checkpoint 3')).toBeInTheDocument();
+        expect(customOnAdvance).toHaveBeenCalled();
+      });
+
+      it('onClick of back button rewinds to last checkpoint', async () => {
+        render(<ProductTourWrapper tours={[tourData]} />);
+        // Verify the first Checkpoint has rendered
+        expect(screen.getByRole('heading', { name: 'Checkpoint 1' })).toBeInTheDocument();
+
+        // Click the advance button
+        const advanceButton = screen.getByRole('button', { name: 'Next' });
+        await userEvent.click(advanceButton);
+
+        // go forward to the 3rd checkpoint
+        expect(screen.getByText('Checkpoint 2')).toBeInTheDocument();
+        await userEvent.click(advanceButton);
+        expect(screen.getByText('Checkpoint 3')).toBeInTheDocument();
+
+        // First back button should use custom on back function
+        let backButton = screen.getByRole('button', { name: 'Override back' });
+        await userEvent.click(backButton);
+        expect(screen.getByText('Checkpoint 2')).toBeInTheDocument();
+        expect(customOnBack).toHaveBeenCalled();
+
+        // Second back button should use the tour's default back function
+        backButton = screen.getByRole('button', { name: 'Back' });
+        await userEvent.click(backButton);
+        expect(screen.getByText('Checkpoint 1')).toBeInTheDocument();
+        expect(handleBack).toHaveBeenCalled();
       });
 
       it('onClick of dismiss button disables tour', async () => {
@@ -191,7 +231,6 @@ describe('<ProductTour />', () => {
 
         // Verify no Checkpoints have rendered
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-        expect(handleEnd).toHaveBeenCalledTimes(1);
         expect(customOnEnd).not.toHaveBeenCalled();
       });
 
@@ -284,7 +323,6 @@ describe('<ProductTour />', () => {
         expect(screen.getByText('Checkpoint 4')).toBeInTheDocument();
         const endButton = screen.getByRole('button', { name: 'Override end' });
         await user.click(endButton);
-        expect(handleEnd).toBeCalledTimes(1);
         expect(customOnEnd).toHaveBeenCalledTimes(1);
         expect(screen.queryByText('Checkpoint 4')).not.toBeInTheDocument();
       });

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -12,7 +12,8 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     startingIndex,
     onEscape,
     onEnd,
-    onBack,
+    onAdvance: tourOnAdvance,
+    onBack: tourOnBack,
     onDismiss: tourOnDismiss,
     advanceButtonText: tourAdvanceButtonText,
     dismissAltText: tourDismissAltText,
@@ -27,6 +28,7 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     title,
     body,
     onAdvance,
+    onBack,
     onDismiss,
     advanceButtonText,
     dismissAltText,
@@ -85,6 +87,8 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     setIndex(index + 1);
     if (onAdvance) {
       onAdvance();
+    } else if (tourOnAdvance) {
+      tourOnAdvance();
     }
   };
 
@@ -92,6 +96,8 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     setIndex(index - 1);
     if (onBack) {
       onBack();
+    } else if (tourOnBack) {
+      tourOnBack();
     }
   };
 
@@ -100,7 +106,7 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
     setIsTourEnabled(false);
     if (onDismiss) {
       onDismiss();
-    } else {
+    } else if (tourOnDismiss) {
       tourOnDismiss();
     }
     setCurrentCheckpointData(null);


### PR DESCRIPTION
## Description

With the ProductTour, we provide the availability to override the onAdvance, onBack, and onDismiss functionality for every checkpoint. This is a quick fix (and associated test) for the onBack override functionality.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
