### PR TITLE
docs: updated link to new React docs in ModalPopup

### DIFF
--- a/src/Modal/modal-popup.mdx
+++ b/src/Modal/modal-popup.mdx
@@ -16,7 +16,7 @@ notes: |
 A generic component for creating accessible modal popup objects.
 
 Note that `ModalPopup` expects DOM node, not ref, in order to be able to update when the node changes.
-A proper way to implement this is to use [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) with `useState` hook as in the example below.
+A proper way to implement this is to use [callback refs](https://react.dev/reference/react-dom/components/common#ref-callback) with `useState` hook as in the example below.
 
 ## Basic Usage
 


### PR DESCRIPTION
## Description

The [old React documentation](https://legacy.reactjs.org/docs/refs-and-the-dom.html#callback-refs) is currently deprecated, so it makes sense to change the link to the [new official React documentation](https://react.dev/learn).

A search was conducted for all obsolete links, except for the ModalPopup component, the documentation site no longer links to the React documentation.

Issue: https://github.com/openedx/paragon/issues/2935

### Deploy Preview

https://deploy-preview-3728--paragon-openedx-v22.netlify.app/components/modal/modal-popup/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
