### PR TITLE
chore: provided className for Sheet component

### DIFF
--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -45,6 +45,12 @@ describe('<Sheet />', () => {
         renderJSON(<Sheet position={POSITIONS.right} variant={VARIANTS.dark} />),
       ).toMatchSnapshot();
     });
+
+    test('className snapshot', () => {
+      expect(
+        renderJSON(<Sheet className="custom-classname" />),
+      ).toMatchSnapshot();
+    });
   });
   describe('correct rendering', () => {
     it('returns empty render if show is false', () => {

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -31,6 +31,37 @@ exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
 </sheet-container>
 `;
 
+exports[`<Sheet /> snapshots className snapshot 1`] = `
+<sheet-container>
+  <div
+    className="pgn__sheet-skrim hidden"
+    role="presentation"
+  />
+  <focus-on
+    onClickOutside={[Function]}
+    onEscapeKey={[Function]}
+    shards={
+      [
+        {
+          "current": null,
+        },
+      ]
+    }
+  >
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className="pgn__sheet-component pgn__sheet__light bottom custom-classname"
+      role="alert"
+    >
+      <div
+        className="pgn__sheet-content"
+      />
+    </div>
+  </focus-on>
+</sheet-container>
+`;
+
 exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
 <sheet-container>
   <div

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -26,13 +26,16 @@ class Sheet extends React.Component {
   }
 
   renderSheet() {
-    const { children, position, variant } = this.props;
+    const {
+      children, position, variant, className,
+    } = this.props;
     return (
       <div
         className={classNames(
           'pgn__sheet-component',
           `pgn__sheet__${variant}`,
           position,
+          className,
         )}
         role="alert"
         aria-live="polite"
@@ -93,6 +96,8 @@ Sheet.propTypes = {
   onClose: PropTypes.func,
   /** a string designating which version of the sheet to show (light vs dark) */
   variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark]),
+  /** Specifies class name to append to the base element. */
+  className: PropTypes.string,
 };
 
 Sheet.defaultProps = {
@@ -102,6 +107,7 @@ Sheet.defaultProps = {
   show: true,
   onClose: () => {},
   variant: VARIANTS.light,
+  className: undefined,
 };
 
 export default Sheet;


### PR DESCRIPTION
## Description

This PR allows consumers to pass to Paragon Sheet component custom CSS class name.

**Issue:** https://github.com/openedx/paragon/issues/3023

### Deploy Preview

[Paragon Sheet component](https://deploy-preview-3735--paragon-openedx-v22.netlify.app/components/sheet/)

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
