### PR TITLE
Remove propTypes+defaultProps from <Bubble>, <ModalDialog>, and <ModalLayer>

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,14 +81,6 @@ module.exports = {
         '@typescript-eslint/return-await': 'off',
       },
     },
-    // We can remove the following .tsx default-props override if
-    // https://github.com/openedx/eslint-config/pull/178 merges and we pull in that version.
-    {
-      files: ['**/*.tsx'],
-      rules: {
-        'react/require-default-props': 'off',
-      },
-    },
   ],
   env: {
     jest: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
         "@edx/browserslist-config": "^1.5.0",
-        "@edx/eslint-config": "^4.3.0",
+        "@edx/eslint-config": "^4.4.0",
         "@edx/stylelint-config-edx": "^2.3.0",
         "@edx/typescript-config": "^1.1.0",
         "@formatjs/cli": "^5.0.2",
@@ -6983,7 +6983,9 @@
       "license": "AGPL-3.0"
     },
     "node_modules/@edx/eslint-config": {
-      "version": "4.3.0",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.4.0.tgz",
+      "integrity": "sha512-NoKXNU2F2O5FEnV/DoBIgN8XiiG6FZcIwSBn1GBUgY1tm/+kSpgFMF8UfGK8g5Kk437u5ofpRLx3J+PnEfBf2Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@edx/browserslist-config": "^1.5.0",
-    "@edx/eslint-config": "^4.3.0",
+    "@edx/eslint-config": "^4.4.0",
     "@edx/stylelint-config-edx": "^2.3.0",
     "@edx/typescript-config": "^1.1.0",
     "@formatjs/cli": "^5.0.2",

--- a/src/Bubble/index.tsx
+++ b/src/Bubble/index.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const STYLE_VARIANTS = ['primary', 'success', 'error', 'warning'] as const;
-
-export type BubbleVariant = typeof STYLE_VARIANTS[number];
+export type BubbleVariant = 'primary' | 'success' | 'error' | 'warning';
 
 export interface BubbleProps {
+  /** Specifies contents of the component. */
   children: React.ReactNode;
+  /** The `Bubble` style variant to use. */
   variant?: BubbleVariant;
+  /** Activates disabled variant. */
   disabled?: boolean;
+  /** Optional class name(s) to append to the base element. */
   className?: string;
+  /** Specifies whether to add padding to the `Bubble` or not. */
   expandable?: boolean;
 }
 
-const Bubble = React.forwardRef<HTMLDivElement, BubbleProps>(({
-  variant,
+const Bubble = React.forwardRef(({
+  variant = 'primary',
   className,
-  children,
-  disabled,
-  expandable,
+  children = null,
+  disabled = false,
+  expandable = false,
   ...props
-}, ref) => (
+}: BubbleProps, ref: React.ForwardedRef<HTMLDivElement>) => (
   <div
     ref={ref}
     className={classNames(
@@ -35,27 +37,5 @@ const Bubble = React.forwardRef<HTMLDivElement, BubbleProps>(({
     {children}
   </div>
 ));
-
-Bubble.propTypes = {
-  /** Specifies contents of the component. */
-  // @ts-ignore
-  children: PropTypes.node,
-  /** The `Bubble` style variant to use. */
-  variant: PropTypes.oneOf(STYLE_VARIANTS),
-  /** Activates disabled variant. */
-  disabled: PropTypes.bool,
-  /** A class name to append to the base element. */
-  className: PropTypes.string,
-  /** Specifies whether to add padding to the `Bubble` or not. */
-  expandable: PropTypes.bool,
-};
-
-Bubble.defaultProps = {
-  children: null,
-  variant: 'primary',
-  disabled: false,
-  className: undefined,
-  expandable: false,
-};
 
 export default Bubble;

--- a/src/Modal/ModalDialog.tsx
+++ b/src/Modal/ModalDialog.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useMediaQuery } from 'react-responsive';
 import { useIntl } from 'react-intl';
@@ -52,7 +51,12 @@ interface Props {
   isBlocking?: boolean;
   /** Specifies the z-index of the modal */
   zIndex?: number;
-  /** Specifies whether overflow is visible in the modal */
+  /**
+   * Specifies whether overflow content inside the modal should be visible.
+   * - `true` - content that exceeds the modal boundaries will remain visible outside the modal's main viewport,
+   * rather than being clipped or hidden.
+   * - `false` - any overflow content will be clipped to fit within the modal's dimensions.
+   */
   isOverflowVisible: boolean;
 }
 
@@ -108,70 +112,6 @@ function ModalDialog({
     </ModalLayer>
   );
 }
-
-ModalDialog.propTypes = {
-  /**
-   *  Specifies the content of the dialog
-   */
-  children: PropTypes.node.isRequired,
-  /**
-   * The aria-label of the dialog
-   */
-  title: PropTypes.string.isRequired,
-  /**
-   * A callback to close the modal dialog
-   */
-  onClose: PropTypes.func.isRequired,
-  /**
-   * Is the modal dialog open or closed
-   */
-  isOpen: PropTypes.bool,
-  /**
-   * The close 'x' icon button in the top right of the dialog box
-   */
-  hasCloseButton: PropTypes.bool,
-  /**
-   * Sizes determine the maximum width of the dialog box
-   */
-  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'fullscreen']),
-  /**
-   * The visual style of the dialog box
-   */
-  variant: PropTypes.oneOf(['default', 'warning', 'danger', 'success', 'dark']),
-  /**
-   * The label supplied to the close icon button if one is rendered
-   */
-  closeLabel: PropTypes.string,
-  /**
-   *  Specifies class name to append to the base element
-   */
-  className: PropTypes.string,
-  /**
-   * Determines where a scrollbar should appear if a modal is too large for the
-   * viewport. When false, the ``ModalDialog``. Body receives a scrollbar, when true
-   * the browser window itself receives the scrollbar.
-   */
-  isFullscreenScroll: PropTypes.bool,
-  /**
-   * To show full screen view on mobile screens
-   */
-  isFullscreenOnMobile: PropTypes.bool,
-  /**
-   * Prevent clicking on the backdrop or pressing Esc to close the modal
-   */
-  isBlocking: PropTypes.bool,
-  /**
-   * Specifies the z-index of the modal
-   */
-  zIndex: PropTypes.number,
-  /**
-   * Specifies whether overflow content inside the modal should be visible.
-   * - `true` - content that exceeds the modal boundaries will remain visible outside the modal's main viewport,
-   * rather than being clipped or hidden.
-   * - `false` - any overflow content will be clipped to fit within the modal's dimensions.
-   */
-  isOverflowVisible: PropTypes.bool.isRequired,
-};
 
 ModalDialog.Header = ModalDialogHeader;
 ModalDialog.Title = ModalDialogTitle;

--- a/src/Modal/ModalLayer.tsx
+++ b/src/Modal/ModalLayer.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import { FocusOn } from 'react-focus-on';
 import Portal from './Portal';
 import { ModalContextProvider } from './ModalContext';
@@ -18,18 +17,10 @@ function ModalBackdrop({ onClick }: { onClick?: () => void }) {
   );
 }
 
-ModalBackdrop.propTypes = {
-  onClick: PropTypes.func,
-};
-
 // istanbul ignore next
 function ModalContentContainer({ children = null }: { children?: React.ReactNode }) {
   return <div className="pgn__modal-content-container">{children}</div>;
 }
-
-ModalContentContainer.propTypes = {
-  children: PropTypes.node,
-};
 
 interface Props {
   /** Specifies the contents of the modal */
@@ -93,19 +84,6 @@ function ModalLayer({
     </ModalContextProvider>
   );
 }
-
-ModalLayer.propTypes = {
-  /** Specifies the contents of the modal */
-  children: PropTypes.node.isRequired,
-  /** A callback function for when the modal is dismissed */
-  onClose: PropTypes.func.isRequired,
-  /** Is the modal dialog open or closed */
-  isOpen: PropTypes.bool.isRequired,
-  /** Prevent clicking on the backdrop or pressing Esc to close the modal */
-  isBlocking: PropTypes.bool,
-  /** Specifies the z-index of the modal */
-  zIndex: PropTypes.number,
-};
 
 export { ModalBackdrop, ModalContentContainer };
 export default ModalLayer;


### PR DESCRIPTION
## Description

Some of our components have their `props` types defined as both TypeScript interfaces and `propTypes` runtime checks, with `defaultProps` defaults. Since propTypes and defaultProps are deprecated and they are redundant with TypeScript types, this PR continues my ongoing work to remove the redundant specifications from a few components: `<Bubble>`, `<ModalDialog>`, and `<ModalLayer>`.

This _should_ not have any effect other than eliminating warnings like this from the console:

```
Warning: Bubble: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```

### Deploy Preview

* `<Bubble>`
   - Before: https://paragon-openedx.netlify.app/components/bubble/
   - After: https://deploy-preview-3738--paragon-openedx-v23.netlify.app/components/bubble/
* `<ModalDialog>`
   - Before: https://paragon-openedx.netlify.app/components/modal-dialog/
   - After: https://deploy-preview-3738--paragon-openedx-v23.netlify.app/components/modal-dialog/
* `<ModalLayer>`
   - Before: https://paragon-openedx.netlify.app/components/modal-layer/
   - After: https://deploy-preview-3738--paragon-openedx-v23.netlify.app/components/modal-layer/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
