### PR TITLE
docs: update maintainers in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,6 +28,6 @@ metadata:
   annotations:
     openedx.org/arch-interest-groups: "adamstankiewicz"
 spec:
-  owner: group:paragon-working-group
+  owner: group:committers-paragon
   type: 'library'
   lifecycle: 'production'


### PR DESCRIPTION
The previously mentioned group no longer exists. This updates the maintainers to https://github.com/orgs/openedx/teams/committers-paragon which does exist.