### PR TITLE
Remove `propTypes` + `defaultProps` from `<Button>`, improve typing

### DIFF
--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -1,14 +1,30 @@
 import React from 'react';
-import PropTypes, { type Requireable } from 'prop-types';
 import classNames from 'classnames';
 import BaseButton, { type ButtonProps as BaseButtonProps } from 'react-bootstrap/Button';
 import BaseButtonGroup, { type ButtonGroupProps as BaseButtonGroupProps } from 'react-bootstrap/ButtonGroup';
-import BaseButtonToolbar, { type ButtonToolbarProps } from 'react-bootstrap/ButtonToolbar';
+import BaseButtonToolbar, { type ButtonToolbarProps as BaseButtonToolbarProps } from 'react-bootstrap/ButtonToolbar';
 import type { ComponentWithAsProp } from '../utils/types/bootstrap';
 
 import Icon from '../Icon';
 
-interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
+type BaseVariant = (
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'brand'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'dark'
+  | 'light'
+  | 'link'
+);
+
+export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
+  /** Set a custom element for this component (default: `button`, with `type="button"`). */
+  as?: React.ElementType;
+  size?: 'sm' | 'md' | 'lg' | 'inline';
   /**
    * An icon component to render. Example:
    * ```
@@ -25,18 +41,32 @@ interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
    * ```
    */
   iconAfter?: React.ComponentType;
-  size?: 'sm' | 'md' | 'lg' | 'inline';
+
+  // The following are the same as in BaseButtonProps, but we re-define them to add documentation.
+  // The upstream type defintions do not have any comments/docs.
+
+  /** Disables the Button, preventing mouse events, even if the underlying component is an `<a>` element */
+  disabled?: boolean;
+  /** Optional: Specify additional class name(s) to apply to the button */
+  className?: string;
+  /** Specifies the text that is displayed within the button. */
+  children: React.ReactNode;
+  /** Specifies variant to use.
+   * Can be one of the base variants: `primary`, `secondary`, `tertiary`, `brand`, `success`, `danger`, `warning`,
+   * `info`, `dark`, `light`, `link`,
+   * as well as one of the customized variants (= base variant prefixed with `inverse-`, `outline-`
+   * or `inverse-outline-`)
+   * */
+  variant?: BaseVariant | `inverse-${BaseVariant}` | `outline-${BaseVariant}` | `inverse-outline-${BaseVariant}`;
 }
 
-type ButtonType = ComponentWithAsProp<'button', ButtonProps> & { Deprecated?: any };
-
-const Button: ButtonType = React.forwardRef<HTMLButtonElement, ButtonProps>(({
+const Button: ComponentWithAsProp<'button', ButtonProps> = React.forwardRef(({
   children,
   iconAfter,
   iconBefore,
   size,
   ...props
-}, ref) => (
+}: ButtonProps, ref: React.ForwardedRef<HTMLDivElement>) => (
   <BaseButton
     size={size as 'sm' | 'lg' | undefined} // Bootstrap's <Button> types do not allow 'md' or 'inline', but we do.
     {...props}
@@ -49,107 +79,46 @@ const Button: ButtonType = React.forwardRef<HTMLButtonElement, ButtonProps>(({
   </BaseButton>
 ));
 
-Button.propTypes = {
-  /** Specifies class name to apply to the button */
-  className: PropTypes.string,
-  /** Disables the Button, preventing mouse events, even if the underlying component is an `<a>` element */
-  disabled: PropTypes.bool,
-  /** Specifies the text that is displayed within the button. */
-  children: PropTypes.node.isRequired,
-  /** A function that would specify what the button should do when the `onClick` event is triggered.
-   * For example, the button could launch a `Modal`. The default is an empty function. */
-  onClick: PropTypes.func,
-  /** A function that would specify what the button should do when the `onKeyDown` event is triggered.
-   * For example, this could handle using the `Escape` key to trigger the button's action.
-   * The default is an empty function. */
-  onKeyDown: PropTypes.func,
-  /** Used to set the `type` attribute on the `button` tag.  The default type is `button`. */
-  type: PropTypes.string,
-  /** Specifies variant to use.
-   * Can be on of the base variants: `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `dark`,
-   * `light`, `link`
-   *
-   * as well as one of the customized variants (= base variant prefixed with `inverse-`, `outline-`
-   * or `inverse-outline-`)
-   * */
-  variant: PropTypes.string,
-  /** An icon component to render.
-  * Example import of a Paragon icon component: `import { Check } from '@openedx/paragon/icons';` */
-  iconBefore: PropTypes.elementType as Requireable<React.ComponentType>,
-  /** An icon component to render.
-  * Example import of a Paragon icon component: `import { Check } from '@openedx/paragon/icons';` */
-  iconAfter: PropTypes.elementType as Requireable<React.ComponentType>,
-  // The 'as' type casting above is required for TypeScript checking, because the 'PropTypes.elementType' type normally
-  // allows strings as a value (for use cases like 'div') but we don't support that for <Icon />/iconBefore/iconAfter.
-  // The React TypeScript type definitions are more specific (React.ComponentType vs React.ElementType).
-};
-
-Button.defaultProps = {
-  ...Button.defaultProps,
-  children: undefined,
-  className: undefined,
-  iconBefore: undefined,
-  iconAfter: undefined,
-  disabled: false,
-};
-
-// We could just re-export 'ButtonGroup' and 'ButtonToolbar', but we currently
-// override them to add propTypes validation at runtime, since most Paragon
-// consumers aren't using TypeScript yet. We also force ButtonGroup's 'size'
-// prop to accept our custom values of 'md' and 'inline' which are used in
-// Paragon but not used in the base Bootstrap classes.
+// We could just re-export 'ButtonGroup', but we currently override it to
+// force ButtonGroup's 'size' prop to accept our custom values of 'md' and
+// 'inline' which are used in Paragon but not used in the base Bootstrap classes.
 
 interface ButtonGroupProps extends Omit<BaseButtonGroupProps, 'size'> {
+  /** Specifies element type for this component. */
+  as?: React.ElementType;
+  /** An ARIA role describing the button group (default: `group`). */
+  role?: React.AriaRole;
+  /** Specifies the size for all Buttons in the group (default: `md`). */
   size?: 'sm' | 'md' | 'lg' | 'inline';
+  /** Display as a button toggle group (default: `false`). */
+  toggle?: boolean;
+  /** Specifies if the set of Buttons should appear vertically stacked (default: `false`). */
+  vertical?: boolean;
+  /** Overrides underlying component base CSS class name (default: `btn-group`). */
+  bsPrefix?: string;
 }
 
 const ButtonGroup: ComponentWithAsProp<'div', ButtonGroupProps> = (
-  React.forwardRef<HTMLButtonElement, ButtonGroupProps>(({ size, ...props }, ref) => (
+  React.forwardRef(({ size = 'md', ...props }: ButtonGroupProps, ref: React.ForwardedRef<HTMLDivElement>) => (
     <BaseButtonGroup size={size as 'sm' | 'lg'} {...props} ref={ref} />
   ))
 );
 
-ButtonGroup.propTypes = {
-  /** Specifies element type for this component. */
-  as: PropTypes.elementType,
-  /** An ARIA role describing the button group. */
-  role: PropTypes.string,
-  /** Specifies the size for all Buttons in the group. */
-  size: PropTypes.oneOf(['sm', 'md', 'lg', 'inline']),
-  /** Display as a button toggle group. */
-  toggle: PropTypes.bool,
-  /** Specifies if the set of Buttons should appear vertically stacked. */
-  vertical: PropTypes.bool,
-  /** Overrides underlying component base CSS class name */
-  bsPrefix: PropTypes.string,
-};
+// We could just re-export 'ButtonToolbar', but we currently override it to
+// narrow the type of 'role' to valid roles and to document its properties.
 
-ButtonGroup.defaultProps = {
-  as: 'div',
-  role: 'group',
-  toggle: false,
-  vertical: false,
-  bsPrefix: 'btn-group',
-  size: 'md',
-};
+interface ButtonToolbarProps extends BaseButtonToolbarProps {
+  /** An ARIA role describing the button group (default: `toolbar`). */
+  role?: React.AriaRole;
+  /** Overrides underlying component base CSS class name (default: `btn-toolbar`) */
+  bsPrefix?: string;
+}
 
 const ButtonToolbar: ComponentWithAsProp<'div', ButtonToolbarProps> = (
-  React.forwardRef<HTMLButtonElement, ButtonToolbarProps>((props, ref) => (
+  React.forwardRef((props: ButtonToolbarProps, ref: React.ForwardedRef<HTMLDivElement>) => (
     <BaseButtonToolbar {...props} ref={ref} />
   ))
 );
-
-ButtonToolbar.propTypes = {
-  /** An ARIA role describing the button group. */
-  role: PropTypes.string,
-  /** Overrides underlying component base CSS class name */
-  bsPrefix: PropTypes.string,
-};
-
-ButtonToolbar.defaultProps = {
-  role: 'toolbar',
-  bsPrefix: 'btn-toolbar',
-};
 
 export default Button;
 export { ButtonGroup, ButtonToolbar };

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -21,6 +21,13 @@ type BaseVariant = (
   | 'link'
 );
 
+/**
+ * This was added so these types could be added as a non-breaking change, it should be removed
+ * in the next major release, and all uses should be updated to the non-deprecated Variant.
+ * @deprecated - remove in Paragon 24
+ */
+type OtherDeprecatedValue = string & {}; // Allow any other string value for now, even though it's invalid
+
 export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
   /** Set a custom element for this component (default: `button`, with `type="button"`). */
   as?: React.ElementType;
@@ -57,7 +64,7 @@ export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
    * as well as one of the customized variants (= base variant prefixed with `inverse-`, `outline-`
    * or `inverse-outline-`)
    * */
-  variant?: BaseVariant | `inverse-${BaseVariant}` | `outline-${BaseVariant}` | `inverse-outline-${BaseVariant}`;
+  variant?: BaseVariant | `inverse-${BaseVariant}` | `outline-${BaseVariant}` | `inverse-outline-${BaseVariant}` | OtherDeprecatedValue;
 }
 
 const Button: ComponentWithAsProp<'button', ButtonProps> = React.forwardRef(({

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -22,8 +22,7 @@ type BaseVariant = (
 );
 
 /**
- * This was added so these types could be added as a non-breaking change, it should be removed
- * in the next major release, and all uses should be updated to the non-deprecated Variant.
+ * This was added so these types could be added as a non-breaking change.
  * @deprecated - remove in Paragon 24
  */
 type OtherDeprecatedValue = string & {}; // Allow any other string value for now, even though it's invalid

--- a/www/src/components/LeaveFeedback.tsx
+++ b/www/src/components/LeaveFeedback.tsx
@@ -1,5 +1,4 @@
 import React, { AnchorHTMLAttributes } from 'react';
-import PropTypes from 'prop-types';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { Nav, Button, Hyperlink } from '~paragon-react';
 import { LEAVE_FEEDBACK_CLICKED_EVENT, sendUserAnalyticsEvent } from '../../segment-events';
@@ -8,7 +7,7 @@ export interface LeaveFeedbackProps extends Partial<AnchorHTMLAttributes<HTMLAnc
   isNavLink?: boolean;
 }
 
-function LeaveFeedback({ isNavLink, ...props }: LeaveFeedbackProps) {
+function LeaveFeedback({ isNavLink = false, ...props }: LeaveFeedbackProps) {
   const location = useLocation();
   const FEEDBACK_URL = `https://github.com/openedx/paragon/issues/new?title=%5Bparagon-openedx.netlify.app%5D%20Feedback%20(on%20${location.pathname})&amp;labels=docs&template=feedback_template.md`;
   const leaveFeedbackLinkTitle = 'Leave feedback';
@@ -42,13 +41,5 @@ function LeaveFeedback({ isNavLink, ...props }: LeaveFeedbackProps) {
     </Button>
   );
 }
-
-LeaveFeedback.propTypes = {
-  isNavLink: PropTypes.bool,
-};
-
-LeaveFeedback.defaultProps = {
-  isNavLink: false,
-};
 
 export default LeaveFeedback;

--- a/www/src/components/PageEditBtn/index.tsx
+++ b/www/src/components/PageEditBtn/index.tsx
@@ -1,5 +1,4 @@
 import React, { AnchorHTMLAttributes } from 'react';
-import PropTypes from 'prop-types';
 import { Button, Hyperlink, Nav } from '~paragon-react';
 import { PAGE_EDIT_BTN_CLICKED_EVENT, sendUserAnalyticsEvent } from '../../../segment-events';
 
@@ -40,14 +39,5 @@ function PageEditBtn({ githubEditPath, isNavLink, ...props }: PageEditBtnProps) 
     </Button>
   );
 }
-
-PageEditBtn.propTypes = {
-  githubEditPath: PropTypes.string.isRequired,
-  isNavLink: PropTypes.bool,
-};
-
-PageEditBtn.defaultProps = {
-  isNavLink: false,
-};
 
 export default PageEditBtn;

--- a/www/src/components/PropType.tsx
+++ b/www/src/components/PropType.tsx
@@ -37,7 +37,8 @@ function PropType({
         raw={raw}
       />
     );
-  } else if (name) {
+  }
+  if (name) {
     // For TypeScript types, we simply display the type as a string.
     return (
       <span>
@@ -45,9 +46,8 @@ function PropType({
         <RequiredBadge isRequired={required} />
       </span>
     );
-  } else {
-    return <>unknown type</>;
   }
+  return <>unknown type</>;
 }
 
 export interface ISimplePropType {

--- a/www/src/components/PropsTable.tsx
+++ b/www/src/components/PropsTable.tsx
@@ -100,10 +100,13 @@ function PropsTable({ props: componentProps, displayName, content }: IPropsTable
       {content && <p className="px-4 small">{content}</p>}
       {bootstrapLink && (
         <p className="px-4 small mb-3">
-          This is a pass through component from React-Bootstrap, see original props documentation{' '}
+          This is a pass through component from React-Bootstrap; see original props documentation{' '}
           <Hyperlink destination={bootstrapLink}>
             here.
-          </Hyperlink>
+          </Hyperlink>{' '}
+          You can also pass any HTML attributes, such as <code>onClick</code>, <code>role</code>, etc. Which attributes
+          are available depends on whether or not you have overriden the underlying HTML element using the{' '}
+          <code>as</code> property.
         </p>
       )}
       {componentProps.length > 0 ? (


### PR DESCRIPTION
## Description

Like in #3738, this PR removes deprecated `propTypes` and `defaultProps` from `<Button>` and related components. It also makes the TypeScript definitions slightly more strict (e.g. requires a valid ARIA role for the `role` attribute, and a valid variant for the `variant` attribute). It also corrects the documentation to mention the missing (but valid) `tertiary` variant, and that you can include arbitrary HTML props.

I've actually _removed_ some props documentation in this case, e.g. `onClick` is no longer listed as an explicit prop, because it too difficult to give it the correct type (the detailed event type depends on whether or not users override the element type with `as`). So instead I omitted props like `onClick` and `role` from our explicit list - this means that they'll always have the right type (based on the `as` prop) in user's IDE and when type checking, but they're no longer documented explicitly on the docs page. To compensate, I put this informative message at the top of the props documentation:

<img width="970" height="280" alt="Screenshot 2025-08-14 at 2 59 00 PM" src="https://github.com/user-attachments/assets/b2cfafd3-904c-4d71-968e-3cd0a042591e" />


### Deploy Preview

* `<Button>`: [Before](https://paragon-openedx.netlify.app/components/button/) vs [After](https://deploy-preview-3742--paragon-openedx-v23.netlify.app/components/button/)
* `<ButtonGroup>`: [Before](https://paragon-openedx.netlify.app/components/button/button-group/) vs [After](https://deploy-preview-3742--paragon-openedx-v23.netlify.app/components/button/button-group/)
* `<ButtonToolbar>`: [Before](https://paragon-openedx.netlify.app/components/button/button-group/#buttontoolbar) vs [After](https://deploy-preview-3742--paragon-openedx-v23.netlify.app/components/button/button-group/#buttontoolbar)

## Merge Checklist

n/a
