### PR TITLE
Remove propTypes + defaultProps from <Chip>, <Toast>, <FormLabel> and <IconButton>

### DIFF
--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -7,14 +7,11 @@ export const CHIP_PGN_CLASS = 'pgn__chip';
 export interface IChip {
   /** Specifies the content of the `Chip`. */
   children: React.ReactNode,
-  /** Click handler for the whole Chip, has effect only when Chip does not have any interactive icons. */
+  /** Click handler for the whole `Chip`, has effect only when Chip does not have any interactive icons. */
   onClick?: KeyboardEventHandler & MouseEventHandler,
   /** Specifies an additional `className` to add to the base element. */
   className?: string,
-  /** The `Chip` style variant to use.
-   * Previously found on /constants as STYLE_VARIANTS,
-   * but wasn't clear on documentation what the options were so hardcoded the options.
-  */
+  /** The `Chip` style variant to use. */
   variant?: 'dark' | 'light',
   /**
    * An icon component to render before the content.

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -1,6 +1,7 @@
 import React, { ForwardedRef, KeyboardEventHandler, MouseEventHandler } from 'react';
 import classNames from 'classnames';
 import ChipIcon from './ChipIcon';
+import { STYLE_VARIANTS } from './constants';
 
 export const CHIP_PGN_CLASS = 'pgn__chip';
 
@@ -11,8 +12,8 @@ export interface IChip {
   onClick?: KeyboardEventHandler & MouseEventHandler,
   /** Specifies an additional `className` to add to the base element. */
   className?: string,
-  /** The `Chip` style variant to use. */
-  variant?: 'dark' | 'light',
+  /** The `Chip` style variant to use. Can be `dark` | `light` */
+  variant?: typeof STYLE_VARIANTS[keyof typeof STYLE_VARIANTS],
   /**
    * An icon component to render before the content.
    * Example import of a Paragon icon component:

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -1,6 +1,5 @@
 import React, { ForwardedRef, KeyboardEventHandler, MouseEventHandler } from 'react';
 import classNames from 'classnames';
-import { STYLE_VARIANTS } from './constants';
 import ChipIcon from './ChipIcon';
 
 export const CHIP_PGN_CLASS = 'pgn__chip';
@@ -12,8 +11,11 @@ export interface IChip {
   onClick?: KeyboardEventHandler & MouseEventHandler,
   /** Specifies an additional `className` to add to the base element. */
   className?: string,
-  /** The `Chip` style variant to use. */
-  variant?: typeof STYLE_VARIANTS[keyof typeof STYLE_VARIANTS],
+  /** The `Chip` style variant to use.
+   * Previously found on /constants as STYLE_VARIANTS,
+   * but wasn't clear on documentation what the options were so hardcoded the options.
+  */
+  variant?: 'dark' | 'light',
   /**
    * An icon component to render before the content.
    * Example import of a Paragon icon component:
@@ -32,6 +34,7 @@ export interface IChip {
   iconAfter?: React.ComponentType,
   /** Specifies icon alt text. */
   iconAfterAlt?: string,
+  /** A click handler for the `Chip` icon before. */
   onIconBeforeClick?: KeyboardEventHandler & MouseEventHandler,
   /** A click handler for the `Chip` icon after. */
   onIconAfterClick?: KeyboardEventHandler & MouseEventHandler,
@@ -44,7 +47,7 @@ export interface IChip {
 const Chip = React.forwardRef(({
   children,
   className,
-  variant = STYLE_VARIANTS.LIGHT,
+  variant = 'light',
   iconBefore,
   iconBeforeAlt,
   iconAfter,

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -12,7 +12,7 @@ export interface IChip {
   onClick?: KeyboardEventHandler & MouseEventHandler,
   /** Specifies an additional `className` to add to the base element. */
   className?: string,
-  /** The `Chip` style variant to use. Can be `dark` | `light` */
+  /** The `Chip` style [variant](https://github.com/openedx/paragon/blob/release-23.x/src/Chip/constants.ts) to use. */
   variant?: typeof STYLE_VARIANTS[keyof typeof STYLE_VARIANTS],
   /**
    * An icon component to render before the content.

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -1,40 +1,58 @@
 import React, { ForwardedRef, KeyboardEventHandler, MouseEventHandler } from 'react';
-import PropTypes, { type Requireable } from 'prop-types';
 import classNames from 'classnames';
-// @ts-ignore
-import { requiredWhen } from '../utils/propTypes';
 import { STYLE_VARIANTS } from './constants';
 import ChipIcon from './ChipIcon';
 
 export const CHIP_PGN_CLASS = 'pgn__chip';
 
 export interface IChip {
+  /** Specifies the content of the `Chip`. */
   children: React.ReactNode,
+  /** Click handler for the whole Chip, has effect only when Chip does not have any interactive icons. */
   onClick?: KeyboardEventHandler & MouseEventHandler,
+  /** Specifies an additional `className` to add to the base element. */
   className?: string,
+  /** The `Chip` style variant to use. */
   variant?: typeof STYLE_VARIANTS[keyof typeof STYLE_VARIANTS],
+  /**
+   * An icon component to render before the content.
+   * Example import of a Paragon icon component:
+   *
+   * `import { Check } from '@openedx/paragon/icons';`
+   */
   iconBefore?: React.ComponentType,
+  /** Specifies icon alt text. */
   iconBeforeAlt?: string,
+  /**
+   * An icon component to render before after the content.
+   * Example import of a Paragon icon component:
+   *
+   * `import { Check } from '@openedx/paragon/icons';`
+   */
   iconAfter?: React.ComponentType,
+  /** Specifies icon alt text. */
   iconAfterAlt?: string,
   onIconBeforeClick?: KeyboardEventHandler & MouseEventHandler,
+  /** A click handler for the `Chip` icon after. */
   onIconAfterClick?: KeyboardEventHandler & MouseEventHandler,
+  /** Disables the `Chip`. */
   disabled?: boolean,
+  /** Indicates if `Chip` has been selected. */
   isSelected?: boolean,
 }
 
 const Chip = React.forwardRef(({
   children,
   className,
-  variant,
+  variant = STYLE_VARIANTS.LIGHT,
   iconBefore,
   iconBeforeAlt,
   iconAfter,
   iconAfterAlt,
   onIconBeforeClick,
   onIconAfterClick,
-  disabled,
-  isSelected,
+  disabled = false,
+  isSelected = false,
   onClick,
   ...props
 }: IChip, ref: ForwardedRef<HTMLDivElement>) => {
@@ -91,57 +109,5 @@ const Chip = React.forwardRef(({
     </div>
   );
 });
-
-Chip.propTypes = {
-  /** Specifies the content of the `Chip`. */
-  // @ts-ignore
-  children: PropTypes.node.isRequired,
-  /** Specifies an additional `className` to add to the base element. */
-  className: PropTypes.string,
-  /** The `Chip` style variant to use. */
-  variant: PropTypes.oneOf(['light', 'dark']),
-  /** Disables the `Chip`. */
-  disabled: PropTypes.bool,
-  /** Click handler for the whole Chip, has effect only when Chip does not have any interactive icons. */
-  onClick: PropTypes.func,
-  /**
-   * An icon component to render before the content.
-   * Example import of a Paragon icon component:
-   *
-   * `import { Check } from '@openedx/paragon/icons';`
-   */
-  iconBefore: PropTypes.elementType as Requireable<React.ComponentType>,
-  /** Specifies icon alt text. */
-  iconBeforeAlt: requiredWhen(PropTypes.string, ['iconBefore', 'onIconBeforeClick']),
-  /** A click handler for the `Chip` icon before. */
-  onIconBeforeClick: PropTypes.func,
-  /**
-   * An icon component to render before after the content.
-   * Example import of a Paragon icon component:
-   *
-   * `import { Check } from '@openedx/paragon/icons';`
-   */
-  iconAfter: PropTypes.elementType as Requireable<React.ComponentType>,
-  /** Specifies icon alt text. */
-  iconAfterAlt: requiredWhen(PropTypes.string, ['iconAfter', 'onIconAfterClick']),
-  /** A click handler for the `Chip` icon after. */
-  onIconAfterClick: PropTypes.func,
-  /** Indicates if `Chip` has been selected. */
-  isSelected: PropTypes.bool,
-};
-
-Chip.defaultProps = {
-  className: undefined,
-  variant: STYLE_VARIANTS.LIGHT,
-  disabled: false,
-  onClick: undefined,
-  iconBefore: undefined,
-  iconAfter: undefined,
-  onIconBeforeClick: undefined,
-  onIconAfterClick: undefined,
-  isSelected: false,
-  iconAfterAlt: undefined,
-  iconBeforeAlt: undefined,
-};
 
 export default Chip;

--- a/src/Form/FormLabel.tsx
+++ b/src/Form/FormLabel.tsx
@@ -8,7 +8,7 @@ interface Props {
   children: React.ReactNode;
   /** Specifies whether the component should be displayed with inline styling. */
   isInline?: boolean;
-  /** Specifies class name to append to the base element. */
+  /** Specifies an additional `className` to add to the base element. */
   className?: string;
 }
 

--- a/src/Form/FormLabel.tsx
+++ b/src/Form/FormLabel.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useFormGroupContext } from './FormGroupContext';
 import { FORM_CONTROL_SIZES } from './constants';
@@ -9,6 +8,8 @@ interface Props {
   children: React.ReactNode;
   /** Specifies whether the component should be displayed with inline styling. */
   isInline?: boolean;
+  /** Specifies class name to append to the base element. */
+  className?: string;
 }
 
 function FormLabel({ children, isInline = false, ...props }: Props & React.ComponentPropsWithoutRef<'label'>) {
@@ -26,14 +27,5 @@ function FormLabel({ children, isInline = false, ...props }: Props & React.Compo
   const componentType = isControlGroup ? 'p' : 'label';
   return React.createElement(componentType, labelProps, children);
 }
-
-FormLabel.propTypes = {
-  /** Specifies class name to append to the base element. */
-  className: PropTypes.string,
-  /** Specifies contents of the component. */
-  children: PropTypes.node.isRequired,
-  /** Specifies whether the component should be displayed with inline styling. */
-  isInline: PropTypes.bool,
-};
 
 export default FormLabel;

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -26,15 +26,15 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   iconClassNames?: string;
   /** Click handler for the button */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  /** whether to show the `IconButton` in an active state, whose styling is distinct from default state */
+  /** Whether to show the `IconButton` in an active state, whose styling is distinct from default state */
   isActive?: boolean;
   /** @deprecated Using FontAwesome icons is deprecated. Instead, pass iconAs={Icon} src={...} */
   icon?: { prefix?: string; iconName?: string, icon?: any[] },
   /** Type of button (uses Bootstrap options) */
   variant?: 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'light' | 'dark' | 'black' | 'brand';
-  /** size of button to render */
+  /** Size of button to render */
   size?: 'sm' | 'md' | 'inline';
-  /** no children */
+  /** No children */
   children?: never;
 }
 
@@ -88,9 +88,9 @@ const IconButton = React.forwardRef(({
 });
 
 interface PropsWithTooltip extends Props {
-  /** tooltip placement can be top, left, right etc, choose from https://popper.js.org/docs/v2/constructors/#options */
+  /** Tooltip placement can be top, left, right etc, choose from https://popper.js.org/docs/v2/constructors/#options */
   tooltipPlacement?: Placement,
-  /** any content to pass to tooltip content area */
+  /** Any content to pass to tooltip content area */
   tooltipContent: React.ReactNode,
 }
 

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -28,9 +28,9 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /** Whether to show the `IconButton` in an active state, whose styling is distinct from default state */
   isActive?: boolean;
-  /** @deprecated Using FontAwesome icons is deprecated. Instead, pass iconAs={Icon} src={...} */
+  /** Accepts a [Paragon icon](https://paragon-openedx.netlify.app/foundations/icons) */
   icon?: { prefix?: string; iconName?: string, icon?: any[] },
-  /** Type of button (uses Bootstrap options) */
+  /** Type of button (uses Bootstrap options). */
   variant?: 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'light' | 'dark' | 'black' | 'brand';
   /** Size of button to render */
   size?: 'sm' | 'md' | 'inline';

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -41,7 +41,7 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
 const IconButton = React.forwardRef(({
   className,
   alt,
-  invertColors,
+  invertColors = false,
   icon,
   src,
   iconClassNames,

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -38,7 +38,7 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   children?: never;
 }
 
-const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
+const IconButton = React.forwardRef(({
   className,
   alt,
   invertColors,
@@ -52,7 +52,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
   isActive = false,
   children, // unused, just here because we don't want it to be part of 'attrs'
   ...attrs
-}, ref) => {
+} : Props, ref: React.ForwardedRef<HTMLButtonElement>) => {
   const invert = invertColors ? 'inverse-' : '';
   const activeStyle = isActive ? `${variant}-` : '';
   const IconComponent = iconAs;

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { type Placement } from 'react-bootstrap/Overlay';
 import { OverlayTrigger } from '../Overlay';
@@ -7,6 +6,7 @@ import Tooltip from '../Tooltip';
 import Icon from '../Icon';
 
 interface Props extends React.HTMLAttributes<HTMLButtonElement> {
+  /** Component that renders the icon, currently defaults to `Icon` */
   iconAs?: React.ComponentType<any>,
   /** Additional CSS class[es] to apply to this button */
   className?: string;
@@ -45,11 +45,11 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
   icon,
   src,
   iconClassNames,
-  onClick,
-  size,
-  variant,
-  iconAs,
-  isActive,
+  onClick = () => {},
+  size = 'md',
+  variant = 'primary',
+  iconAs = Icon,
+  isActive = false,
   children, // unused, just here because we don't want it to be part of 'attrs'
   ...attrs
 }, ref) => {
@@ -87,57 +87,9 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
   );
 });
 
-IconButton.defaultProps = {
-  iconAs: Icon,
-  src: undefined,
-  icon: undefined,
-  iconClassNames: undefined,
-  className: undefined,
-  invertColors: false,
-  variant: 'primary',
-  size: 'md',
-  onClick: () => {},
-  isActive: false,
-  children: undefined,
-};
-
-IconButton.propTypes = {
-  /** A custom class name. */
-  className: PropTypes.string,
-  /** Component that renders the icon, currently defaults to `Icon` */
-  iconAs: PropTypes.elementType as any,
-  /** An icon component to render. Example import of a Paragon icon component:
-   * `import { Check } from '@openedx/paragon/icons';`
-   * */
-  src: PropTypes.elementType as any,
-  /** Alt text for your icon. For best practice, avoid using alt text to describe
-   * the image in the `IconButton`. Instead, we recommend describing the function
-   * of the button. */
-  alt: PropTypes.string.isRequired,
-  /** Changes icon styles for dark background */
-  invertColors: PropTypes.bool,
-  /** Accepts a [Paragon icon](https://paragon-openedx.netlify.app/foundations/icons) */
-  icon: PropTypes.shape({
-    prefix: PropTypes.string,
-    iconName: PropTypes.string,
-    // eslint-disable-next-line react/forbid-prop-types
-    icon: PropTypes.array,
-  }) as any,
-  /** Extra class names that will be added to the icon */
-  iconClassNames: PropTypes.string,
-  /** Click handler for the button */
-  onClick: PropTypes.func,
-  /** Type of button (uses Bootstrap options) */
-  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger', 'light', 'dark', 'black', 'brand']),
-  /** size of button to render */
-  size: PropTypes.oneOf(['sm', 'md', 'inline']),
-  /** whether to show the `IconButton` in an active state, whose styling is distinct from default state */
-  isActive: PropTypes.bool,
-};
-
 interface PropsWithTooltip extends Props {
-  /** choose from https://popper.js.org/docs/v2/constructors/#options */
-  tooltipPlacement: Placement,
+  /** tooltip placement can be top, left, right etc, choose from https://popper.js.org/docs/v2/constructors/#options */
+  tooltipPlacement?: Placement,
   /** any content to pass to tooltip content area */
   tooltipContent: React.ReactNode,
 }
@@ -146,7 +98,7 @@ interface PropsWithTooltip extends Props {
  * An icon button wrapped in overlaytrigger to display a tooltip.
  */
 function IconButtonWithTooltip({
-  tooltipPlacement, tooltipContent, ...props
+  tooltipPlacement = 'top', tooltipContent, ...props
 }: PropsWithTooltip) {
   const invert = props.invertColors ? 'inverse-' : '';
   return (
@@ -165,22 +117,6 @@ function IconButtonWithTooltip({
     </OverlayTrigger>
   );
 }
-
-IconButtonWithTooltip.defaultProps = {
-  ...IconButton.defaultProps,
-  tooltipPlacement: 'top',
-};
-
-IconButtonWithTooltip.propTypes = {
-  /** tooltip placement can be top, left, right etc, per https://popper.js.org/docs/v2/constructors/#options  */
-  tooltipPlacement: PropTypes.string,
-  /** any valid JSX or text to be rendered as tooltip contents */
-  tooltipContent: PropTypes.node.isRequired,
-  /** Type of button (uses Bootstrap options) */
-  variant: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger', 'light', 'dark', 'black', 'brand']),
-  /** Changes icon styles for dark background */
-  invertColors: PropTypes.bool,
-};
 
 (IconButton as any).IconButtonWithTooltip = IconButtonWithTooltip;
 

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -28,7 +28,7 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /** Whether to show the `IconButton` in an active state, whose styling is distinct from default state */
   isActive?: boolean;
-  /** Accepts a [Paragon icon](https://paragon-openedx.netlify.app/foundations/icons) */
+  /** @deprecated Using FontAwesome icons is deprecated. Instead, pass iconAs={Icon} src={...} */
   icon?: { prefix?: string; iconName?: string, icon?: any[] },
   /** Type of button (uses Bootstrap options). */
   variant?: 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'light' | 'dark' | 'black' | 'brand';

--- a/src/Toast/index.tsx
+++ b/src/Toast/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import BaseToast from 'react-bootstrap/Toast';
 import { useIntl } from 'react-intl';
 
@@ -20,12 +19,30 @@ interface ToastAction {
 }
 
 interface ToastProps {
+  /** A string or an element that is rendered inside the main body of the `Toast`. */
   children: string;
+  /**
+   * A function that is called on close. It can be used to perform
+   * actions upon closing of the `Toast`, such as setting the "show"
+   * element to false.
+   * */
   onClose: () => void;
+  /** Boolean used to control whether the `Toast` shows */
   show: boolean;
+  /**
+   * Fields used to build optional action button.
+   * `label` is a string rendered inside the button.
+   * `href` is a link that will render the action button as an anchor tag.
+   * `onClick` is a function that is called when the button is clicked.
+   */
   action?: ToastAction;
+  /**
+   * Alt text for the `Toast`'s dismiss button. Defaults to 'Close'.
+   */
   closeLabel?: string;
+  /** Time in milliseconds for which the `Toast` will display. */
   delay?: number;
+  /** Class names for the `BaseToast` component */
   className?: string;
 }
 
@@ -36,6 +53,7 @@ function Toast({
   closeLabel,
   onClose,
   show,
+  delay = TOAST_DELAY,
   ...rest
 }: ToastProps) {
   const intl = useIntl();
@@ -58,6 +76,7 @@ function Toast({
         onMouseOut={() => setAutoHide(true)}
         onMouseOver={() => setAutoHide(false)}
         show={show}
+        delay={delay}
         {...rest}
       >
         <div className="toast-header">
@@ -89,44 +108,5 @@ function Toast({
     </ToastContainer>
   );
 }
-
-Toast.defaultProps = {
-  action: null,
-  closeLabel: undefined,
-  delay: TOAST_DELAY,
-  className: undefined,
-};
-
-Toast.propTypes = {
-  /** A string or an element that is rendered inside the main body of the `Toast`. */
-  children: PropTypes.string.isRequired,
-  /**
-   * A function that is called on close. It can be used to perform
-   * actions upon closing of the `Toast`, such as setting the "show"
-   * element to false.
-   * */
-  onClose: PropTypes.func.isRequired,
-  /** Boolean used to control whether the `Toast` shows */
-  show: PropTypes.bool.isRequired,
-  /**
-   * Fields used to build optional action button.
-   * `label` is a string rendered inside the button.
-   * `href` is a link that will render the action button as an anchor tag.
-   * `onClick` is a function that is called when the button is clicked.
-   */
-  action: PropTypes.shape({
-    label: PropTypes.string.isRequired,
-    href: PropTypes.string,
-    onClick: PropTypes.func,
-  }),
-  /**
-   * Alt text for the `Toast`'s dismiss button. Defaults to 'Close'.
-   */
-  closeLabel: PropTypes.string,
-  /** Time in milliseconds for which the `Toast` will display. */
-  delay: PropTypes.number,
-  /** Class names for the `BaseToast` component */
-  className: PropTypes.string,
-};
 
 export default Toast;

--- a/src/Toast/index.tsx
+++ b/src/Toast/index.tsx
@@ -27,7 +27,7 @@ interface ToastProps {
    * element to false.
    * */
   onClose: () => void;
-  /** Boolean used to control whether the `Toast` shows */
+  /** Boolean used to control whether the `Toast` shows. */
   show: boolean;
   /**
    * Fields used to build optional action button.
@@ -42,7 +42,7 @@ interface ToastProps {
   closeLabel?: string;
   /** Time in milliseconds for which the `Toast` will display. */
   delay?: number;
-  /** Class names for the `BaseToast` component */
+  /** Class names for the `BaseToast` component. */
   className?: string;
 }
 

--- a/src/Toast/index.tsx
+++ b/src/Toast/index.tsx
@@ -34,6 +34,7 @@ interface ToastProps {
    * `label` is a string rendered inside the button.
    * `href` is a link that will render the action button as an anchor tag.
    * `onClick` is a function that is called when the button is clicked.
+   * The full type definition can be seen [here](https://github.com/openedx/paragon/blob/release-23.x/src/Toast/index.tsx#L16)
    */
   action?: ToastAction;
   /**


### PR DESCRIPTION
## Description
Some of our components have their props types defined as both TypeScript interfaces and propTypes runtime checks, with defaultProps defaults. Since propTypes and defaultProps are deprecated and they are redundant with TypeScript types, this PR continues my ongoing work to remove the redundant specifications from a few components:
- `<Chip>`
- `<Toast>`
- `<FormLabel>`
- `<IconButton>`

As part of the work needed on #3744 

### Deploy Preview

- `<Chip>` - https://deploy-preview-3789--paragon-openedx-v23.netlify.app/components/chip/
- `<Toast>` - https://deploy-preview-3789--paragon-openedx-v23.netlify.app/components/toast/
- `<FormLabel>` - https://deploy-preview-3789--paragon-openedx-v23.netlify.app/components/form/form-label/
- `<IconButton>` - https://deploy-preview-3789--paragon-openedx-v23.netlify.app/components/iconbutton/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
