### PR TITLE
fix: DataTable filter "Clear all" bug fix

### DIFF
--- a/src/DataTable/FilterStatus.jsx
+++ b/src/DataTable/FilterStatus.jsx
@@ -26,7 +26,7 @@ function FilterStatus({
         className={buttonClassName}
         variant={variant}
         size={size}
-        onClick={() => setAllFilters([])}
+        onClick={() => setAllFilters(undefined)}
       >
         {clearFiltersText === undefined
           ? (

--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -27,7 +27,7 @@ function CheckboxFilter({
   return (
     <Form.Group role="group" aria-labelledby={ariaLabel.current}>
       <FormLabel id={ariaLabel.current} className="pgn__checkbox-filter-label">{Header}</FormLabel>
-      <Form.CheckboxSet name={Header} value={checkedBoxes}>
+      <Form.CheckboxSet name={Header}>
         {filterChoices.map(({ name, number, value }) => (
           <Form.Checkbox
             key={`${headerBasedId}${name}`}

--- a/src/DataTable/tests/FilterStatus.test.jsx
+++ b/src/DataTable/tests/FilterStatus.test.jsx
@@ -50,7 +50,7 @@ describe('<FilterStatus />', () => {
     const button = screen.getByText(filterProps.clearFiltersText);
     await userEvent.click(button);
     expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(clearSpy).toHaveBeenCalledWith([]);
+    expect(clearSpy).toHaveBeenCalledWith(undefined);
   });
   it('displays the current filter names', () => {
     render(<FilterStatusWrapper value={instance} props={filterProps} />);


### PR DESCRIPTION
https://github.com/user-attachments/assets/550cfb6e-84e6-436b-9b7d-6ed18b9fb0dd

## Description

There was a [previous bug fix](https://github.com/openedx/paragon/pull/3639) for the filters on DataTable, but this fix introduced a [new bug](https://2u-internal.atlassian.net/browse/ENT-10858) where checkboxes were filtering correctly, but did not visually show as checked. This fix still provides correct functionality when clicking "Clear all" (all checkboxes get unchecked) but also fixes the new bug. The underlying issue was an empty array not being falsy in javascript. 

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
