### PR TITLE
removing unnecessary react imports

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,14 +1,14 @@
 {
   "presets": [
     ["@babel/preset-env", { "modules": false } ],
-    ["@babel/preset-react", { "useSpread": true } ],
+    ["@babel/preset-react", { "useSpread": true, "runtime": "automatic" } ],
     "@babel/preset-typescript"
   ],
   "env": {
     "test": {
       "presets": [
         ["@babel/preset-env", {}],
-        ["@babel/preset-react", { "useSpread": true } ],
+        ["@babel/preset-react", { "useSpread": true, "runtime": "automatic" } ],
         "@babel/preset-typescript"
       ]
     }

--- a/component-generator/templates/index.jsx
+++ b/component-generator/templates/index.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const componentName = React.forwardRef(({ className, children }, ref) => (
+const componentName = forwardRef(({ className, children }, ref) => (
   <div ref={ref} className={classNames('pgn__css-class', className)}>
     {children}
   </div>

--- a/component-generator/templates/test.jsx
+++ b/component-generator/templates/test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import componentName from './index';
 

--- a/example/src/MyComponent.jsx
+++ b/example/src/MyComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Form, Icon, Bubble, Stack, Container } from '@openedx/paragon'; // eslint-disable-line
 import { FavoriteBorder } from '@openedx/paragon/icons'; // eslint-disable-line
 

--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
 import {
   AppProvider,

--- a/src/ActionRow/index.jsx
+++ b/src/ActionRow/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -8,7 +8,7 @@ function ActionRow({
   children,
   ...props
 }) {
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Alert/Alert.test.tsx
+++ b/src/Alert/Alert.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { IntlProvider } from 'react-intl';
 import renderer, { act } from 'react-test-renderer';
 import { render, screen, within } from '@testing-library/react';
@@ -11,9 +11,9 @@ import Alert, { AlertProps } from '.';
 
 /** A compile time check. Whatever React elements this wraps won't run at runtime. */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function CompileCheck(_props: { children: React.ReactNode }) { return null; }
+function CompileCheck(_props: { children: ReactNode }) { return null; }
 
-function AlertWrapper({ children, ...props }: AlertProps & { children: React.ReactNode }) {
+function AlertWrapper({ children, ...props }: AlertProps & { children: ReactNode }) {
   return (
     <IntlProvider locale="en" messages={{}}>
       <Alert {...props}>

--- a/src/Alert/index.tsx
+++ b/src/Alert/index.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/require-default-props */
-import React, {
+import type { ComponentType, ReactElement, ForwardedRef } from 'react';
+
+import {
   useCallback,
   useEffect,
   useState,
@@ -11,6 +13,7 @@ import React, {
   RefAttributes,
   cloneElement,
 } from 'react';
+
 import classNames from 'classnames';
 import {
   Alert as BaseAlert,
@@ -46,7 +49,7 @@ export interface AlertProps extends BaseProps {
   transition?: boolean | TransitionComponent;
   children?: ReactNode;
   /** Icon that will be shown in the alert */
-  icon?: React.ComponentType<IconProps>;
+  icon?: ComponentType<IconProps>;
   /** Whether the alert is shown. */
   show?: boolean;
   /** Whether the alert is dismissible. Defaults to false. */
@@ -54,7 +57,7 @@ export interface AlertProps extends BaseProps {
   /** Optional callback function for when the alert it dismissed. */
   onClose?: () => void;
   /** Optional list of action elements. May include, at most, 2 actions, or 1 if dismissible is true. */
-  actions?: React.ReactElement[];
+  actions?: ReactElement[];
   /** Position of the dismiss and call-to-action buttons. Defaults to `false`. */
   stacked?: boolean;
   /** Sets the text for alert close button, defaults to 'Dismiss'. */
@@ -96,7 +99,7 @@ const Alert = forwardRef(({
   stacked = false,
   show = true,
   ...props
-}: AlertProps, ref: React.ForwardedRef<HTMLDivElement>) => {
+}: AlertProps, ref: ForwardedRef<HTMLDivElement>) => {
   const [isStacked, setIsStacked] = useState(stacked);
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
   const actionButtonSize = 'sm';
@@ -110,7 +113,7 @@ const Alert = forwardRef(({
   }, [isExtraSmall, stacked]);
 
   const cloneActionElement = useCallback(
-    (Action: React.ReactElement) => {
+    (Action: ReactElement) => {
       const addtlActionProps = { size: actionButtonSize, key: Action.props.children };
       return cloneElement(Action, addtlActionProps);
     },

--- a/src/Annotation/Annotation.test.jsx
+++ b/src/Annotation/Annotation.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import Annotation from '.';

--- a/src/Annotation/index.jsx
+++ b/src/Annotation/index.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Annotation = React.forwardRef(({
+const Annotation = forwardRef(({
   className,
   variant,
   children,

--- a/src/Avatar/Avatar.test.jsx
+++ b/src/Avatar/Avatar.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import Avatar from './index';
 

--- a/src/Avatar/index.jsx
+++ b/src/Avatar/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import defaultAvatar from './default-avatar.svg';

--- a/src/AvatarButton/AvatarButton.test.jsx
+++ b/src/AvatarButton/AvatarButton.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import AvatarButton from '.';
 

--- a/src/AvatarButton/index.jsx
+++ b/src/AvatarButton/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from '../Button';
@@ -10,7 +10,7 @@ const buttonSizesToAvatarSize = {
   lg: 'md',
 };
 
-const AvatarButton = React.forwardRef(({
+const AvatarButton = forwardRef(({
   children,
   className,
   showLabel,

--- a/src/Badge/index.jsx
+++ b/src/Badge/index.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import BaseBadge from 'react-bootstrap/Badge';
 
-const Badge = React.forwardRef((props, ref) => <BaseBadge {...props} ref={ref} />);
+const Badge = forwardRef((props, ref) => <BaseBadge {...props} ref={ref} />);
 
 const STYLE_VARIANTS = [
   'primary',

--- a/src/Breadcrumb/Breadcrumb.test.jsx
+++ b/src/Breadcrumb/Breadcrumb.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Breadcrumb/BreadcrumbLink.jsx
+++ b/src/Breadcrumb/BreadcrumbLink.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -24,7 +24,7 @@ export default function BreadcrumbLink({ as, clickHandler, linkProps }) {
     addtlProps.onClick = clickHandler;
   }
 
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Breadcrumb/index.jsx
+++ b/src/Breadcrumb/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -14,28 +14,30 @@ function Breadcrumb({
   const displayLinks = isMobile ? [links[linkCount - 1]] : links;
 
   return (
-    <nav
-      aria-label={ariaLabel}
-      className={classNames('pgn__breadcrumb', `pgn__breadcrumb-${variant}`)}
-      {...props}
-    >
-      <ol className={classNames('list-inline', { 'is-mobile': isMobile })}>
-        {displayLinks.map((link, i) => (
-          <React.Fragment key={link.label}>
-            <li className={classNames('list-inline-item')}>
-              <BreadcrumbLink as={linkAs} clickHandler={clickHandler} linkProps={link} />
-            </li>
-            {(activeLabel || ((i + 1) < linkCount))
+    (
+      <nav
+        aria-label={ariaLabel}
+        className={classNames('pgn__breadcrumb', `pgn__breadcrumb-${variant}`)}
+        {...props}
+      >
+        <ol className={classNames('list-inline', { 'is-mobile': isMobile })}>
+          {displayLinks.map((link, i) => (
+            <Fragment key={link.label}>
+              <li className={classNames('list-inline-item')}>
+                <BreadcrumbLink as={linkAs} clickHandler={clickHandler} linkProps={link} />
+              </li>
+              {(activeLabel || ((i + 1) < linkCount))
               && (
               <li className="list-inline-item" role="presentation">
                 {spacer || <Icon src={ChevronRight} id={`spacer-${i}`} />}
               </li>
               )}
-          </React.Fragment>
-        ))}
-        {!isMobile && activeLabel && <li className="list-inline-item active" key="active" aria-current="page">{activeLabel}</li>}
-      </ol>
-    </nav>
+            </Fragment>
+          ))}
+          {!isMobile && activeLabel && <li className="list-inline-item active" key="active" aria-current="page">{activeLabel}</li>}
+        </ol>
+      </nav>
+    )
   );
 }
 

--- a/src/Bubble/Bubble.test.tsx
+++ b/src/Bubble/Bubble.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import Bubble from '.';

--- a/src/Bubble/index.tsx
+++ b/src/Bubble/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { ReactNode, ForwardedRef } from 'react';
+import { forwardRef } from 'react';
 import classNames from 'classnames';
 
 export type BubbleVariant = 'primary' | 'success' | 'error' | 'warning';
 
 export interface BubbleProps {
   /** Specifies contents of the component. */
-  children: React.ReactNode;
+  children: ReactNode;
   /** The `Bubble` style variant to use. */
   variant?: BubbleVariant;
   /** Activates disabled variant. */
@@ -16,14 +17,14 @@ export interface BubbleProps {
   expandable?: boolean;
 }
 
-const Bubble = React.forwardRef(({
+const Bubble = forwardRef(({
   variant = 'primary',
   className,
   children = null,
   disabled = false,
   expandable = false,
   ...props
-}: BubbleProps, ref: React.ForwardedRef<HTMLDivElement>) => (
+}: BubbleProps, ref: ForwardedRef<HTMLDivElement>) => (
   <div
     ref={ref}
     className={classNames(

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/Button/ButtonGroup.test.tsx
+++ b/src/Button/ButtonGroup.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Button, { ButtonGroup } from './index';

--- a/src/Button/ButtonToolbar.test.tsx
+++ b/src/Button/ButtonToolbar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 
 import { ButtonToolbar } from './index';

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import type {
+  ElementType, ComponentType, ReactNode, ForwardedRef, AriaRole,
+} from 'react';
+import { forwardRef } from 'react';
 import classNames from 'classnames';
 import BaseButton, { type ButtonProps as BaseButtonProps } from 'react-bootstrap/Button';
 import BaseButtonGroup, { type ButtonGroupProps as BaseButtonGroupProps } from 'react-bootstrap/ButtonGroup';
@@ -29,7 +32,7 @@ type OtherDeprecatedValue = string & {}; // Allow any other string value for now
 
 export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
   /** Set a custom element for this component (default: `button`, with `type="button"`). */
-  as?: React.ElementType;
+  as?: ElementType;
   size?: 'sm' | 'md' | 'lg' | 'inline';
   /**
    * An icon component to render. Example:
@@ -38,7 +41,7 @@ export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
    * <Button iconBefore={Close}>Close</Button>
    * ```
    */
-  iconBefore?: React.ComponentType;
+  iconBefore?: ComponentType;
   /**
    * An icon component to render. Example:
    * ```
@@ -46,7 +49,7 @@ export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
    * <Button iconAfter={Close}>Close</Button>
    * ```
    */
-  iconAfter?: React.ComponentType;
+  iconAfter?: ComponentType;
 
   // The following are the same as in BaseButtonProps, but we re-define them to add documentation.
   // The upstream type defintions do not have any comments/docs.
@@ -56,7 +59,7 @@ export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
   /** Optional: Specify additional class name(s) to apply to the button */
   className?: string;
   /** Specifies the text that is displayed within the button. */
-  children: React.ReactNode;
+  children: ReactNode;
   /** Specifies variant to use.
    * Can be one of the base variants: `primary`, `secondary`, `tertiary`, `brand`, `success`, `danger`, `warning`,
    * `info`, `dark`, `light`, `link`,
@@ -66,13 +69,13 @@ export interface ButtonProps extends Omit<BaseButtonProps, 'size'> {
   variant?: BaseVariant | `inverse-${BaseVariant}` | `outline-${BaseVariant}` | `inverse-outline-${BaseVariant}` | OtherDeprecatedValue;
 }
 
-const Button: ComponentWithAsProp<'button', ButtonProps> = React.forwardRef(({
+const Button: ComponentWithAsProp<'button', ButtonProps> = forwardRef(({
   children,
   iconAfter,
   iconBefore,
   size,
   ...props
-}: ButtonProps, ref: React.ForwardedRef<HTMLDivElement>) => (
+}: ButtonProps, ref: ForwardedRef<HTMLDivElement>) => (
   <BaseButton
     size={size as 'sm' | 'lg' | undefined} // Bootstrap's <Button> types do not allow 'md' or 'inline', but we do.
     {...props}
@@ -91,9 +94,9 @@ const Button: ComponentWithAsProp<'button', ButtonProps> = React.forwardRef(({
 
 interface ButtonGroupProps extends Omit<BaseButtonGroupProps, 'size'> {
   /** Specifies element type for this component. */
-  as?: React.ElementType;
+  as?: ElementType;
   /** An ARIA role describing the button group (default: `group`). */
-  role?: React.AriaRole;
+  role?: AriaRole;
   /** Specifies the size for all Buttons in the group (default: `md`). */
   size?: 'sm' | 'md' | 'lg' | 'inline';
   /** Display as a button toggle group (default: `false`). */
@@ -105,7 +108,7 @@ interface ButtonGroupProps extends Omit<BaseButtonGroupProps, 'size'> {
 }
 
 const ButtonGroup: ComponentWithAsProp<'div', ButtonGroupProps> = (
-  React.forwardRef(({ size = 'md', ...props }: ButtonGroupProps, ref: React.ForwardedRef<HTMLDivElement>) => (
+  forwardRef(({ size = 'md', ...props }: ButtonGroupProps, ref: ForwardedRef<HTMLDivElement>) => (
     <BaseButtonGroup size={size as 'sm' | 'lg'} {...props} ref={ref} />
   ))
 );
@@ -115,13 +118,13 @@ const ButtonGroup: ComponentWithAsProp<'div', ButtonGroupProps> = (
 
 interface ButtonToolbarProps extends BaseButtonToolbarProps {
   /** An ARIA role describing the button group (default: `toolbar`). */
-  role?: React.AriaRole;
+  role?: AriaRole;
   /** Overrides underlying component base CSS class name (default: `btn-toolbar`) */
   bsPrefix?: string;
 }
 
 const ButtonToolbar: ComponentWithAsProp<'div', ButtonToolbarProps> = (
-  React.forwardRef((props: ButtonToolbarProps, ref: React.ForwardedRef<HTMLDivElement>) => (
+  forwardRef((props: ButtonToolbarProps, ref: ForwardedRef<HTMLDivElement>) => (
     <BaseButtonToolbar {...props} ref={ref} />
   ))
 );

--- a/src/Card/BaseCard.tsx
+++ b/src/Card/BaseCard.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -34,11 +35,11 @@ interface Props extends BsPropsWithAs {
   borderColor?: ColorVariant;
   hasBody?: boolean;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 type BaseCardType = ComponentWithAsProp<'div', Props>;
 
-const BaseCard : BaseCardType = React.forwardRef<HTMLDivElement, Props>(
+const BaseCard : BaseCardType = forwardRef<HTMLDivElement, Props>(
   (
     {
       prefix,

--- a/src/Card/CardBody.jsx
+++ b/src/Card/CardBody.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const CardBody = React.forwardRef(({ className, children, ...rest }, ref) => (
+const CardBody = forwardRef(({ className, children, ...rest }, ref) => (
   <div className={classNames('pgn__card-body', className)} ref={ref} {...rest}>
     {children}
   </div>

--- a/src/Card/CardCarousel/CardCarousel.jsx
+++ b/src/Card/CardCarousel/CardCarousel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { OverflowScroll } from '../../OverflowScroll';
 import CardCarouselProvider from './CardCarouselProvider';

--- a/src/Card/CardCarousel/CardCarouselControls.jsx
+++ b/src/Card/CardCarousel/CardCarouselControls.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import Stack from '../../Stack';
 import IconButton from '../../IconButton';

--- a/src/Card/CardCarousel/CardCarouselHeader.jsx
+++ b/src/Card/CardCarousel/CardCarouselHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, isValidElement } from 'react';
+import { useContext, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import CardCarouselTitle from './CardCarouselTitle';
 import CardCarouselSubtitle from './CardCarouselSubtitle';

--- a/src/Card/CardCarousel/CardCarouselItems.jsx
+++ b/src/Card/CardCarousel/CardCarouselItems.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import CardDeck from '../CardDeck';
 import { CardCarouselContext } from './CardCarouselProvider';

--- a/src/Card/CardCarousel/CardCarouselProvider.jsx
+++ b/src/Card/CardCarousel/CardCarouselProvider.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { OverflowScrollContext } from '../../OverflowScroll';
 

--- a/src/Card/CardCarousel/CardCarouselSubtitle.jsx
+++ b/src/Card/CardCarousel/CardCarouselSubtitle.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/Card/CardCarousel/CardCarouselTitle.jsx
+++ b/src/Card/CardCarousel/CardCarouselTitle.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/Card/CardCarousel/tests/CardCarousel.test.jsx
+++ b/src/Card/CardCarousel/tests/CardCarousel.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import renderer from 'react-test-renderer';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/Card/CardCarousel/tests/CardCarouselControls.test.jsx
+++ b/src/Card/CardCarousel/tests/CardCarouselControls.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/Card/CardContext.jsx
+++ b/src/Card/CardContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react';
+import { createContext } from 'react';
 import PropTypes from 'prop-types';
 
 const CardContext = createContext({});

--- a/src/Card/CardDeck.jsx
+++ b/src/Card/CardDeck.jsx
@@ -1,11 +1,11 @@
-import React, { Children, useMemo } from 'react';
+import { forwardRef, Children, useMemo } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import { useOverflowScrollItems } from '../OverflowScroll';
 
-const CardDeck = React.forwardRef(({
+const CardDeck = forwardRef(({
   className,
   children,
   columnSizes,

--- a/src/Card/CardDivider.jsx
+++ b/src/Card/CardDivider.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const CardDivider = React.forwardRef(({ className, ...props }, ref) => (
+const CardDivider = forwardRef(({ className, ...props }, ref) => (
   <div className={classNames('pgn__card-divider', className)} ref={ref} {...props} />
 ));
 

--- a/src/Card/CardFooter.jsx
+++ b/src/Card/CardFooter.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -6,7 +6,7 @@ import CardContext from './CardContext';
 
 const IS_LOADING_HEIGHT_VALUE = 18;
 
-const CardFooter = React.forwardRef(({
+const CardFooter = forwardRef(({
   children,
   className,
   isStacked,

--- a/src/Card/CardGrid.jsx
+++ b/src/Card/CardGrid.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { Children, useMemo } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Row from 'react-bootstrap/Row';
@@ -11,7 +11,7 @@ function CardGrid({
   hasEqualColumnHeights,
 }) {
   const cards = useMemo(
-    () => React.Children.map(children, (card) => (
+    () => Children.map(children, (card) => (
       <Col
         {...columnSizes}
         className={classNames(

--- a/src/Card/CardHeader.jsx
+++ b/src/Card/CardHeader.jsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useContext } from 'react';
+import {
+  forwardRef, isValidElement, cloneElement, useCallback, useContext,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -6,7 +8,7 @@ import CardContext from './CardContext';
 
 const SKELETON_HEIGHT_VALUE = 20;
 
-const CardHeader = React.forwardRef(({
+const CardHeader = forwardRef(({
   actions,
   className,
   size,
@@ -18,13 +20,13 @@ const CardHeader = React.forwardRef(({
   const { isLoading } = useContext(CardContext);
   const cloneActions = useCallback(
     (Action) => {
-      if (React.isValidElement(Action)) {
+      if (isValidElement(Action)) {
         const { children } = Action.props;
         const addtlActionProps = {
           size,
           children: Array.isArray(children) ? children.map(cloneActions) : cloneActions(children),
         };
-        return React.cloneElement(Action, addtlActionProps);
+        return cloneElement(Action, addtlActionProps);
       }
 
       return Action;

--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { forwardRef, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -8,7 +8,7 @@ import { cardSrcFallbackImg } from './CardFallbackDefaultImage';
 const SKELETON_HEIGHT_VALUE = 140;
 const LOGO_SKELETON_HEIGHT_VALUE = 41;
 
-const CardImageCap = React.forwardRef(({
+const CardImageCap = forwardRef(({
   src,
   fallbackSrc,
   srcAlt,

--- a/src/Card/CardSection.jsx
+++ b/src/Card/CardSection.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
@@ -6,7 +6,7 @@ import CardContext from './CardContext';
 
 const SKELETON_HEIGHT_VALUE = 100;
 
-const CardSection = React.forwardRef(({
+const CardSection = forwardRef(({
   className,
   children,
   title,

--- a/src/Card/CardStatus.jsx
+++ b/src/Card/CardStatus.jsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Skeleton from 'react-loading-skeleton';
 import Icon from '../Icon';
 import CardContext from './CardContext';
 
-const CardStatus = React.forwardRef(({
+const CardStatus = forwardRef(({
   className,
   children,
   variant,

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import BaseCard from './BaseCard';
@@ -14,7 +14,7 @@ import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 
 export const CARD_VARIANTS = ['light', 'dark', 'muted'];
 
-const Card = React.forwardRef(({
+const Card = forwardRef(({
   orientation,
   isLoading,
   className,

--- a/src/Card/tests/BaseCard.test.jsx
+++ b/src/Card/tests/BaseCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import BaseCard from '../BaseCard';

--- a/src/Card/tests/CardBody.test.jsx
+++ b/src/Card/tests/CardBody.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import CardBody from '../CardBody';

--- a/src/Card/tests/CardContext.test.jsx
+++ b/src/Card/tests/CardContext.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import { CardContextProvider } from '../CardContext';

--- a/src/Card/tests/CardDeck.test.jsx
+++ b/src/Card/tests/CardDeck.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { v4 as uuidv4 } from 'uuid';
 import CardDeck from '../CardDeck';

--- a/src/Card/tests/CardDivider.test.jsx
+++ b/src/Card/tests/CardDivider.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import CardDivider from '../CardDivider';
 

--- a/src/Card/tests/CardFooter.test.jsx
+++ b/src/Card/tests/CardFooter.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import Button from '../../Button';

--- a/src/Card/tests/CardGrid.test.jsx
+++ b/src/Card/tests/CardGrid.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import CardGrid from '../CardGrid';
 import Card from '..';

--- a/src/Card/tests/CardHeader.test.jsx
+++ b/src/Card/tests/CardHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import Button from '../../Button';

--- a/src/Card/tests/CardImageCap.test.jsx
+++ b/src/Card/tests/CardImageCap.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, fireEvent, screen } from '@testing-library/react';
 import CardImageCap from '../CardImageCap';

--- a/src/Card/tests/CardSection.test.jsx
+++ b/src/Card/tests/CardSection.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import Button from '../../Button';

--- a/src/Card/tests/CardStatus.test.jsx
+++ b/src/Card/tests/CardStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 

--- a/src/Carousel/index.jsx
+++ b/src/Carousel/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import BaseCarousel from 'react-bootstrap/Carousel';
 import BaseCarouselItem from 'react-bootstrap/CarouselItem';
@@ -7,11 +7,11 @@ import BaseCarouselCaption from 'react-bootstrap/CarouselCaption';
 export const CAROUSEL_NEXT_LABEL_TEXT = 'Next';
 export const CAROUSEL_PREV_LABEL_TEXT = 'Previous';
 
-const Carousel = React.forwardRef((props, ref) => <BaseCarousel {...props} ref={ref} />);
+const Carousel = forwardRef((props, ref) => <BaseCarousel {...props} ref={ref} />);
 
-const CarouselItem = React.forwardRef((props, ref) => <BaseCarouselItem {...props} ref={ref} />);
+const CarouselItem = forwardRef((props, ref) => <BaseCarouselItem {...props} ref={ref} />);
 
-const CarouselCaption = React.forwardRef((props, ref) => <BaseCarouselCaption {...props} ref={ref} />);
+const CarouselCaption = forwardRef((props, ref) => <BaseCarouselCaption {...props} ref={ref} />);
 
 Carousel.propTypes = {
   /** Specifies element type for this component. */

--- a/src/Chip/Chip.test.tsx
+++ b/src/Chip/Chip.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ComponentProps } from 'react';
 import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,7 +7,7 @@ import { Close } from '../../icons';
 import { STYLE_VARIANTS } from './constants';
 import Chip from '.';
 
-function TestChip(props: Omit<React.ComponentProps<typeof Chip>, 'children'>) {
+function TestChip(props: Omit<ComponentProps<typeof Chip>, 'children'>) {
   return (
     <Chip {...props}>
       Test

--- a/src/Chip/ChipIcon.tsx
+++ b/src/Chip/ChipIcon.tsx
@@ -1,4 +1,5 @@
-import React, { KeyboardEventHandler, MouseEventHandler } from 'react';
+import type { ComponentType } from 'react';
+import { KeyboardEventHandler, MouseEventHandler } from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';
 import IconButton from '../IconButton';
@@ -6,7 +7,7 @@ import { STYLE_VARIANTS } from './constants';
 
 export type ChipIconProps = {
   className: string,
-  src: React.ComponentType,
+  src: ComponentType,
   variant: typeof STYLE_VARIANTS[keyof typeof STYLE_VARIANTS],
   disabled?: boolean,
 } & (

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -1,4 +1,7 @@
-import React, { ForwardedRef, KeyboardEventHandler, MouseEventHandler } from 'react';
+import type { ReactNode, ComponentType } from 'react';
+import {
+  forwardRef, ForwardedRef, KeyboardEventHandler, MouseEventHandler,
+} from 'react';
 import PropTypes, { type Requireable } from 'prop-types';
 import classNames from 'classnames';
 // @ts-ignore
@@ -9,13 +12,13 @@ import ChipIcon from './ChipIcon';
 export const CHIP_PGN_CLASS = 'pgn__chip';
 
 export interface IChip {
-  children: React.ReactNode,
+  children: ReactNode,
   onClick?: KeyboardEventHandler & MouseEventHandler,
   className?: string,
   variant?: typeof STYLE_VARIANTS[keyof typeof STYLE_VARIANTS],
-  iconBefore?: React.ComponentType,
+  iconBefore?: ComponentType,
   iconBeforeAlt?: string,
-  iconAfter?: React.ComponentType,
+  iconAfter?: ComponentType,
   iconAfterAlt?: string,
   onIconBeforeClick?: KeyboardEventHandler & MouseEventHandler,
   onIconAfterClick?: KeyboardEventHandler & MouseEventHandler,
@@ -23,7 +26,7 @@ export interface IChip {
   isSelected?: boolean,
 }
 
-const Chip = React.forwardRef(({
+const Chip = forwardRef(({
   children,
   className,
   variant,
@@ -110,7 +113,7 @@ Chip.propTypes = {
    *
    * `import { Check } from '@openedx/paragon/icons';`
    */
-  iconBefore: PropTypes.elementType as Requireable<React.ComponentType>,
+  iconBefore: PropTypes.elementType as Requireable<ComponentType>,
   /** Specifies icon alt text. */
   iconBeforeAlt: requiredWhen(PropTypes.string, ['iconBefore', 'onIconBeforeClick']),
   /** A click handler for the `Chip` icon before. */
@@ -121,7 +124,7 @@ Chip.propTypes = {
    *
    * `import { Check } from '@openedx/paragon/icons';`
    */
-  iconAfter: PropTypes.elementType as Requireable<React.ComponentType>,
+  iconAfter: PropTypes.elementType as Requireable<ComponentType>,
   /** Specifies icon alt text. */
   iconAfterAlt: requiredWhen(PropTypes.string, ['iconAfter', 'onIconAfterClick']),
   /** A click handler for the `Chip` icon after. */

--- a/src/ChipCarousel/ChipCarousel.test.jsx
+++ b/src/ChipCarousel/ChipCarousel.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';

--- a/src/ChipCarousel/index.tsx
+++ b/src/ChipCarousel/index.tsx
@@ -1,4 +1,5 @@
-import React, { ForwardedRef } from 'react';
+import type { ReactElement } from 'react';
+import { forwardRef, createElement, ForwardedRef } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
@@ -22,7 +23,7 @@ export interface OverflowScrollContextProps {
 
 export interface ChipCarouselProps {
   className?: string;
-  items: Array<React.ReactElement>;
+  items: Array<ReactElement>;
   ariaLabel: string;
   disableOpacityMasks?: boolean;
   onScrollPrevious?: () => void;
@@ -33,7 +34,7 @@ export interface ChipCarouselProps {
   gap?: number;
 }
 
-const ChipCarousel = React.forwardRef(({
+const ChipCarousel = forwardRef(({
   className,
   items,
   ariaLabel,
@@ -49,32 +50,33 @@ const ChipCarousel = React.forwardRef(({
   const intl = useIntl();
 
   return (
-    <div
-      className={classNames('pgn__chip-carousel', className, gap ? `pgn__chip-carousel-gap__${gap}` : '')}
-      {...props}
-      ref={ref}
-    >
-      <OverflowScroll
-        ariaLabel={ariaLabel}
-        hasInteractiveChildren
-        disableScroll={!canScrollHorizontal}
-        disableOpacityMasks={disableOpacityMasks}
-        onScrollPrevious={onScrollPrevious}
-        onScrollNext={onScrollNext}
-        offset={offset}
-        offsetType={offsetType}
+    (
+      <div
+        className={classNames('pgn__chip-carousel', className, gap ? `pgn__chip-carousel-gap__${gap}` : '')}
+        {...props}
+        ref={ref}
       >
-        <OverflowScrollContext.Consumer>
-          {({
-            setOverflowRef,
-            isScrolledToStart,
-            isScrolledToEnd,
-            scrollToPrevious,
-            scrollToNext,
-          }: OverflowScrollContextProps) => (
-            <>
+        <OverflowScroll
+          ariaLabel={ariaLabel}
+          hasInteractiveChildren
+          disableScroll={!canScrollHorizontal}
+          disableOpacityMasks={disableOpacityMasks}
+          onScrollPrevious={onScrollPrevious}
+          onScrollNext={onScrollNext}
+          offset={offset}
+          offsetType={offsetType}
+        >
+          <OverflowScrollContext.Consumer>
+            {({
+              setOverflowRef,
+              isScrolledToStart,
+              isScrolledToEnd,
+              scrollToPrevious,
+              scrollToNext,
+            }: OverflowScrollContextProps) => (
               <>
-                {!isScrolledToStart && (
+                <>
+                  {!isScrolledToStart && (
                   <IconButton
                     size="sm"
                     className="pgn__chip-carousel__left-control"
@@ -83,8 +85,8 @@ const ChipCarousel = React.forwardRef(({
                     alt={intl.formatMessage(messages.scrollToPrevious)}
                     onClick={scrollToPrevious}
                   />
-                )}
-                {!isScrolledToEnd && (
+                  )}
+                  {!isScrolledToEnd && (
                   <IconButton
                     size="sm"
                     className="pgn__chip-carousel__right-control"
@@ -93,25 +95,26 @@ const ChipCarousel = React.forwardRef(({
                     alt={intl.formatMessage(messages.scrollToNext)}
                     onClick={scrollToNext}
                   />
-                )}
+                  )}
+                </>
+                <div ref={setOverflowRef} className="d-flex">
+                  <OverflowScroll.Items>
+                    {items?.map((item, id) => {
+                      const { children } = item?.props || {};
+                      if (!children) {
+                        return null;
+                      }
+                      // eslint-disable-next-line react/no-array-index-key
+                      return createElement(Chip, { ...item.props, key: id });
+                    })}
+                  </OverflowScroll.Items>
+                </div>
               </>
-              <div ref={setOverflowRef} className="d-flex">
-                <OverflowScroll.Items>
-                  {items?.map((item, id) => {
-                    const { children } = item?.props || {};
-                    if (!children) {
-                      return null;
-                    }
-                    // eslint-disable-next-line react/no-array-index-key
-                    return React.createElement(Chip, { ...item.props, key: id });
-                  })}
-                </OverflowScroll.Items>
-              </div>
-            </>
-          )}
-        </OverflowScrollContext.Consumer>
-      </OverflowScroll>
-    </div>
+            )}
+          </OverflowScrollContext.Consumer>
+        </OverflowScroll>
+      </div>
+    )
   );
 });
 

--- a/src/Collapsible/Collapsible.test.jsx
+++ b/src/Collapsible/Collapsible.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createRef } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';
@@ -69,7 +69,7 @@ describe('<Collapsible />', () => {
   });
 
   describe('Imperative Methods', () => {
-    const ref = React.createRef();
+    const ref = createRef();
     beforeEach(() => {
       render(
         <Collapsible.Advanced ref={ref}>{collapsibleContent}</Collapsible.Advanced>,
@@ -117,7 +117,7 @@ describe('<Collapsible />', () => {
 
   describe('Mouse Interactions', () => {
     let collapsible;
-    const ref = React.createRef();
+    const ref = createRef();
     beforeEach(() => {
       render(
         <Collapsible.Advanced ref={ref}>{collapsibleContent}</Collapsible.Advanced>,
@@ -167,7 +167,7 @@ describe('<Collapsible />', () => {
 
   describe('Keyboard Interactions', () => {
     let collapsible;
-    const ref = React.createRef();
+    const ref = createRef();
     beforeEach(() => {
       render(
         <Collapsible.Advanced ref={ref}>{collapsibleContent}</Collapsible.Advanced>,

--- a/src/Collapsible/CollapsibleAdvanced.jsx
+++ b/src/Collapsible/CollapsibleAdvanced.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { createContext, Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-export const CollapsibleContext = React.createContext();
+export const CollapsibleContext = createContext();
 
-class CollapsibleAdvanced extends React.Component {
+class CollapsibleAdvanced extends Component {
   static getDerivedStateFromProps(props) {
     if (props.open !== undefined) {
       return {

--- a/src/Collapsible/CollapsibleBody.jsx
+++ b/src/Collapsible/CollapsibleBody.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { createElement, cloneElement, useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import Collapse from '../Collapse';
@@ -13,11 +13,11 @@ function CollapsibleBody({
   // Keys are added to these elements so that TransitionReplace
   // will recognize them as unique components and perform the
   // transition properly.
-  const content = React.createElement(tag, { key: 'body', ...props }, children);
+  const content = createElement(tag, { key: 'body', ...props }, children);
   const transitionBody = isOpen ? content : <div key="empty" />;
 
   if (transitionWrapper) {
-    return React.cloneElement(transitionWrapper, {}, transitionBody);
+    return cloneElement(transitionWrapper, {}, transitionBody);
   }
   /* istanbul ignore next */
   return unmountOnExit

--- a/src/Collapsible/CollapsibleTrigger.jsx
+++ b/src/Collapsible/CollapsibleTrigger.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import { createElement, useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { CollapsibleContext } from './CollapsibleAdvanced';
@@ -36,7 +36,7 @@ function CollapsibleTrigger({
     }
   }, [onKeyDown, handleToggle]);
 
-  return React.createElement(
+  return createElement(
     tag,
     {
       ...props,

--- a/src/Collapsible/CollapsibleVisible.jsx
+++ b/src/Collapsible/CollapsibleVisible.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { CollapsibleContext } from './CollapsibleAdvanced';

--- a/src/Collapsible/index.jsx
+++ b/src/Collapsible/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef, isValidElement } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -17,7 +17,7 @@ const styleIcons = {
   // card and card-lg use the defaults specified in defaultProps
 };
 
-const Collapsible = React.forwardRef((props, ref) => {
+const Collapsible = forwardRef((props, ref) => {
   const {
     children,
     className,
@@ -29,7 +29,7 @@ const Collapsible = React.forwardRef((props, ref) => {
   } = props;
 
   const icons = { iconWhenClosed, iconWhenOpen, ...styleIcons[styling] };
-  const titleElement = React.isValidElement(title) ? title : <span>{title}</span>;
+  const titleElement = isValidElement(title) ? title : <span>{title}</span>;
 
   return (
     <Collapsible.Advanced

--- a/src/ColorPicker/ColorPicker.test.jsx
+++ b/src/ColorPicker/ColorPicker.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';

--- a/src/ColorPicker/index.jsx
+++ b/src/ColorPicker/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { HexColorPicker } from 'react-colorful';
@@ -14,7 +14,7 @@ function ColorPicker({
   color, setColor, className, size,
 }) {
   const [isOpen, open, close] = useToggle(false);
-  const [target, setTarget] = React.useState(null);
+  const [target, setTarget] = useState(null);
 
   const colorIsValid = (colorToValidate) => {
     const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
@@ -29,16 +29,16 @@ function ColorPicker({
     return colorString.slice(0, 7);
   };
 
-  const [hexValid, setHexValid] = React.useState(() => (color === '' || colorIsValid(formatHexColorString(color))));
+  const [hexValid, setHexValid] = useState(() => (color === '' || colorIsValid(formatHexColorString(color))));
 
-  const [hexColorString, setHexColorString] = React.useState(() => {
+  const [hexColorString, setHexColorString] = useState(() => {
     if (color === '') {
       return '';
     }
 
     return formatHexColorString(color);
   });
-  const [colorToDisplay, setColorToDisplay] = React.useState(() => {
+  const [colorToDisplay, setColorToDisplay] = useState(() => {
     const formattedColor = formatHexColorString(color);
     if (colorIsValid(formattedColor)) {
       return formattedColor;

--- a/src/Container/Container.test.tsx
+++ b/src/Container/Container.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Container, { type ContainerSize } from '.';
 

--- a/src/Container/index.tsx
+++ b/src/Container/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/require-default-props */
-import React from 'react';
+import { forwardRef } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import RBContainer, { type ContainerProps as RBContainerProps } from 'react-bootstrap/Container';
@@ -22,7 +22,7 @@ interface ContainerProps extends RBContainerProps {
 
 type ContainerType = ComponentWithAsProp<'div', ContainerProps>;
 
-const Container: ContainerType = React.forwardRef<Element, ContainerProps>(({
+const Container: ContainerType = forwardRef<Element, ContainerProps>(({
   size,
   children,
   ...props

--- a/src/DataTable/ActionDisplay.jsx
+++ b/src/DataTable/ActionDisplay.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import BulkActions from './BulkActions';
 import TableActions from './TableActions';
 import DataTableContext from './DataTableContext';

--- a/src/DataTable/BulkActions.jsx
+++ b/src/DataTable/BulkActions.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/DataTable/CardView.jsx
+++ b/src/DataTable/CardView.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/DataTable/CollapsibleButtonGroup.jsx
+++ b/src/DataTable/CollapsibleButtonGroup.jsx
@@ -1,4 +1,6 @@
-import React, { useContext, useMemo, useState } from 'react';
+import {
+  cloneElement, useContext, useMemo, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 
 import { MoreVert } from '../../icons';
@@ -48,7 +50,7 @@ function CollapsibleButtonGroup({
     return null;
   }
 
-  const cloneAction = (action, index) => React.cloneElement(
+  const cloneAction = (action, index) => cloneElement(
     action.component,
     {
       // eslint-disable-next-line react/no-array-index-key

--- a/src/DataTable/DataTableLayout.jsx
+++ b/src/DataTable/DataTableLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { GridView, ListView } from '../../icons';
 import DataTableContext from './DataTableContext';
 import Icon from '../Icon';

--- a/src/DataTable/DropdownFilters.jsx
+++ b/src/DataTable/DropdownFilters.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import DataTableContext from './DataTableContext';
 import { DropdownButton } from '../Dropdown';

--- a/src/DataTable/EmptyTable.jsx
+++ b/src/DataTable/EmptyTable.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import DataTableContext from './DataTableContext';

--- a/src/DataTable/ExpandAll.jsx
+++ b/src/DataTable/ExpandAll.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import Button from '../Button';

--- a/src/DataTable/ExpandRow.jsx
+++ b/src/DataTable/ExpandRow.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { ExpandLess, ExpandMore } from '../../icons';
 import Icon from '../Icon';

--- a/src/DataTable/FilterStatus.jsx
+++ b/src/DataTable/FilterStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import DataTableContext from './DataTableContext';

--- a/src/DataTable/RowStatus.jsx
+++ b/src/DataTable/RowStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import DataTableContext from './DataTableContext';

--- a/src/DataTable/SidebarFilters.jsx
+++ b/src/DataTable/SidebarFilters.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/DataTable/SmartStatus.jsx
+++ b/src/DataTable/SmartStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import DataTableContext from './DataTableContext';
 import FilterStatusDefault from './FilterStatus';
 import RowStatusDefault from './RowStatus';

--- a/src/DataTable/Table.jsx
+++ b/src/DataTable/Table.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Spinner from '../Spinner';

--- a/src/DataTable/TableActions.jsx
+++ b/src/DataTable/TableActions.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/DataTable/TableCell.jsx
+++ b/src/DataTable/TableCell.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/DataTable/TableFilters.jsx
+++ b/src/DataTable/TableFilters.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Button';
 

--- a/src/DataTable/TableFooter.jsx
+++ b/src/DataTable/TableFooter.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import DataTableContext from './DataTableContext';

--- a/src/DataTable/TableHeaderCell.jsx
+++ b/src/DataTable/TableHeaderCell.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../Icon';

--- a/src/DataTable/TableHeaderRow.jsx
+++ b/src/DataTable/TableHeaderRow.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import TableHeaderCell from './TableHeaderCell';
 

--- a/src/DataTable/TablePagination.jsx
+++ b/src/DataTable/TablePagination.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import DataTableContext from './DataTableContext';
 import Pagination from '../Pagination';

--- a/src/DataTable/TablePaginationMinimal.jsx
+++ b/src/DataTable/TablePaginationMinimal.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import DataTableContext from './DataTableContext';
 import Pagination from '../Pagination';

--- a/src/DataTable/TableRow.jsx
+++ b/src/DataTable/TableRow.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useMemo } from 'react';
+import { useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Form, { FormLabel } from '../../Form';
 import Badge from '../../Badge';

--- a/src/DataTable/filters/DropdownFilter.jsx
+++ b/src/DataTable/filters/DropdownFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Form from '../../Form';
 import { newId } from '../../utils';

--- a/src/DataTable/filters/MultiSelectDropdownFilter.jsx
+++ b/src/DataTable/filters/MultiSelectDropdownFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Badge from '../../Badge';
 import Stack from '../../Stack';

--- a/src/DataTable/filters/TextFilter.jsx
+++ b/src/DataTable/filters/TextFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { isValidElement, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Form from '../../Form';
 import { newId } from '../../utils';
@@ -20,7 +20,7 @@ function TextFilter({
 }) {
   const ariaLabel = useRef(newId(`text-filter-label-${getHeaderProps().key}-`));
   const formattedHeader = formatHeaderForLabel(Header);
-  const inputText = React.isValidElement(formattedHeader) ? formattedHeader : `Search ${formattedHeader}`;
+  const inputText = isValidElement(formattedHeader) ? formattedHeader : `Search ${formattedHeader}`;
   return (
     <Form.Group controlId={ariaLabel.current}>
       <Form.Label className="sr-only">{inputText}</Form.Label>

--- a/src/DataTable/filters/tests/CheckboxFilter.test.jsx
+++ b/src/DataTable/filters/tests/CheckboxFilter.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/DataTable/filters/tests/DropdownFilter.test.jsx
+++ b/src/DataTable/filters/tests/DropdownFilter.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/DataTable/filters/tests/MultiSelectDropdownFilter.test.jsx
+++ b/src/DataTable/filters/tests/MultiSelectDropdownFilter.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/DataTable/filters/tests/TextFilter.test.jsx
+++ b/src/DataTable/filters/tests/TextFilter.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import TextFilter from '../TextFilter';

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -1,6 +1,4 @@
-import React, {
-  useEffect, useMemo, useReducer,
-} from 'react';
+import { useEffect, useMemo, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { useTable, useMountedLayoutEffect } from 'react-table';
 

--- a/src/DataTable/selection/BaseSelectionStatus.jsx
+++ b/src/DataTable/selection/BaseSelectionStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/DataTable/selection/ControlledSelect.jsx
+++ b/src/DataTable/selection/ControlledSelect.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { CheckboxControl } from '../../Form';

--- a/src/DataTable/selection/ControlledSelectHeader.jsx
+++ b/src/DataTable/selection/ControlledSelectHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useCallback } from 'react';
+import { useContext, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { CheckboxControl } from '../../Form';

--- a/src/DataTable/selection/ControlledSelectionStatus.jsx
+++ b/src/DataTable/selection/ControlledSelectionStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import DataTableContext from '../DataTableContext';

--- a/src/DataTable/selection/SelectionStatus.jsx
+++ b/src/DataTable/selection/SelectionStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import DataTableContext from '../DataTableContext';

--- a/src/DataTable/selection/tests/ControlledSelect.test.jsx
+++ b/src/DataTable/selection/tests/ControlledSelect.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/DataTable/selection/tests/ControlledSelectHeader.test.jsx
+++ b/src/DataTable/selection/tests/ControlledSelectHeader.test.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/ControlledSelectionStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';

--- a/src/DataTable/selection/tests/SelectionStatus.test.jsx
+++ b/src/DataTable/selection/tests/SelectionStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';

--- a/src/DataTable/tests/ActionDisplay.test.jsx
+++ b/src/DataTable/tests/ActionDisplay.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import ActionDisplay from '../ActionDisplay';

--- a/src/DataTable/tests/BulkActions.test.jsx
+++ b/src/DataTable/tests/BulkActions.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/DataTable/tests/CardView.test.jsx
+++ b/src/DataTable/tests/CardView.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { selectColumn } from '../utils/getVisibleColumns';
 import CardView, { DEFAULT_SKELETON_CARD_COUNT } from '../CardView';

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as reactTable from 'react-table';

--- a/src/DataTable/tests/DataViewToggle.test.jsx
+++ b/src/DataTable/tests/DataViewToggle.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import userEvent from '@testing-library/user-event';

--- a/src/DataTable/tests/DropdownFilters.test.jsx
+++ b/src/DataTable/tests/DropdownFilters.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';

--- a/src/DataTable/tests/EmptyTable.test.jsx
+++ b/src/DataTable/tests/EmptyTable.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import EmptyTableContent from '../EmptyTable';

--- a/src/DataTable/tests/ExpandAll.test.jsx
+++ b/src/DataTable/tests/ExpandAll.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 

--- a/src/DataTable/tests/ExpandRow.test.jsx
+++ b/src/DataTable/tests/ExpandRow.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import ExpandRow from '../ExpandRow';

--- a/src/DataTable/tests/FilterStatus.test.jsx
+++ b/src/DataTable/tests/FilterStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';

--- a/src/DataTable/tests/RowStatus.test.jsx
+++ b/src/DataTable/tests/RowStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 

--- a/src/DataTable/tests/SmartStatus.test.jsx
+++ b/src/DataTable/tests/SmartStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 

--- a/src/DataTable/tests/Table.test.jsx
+++ b/src/DataTable/tests/Table.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import Table from '../Table';

--- a/src/DataTable/tests/TableActions.test.jsx
+++ b/src/DataTable/tests/TableActions.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import classNames from 'classnames';

--- a/src/DataTable/tests/TableCell.test.jsx
+++ b/src/DataTable/tests/TableCell.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import TableCell from '../TableCell';

--- a/src/DataTable/tests/TableFooter.test.jsx
+++ b/src/DataTable/tests/TableFooter.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 

--- a/src/DataTable/tests/TableHeaderCell.test.jsx
+++ b/src/DataTable/tests/TableHeaderCell.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import TableHeaderCell from '../TableHeaderCell';

--- a/src/DataTable/tests/TableHeaderRow.test.jsx
+++ b/src/DataTable/tests/TableHeaderRow.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import TableHeaderRow from '../TableHeaderRow';

--- a/src/DataTable/tests/TablePagination.test.jsx
+++ b/src/DataTable/tests/TablePagination.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, act, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';

--- a/src/DataTable/tests/TableRow.test.jsx
+++ b/src/DataTable/tests/TableRow.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import TableRow from '../TableRow';

--- a/src/DataTable/utils/getVisibleColumns.jsx
+++ b/src/DataTable/utils/getVisibleColumns.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useContext, useEffect } from 'react';
+import { useMemo, useContext, useEffect } from 'react';
 
 import { CheckboxControl } from '../../Form';
 import DataTableContext from '../DataTableContext';

--- a/src/DataTable/utils/tests/selectColumn.test.jsx
+++ b/src/DataTable/utils/tests/selectColumn.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   act, waitFor, render, fireEvent,
 } from '@testing-library/react';

--- a/src/Dropdown/Dropdown.test.jsx
+++ b/src/Dropdown/Dropdown.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   render, screen, waitFor, act,
 } from '@testing-library/react';

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef, useState } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import BaseDropdown from 'react-bootstrap/Dropdown';
@@ -8,7 +8,7 @@ import BaseDropdownToggle from 'react-bootstrap/DropdownToggle';
 import Button from '../Button';
 import IconButton from '../IconButton';
 
-const Dropdown = React.forwardRef(
+const Dropdown = forwardRef(
   // eslint-disable-next-line prefer-arrow-callback
   function Dropdown({
     show,
@@ -18,7 +18,7 @@ const Dropdown = React.forwardRef(
     className,
     ...rest
   }, ref) {
-    const [internalShow, setInternalShow] = React.useState(show);
+    const [internalShow, setInternalShow] = useState(show);
     const isClosingPermitted = (source) => {
       // autoClose=false only permits close on button click
       if (autoClose === false) {
@@ -88,7 +88,7 @@ Dropdown.defaultProps = {
   variant: 'light',
 };
 
-const DropdownToggle = React.forwardRef(
+const DropdownToggle = forwardRef(
   // eslint-disable-next-line prefer-arrow-callback
   function DropdownToggle({
     as,
@@ -116,7 +116,7 @@ DropdownToggle.defaultProps = {
   bsPrefix: 'dropdown-toggle',
 };
 
-Dropdown.Item = React.forwardRef(
+Dropdown.Item = forwardRef(
   // eslint-disable-next-line prefer-arrow-callback
   function DropdownItem({ className, ...otherProps }, ref) {
     return (

--- a/src/Dropzone/DefaultContent.jsx
+++ b/src/Dropzone/DefaultContent.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { getTypesString, formatBytes } from './utils';

--- a/src/Dropzone/DragError.jsx
+++ b/src/Dropzone/DragError.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 function DragError({ message }) {

--- a/src/Dropzone/GenericError.jsx
+++ b/src/Dropzone/GenericError.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Alert from '../Alert';
 import { Info } from '../../icons';

--- a/src/Dropzone/UploadProgress.jsx
+++ b/src/Dropzone/UploadProgress.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import Button from '../Button';

--- a/src/Dropzone/index.jsx
+++ b/src/Dropzone/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useDropzone, ErrorCode } from 'react-dropzone';

--- a/src/Dropzone/tests/DefaultContent.test.jsx
+++ b/src/Dropzone/tests/DefaultContent.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from 'react-intl';
 import { render } from '@testing-library/react';

--- a/src/Dropzone/tests/DragError.test.jsx
+++ b/src/Dropzone/tests/DragError.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import DragError from '../DragError';

--- a/src/Dropzone/tests/Dropzone.test.jsx
+++ b/src/Dropzone/tests/Dropzone.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from 'react-intl';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';

--- a/src/Dropzone/tests/GenericError.test.jsx
+++ b/src/Dropzone/tests/GenericError.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 

--- a/src/Dropzone/tests/UploadProgress.test.jsx
+++ b/src/Dropzone/tests/UploadProgress.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';

--- a/src/Form/FormAutosuggest.jsx
+++ b/src/Form/FormAutosuggest.jsx
@@ -1,5 +1,11 @@
-import React, {
-  useEffect, useState, useRef, forwardRef, useImperativeHandle,
+import {
+  Children,
+  cloneElement,
+  useEffect,
+  useState,
+  useRef,
+  forwardRef,
+  useImperativeHandle,
 } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -86,11 +92,11 @@ const FormAutosuggest = forwardRef(
     };
 
     function getItems(strToFind = '') {
-      let childrenOpt = React.Children.map(children, (child) => {
+      let childrenOpt = Children.map(children, (child) => {
         const { children: childChildren, onClick, ...rest } = child.props;
         const menuItemId = child.props.id ?? uuidv4();
 
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           ...rest,
           children: childChildren,
           'data-value': childChildren,

--- a/src/Form/FormAutosuggestOption.jsx
+++ b/src/Form/FormAutosuggestOption.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import MenuItem from '../Menu/MenuItem';

--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import {
+  forwardRef, useRef, useEffect, createElement,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useCheckboxSetContext } from './FormCheckboxSetContext';
@@ -6,10 +8,10 @@ import { FormGroupContextProvider, useFormGroupContext } from './FormGroupContex
 import FormLabel from './FormLabel';
 import FormControlFeedback from './FormControlFeedback';
 
-const CheckboxControl = React.forwardRef(
+const CheckboxControl = forwardRef(
   ({ isIndeterminate, ...props }, ref) => {
     const { getCheckboxControlProps, hasCheckboxSetProvider } = useCheckboxSetContext();
-    const defaultRef = React.useRef();
+    const defaultRef = useRef();
     const resolvedRef = ref || defaultRef;
     const { getControlProps } = useFormGroupContext();
     let checkboxProps = getControlProps({
@@ -21,7 +23,7 @@ const CheckboxControl = React.forwardRef(
       checkboxProps = getCheckboxControlProps(checkboxProps);
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
       // this if(resolvedRef.current) prevents console errors in testing
       if (resolvedRef.current) {
         resolvedRef.current.indeterminate = isIndeterminate;
@@ -50,7 +52,7 @@ CheckboxControl.defaultProps = {
   className: undefined,
 };
 
-const FormCheckbox = React.forwardRef(({
+const FormCheckbox = forwardRef(({
   children,
   className,
   controlClassName,
@@ -71,7 +73,7 @@ const FormCheckbox = React.forwardRef(({
     role: 'group',
   } : {};
 
-  const control = React.createElement(controlAs, { ...props, className: controlClassName, ref });
+  const control = createElement(controlAs, { ...props, className: controlClassName, ref });
   return (
     <FormGroupContextProvider
       controlId={props.id}

--- a/src/Form/FormCheckboxSet.jsx
+++ b/src/Form/FormCheckboxSet.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useFormGroupContext } from './FormGroupContext';
 import { FormCheckboxSetContextProvider } from './FormCheckboxSetContext';

--- a/src/Form/FormCheckboxSetContext.jsx
+++ b/src/Form/FormCheckboxSetContext.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { callAllHandlers } from './fieldUtils';
 
 const identityFn = props => props;
 
-const FormCheckboxSetContext = React.createContext({
+const FormCheckboxSetContext = createContext({
   getCheckboxControlProps: identityFn,
   hasCheckboxSetProvider: false,
 });

--- a/src/Form/FormControlDecorator.jsx
+++ b/src/Form/FormControlDecorator.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 function FormControlDecorator({ children, location }) {

--- a/src/Form/FormControlDecoratorGroup.jsx
+++ b/src/Form/FormControlDecoratorGroup.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useFormGroupContext } from './FormGroupContext';

--- a/src/Form/FormControlFeedback.jsx
+++ b/src/Form/FormControlFeedback.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useFormGroupContext } from './FormGroupContext';

--- a/src/Form/FormControlFloatingLabel.jsx
+++ b/src/Form/FormControlFloatingLabel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useFormGroupContext } from './FormGroupContext';
 

--- a/src/Form/FormControlSet.jsx
+++ b/src/Form/FormControlSet.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -9,7 +9,7 @@ function FormControlSet({
   children,
   ...props
 }) {
-  return React.createElement(as, {
+  return createElement(as, {
     className: classNames(
       className,
       {

--- a/src/Form/FormGroup.tsx
+++ b/src/Form/FormGroup.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import type { ElementType, ReactNode, ComponentPropsWithoutRef } from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FormGroupContextProvider } from './FormGroupContext';
 import { FORM_CONTROL_SIZES } from './constants';
 
-interface Props<As extends React.ElementType> {
+interface Props<As extends ElementType> {
   /** Specifies contents of the component. */
-  children: React.ReactNode;
+  children: ReactNode;
   /** Specifies class name to append to the base element. */
   className?: string;
   /** Specifies base element for the component. */
@@ -22,7 +23,7 @@ interface Props<As extends React.ElementType> {
   size?: typeof FORM_CONTROL_SIZES.SMALL | typeof FORM_CONTROL_SIZES.LARGE;
 }
 
-function FormGroup<As extends React.ElementType = 'div'>({
+function FormGroup<As extends ElementType = 'div'>({
   children,
   controlId,
   isInvalid = false,
@@ -30,8 +31,8 @@ function FormGroup<As extends React.ElementType = 'div'>({
   size,
   as,
   ...props
-}: Props<As> & React.ComponentPropsWithoutRef<As>) {
-  return React.createElement(
+}: Props<As> & ComponentPropsWithoutRef<As>) {
+  return createElement(
     as ?? 'div',
     {
       ...props,

--- a/src/Form/FormGroupContext.tsx
+++ b/src/Form/FormGroupContext.tsx
@@ -1,5 +1,6 @@
-import React, {
-  useState, useEffect, useMemo, useCallback,
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import {
+  createContext, useContext, useState, useEffect, useMemo, useCallback,
 } from 'react';
 import classNames from 'classnames';
 import { newId } from '../utils';
@@ -11,7 +12,7 @@ const noop = () => {};
 
 interface FormGroupContextData {
   getControlProps: (props: Record<string, any>) => Record<string, any>;
-  getLabelProps: (props: React.ComponentPropsWithoutRef<'label'>) => React.ComponentPropsWithoutRef<'label'>;
+  getLabelProps: (props: ComponentPropsWithoutRef<'label'>) => ComponentPropsWithoutRef<'label'>;
   getDescriptorProps: (props: Record<string, any>) => Record<string, any>;
   useSetIsControlGroupEffect: (isControlGroup: boolean) => void;
   isControlGroup?: boolean;
@@ -22,7 +23,7 @@ interface FormGroupContextData {
   hasFormGroupProvider?: boolean;
 }
 
-const FormGroupContext = React.createContext<FormGroupContextData>({
+const FormGroupContext = createContext<FormGroupContextData>({
   getControlProps: identityFn,
   useSetIsControlGroupEffect: noop,
   getLabelProps: identityFn,
@@ -30,7 +31,7 @@ const FormGroupContext = React.createContext<FormGroupContextData>({
   hasFormGroupProvider: false,
 });
 
-const useFormGroupContext = () => React.useContext(FormGroupContext);
+const useFormGroupContext = () => useContext(FormGroupContext);
 
 function useStateEffect<ValueType extends any>(
   initialState: ValueType,
@@ -49,7 +50,7 @@ function FormGroupContextProvider({
   isValid,
   size,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   controlId?: string;
   isInvalid?: boolean;
   isValid?: boolean;
@@ -82,7 +83,7 @@ function FormGroupContextProvider({
     controlId,
   ]);
 
-  const getLabelProps = (labelProps: React.ComponentPropsWithoutRef<'label'>) => {
+  const getLabelProps = (labelProps: ComponentPropsWithoutRef<'label'>) => {
     const id = registerLabelerId(labelProps?.id);
     if (isControlGroup) {
       return { ...labelProps, id };

--- a/src/Form/FormLabel.tsx
+++ b/src/Form/FormLabel.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode, ComponentPropsWithoutRef } from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useFormGroupContext } from './FormGroupContext';
@@ -6,12 +7,12 @@ import { FORM_CONTROL_SIZES } from './constants';
 
 interface Props {
   /** Specifies contents of the component. */
-  children: React.ReactNode;
+  children: ReactNode;
   /** Specifies whether the component should be displayed with inline styling. */
   isInline?: boolean;
 }
 
-function FormLabel({ children, isInline = false, ...props }: Props & React.ComponentPropsWithoutRef<'label'>) {
+function FormLabel({ children, isInline = false, ...props }: Props & ComponentPropsWithoutRef<'label'>) {
   const { size, isControlGroup, getLabelProps } = useFormGroupContext();
   const className = classNames(
     'pgn__form-label',
@@ -24,7 +25,7 @@ function FormLabel({ children, isInline = false, ...props }: Props & React.Compo
   );
   const labelProps = getLabelProps({ ...props, className });
   const componentType = isControlGroup ? 'p' : 'label';
-  return React.createElement(componentType, labelProps, children);
+  return createElement(componentType, labelProps, children);
 }
 
 FormLabel.propTypes = {

--- a/src/Form/FormRadio.jsx
+++ b/src/Form/FormRadio.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useRadioSetContext } from './FormRadioSetContext';
@@ -6,7 +6,7 @@ import { FormGroupContextProvider, useFormGroupContext } from './FormGroupContex
 import FormLabel from './FormLabel';
 import FormControlFeedback from './FormControlFeedback';
 
-const RadioControl = React.forwardRef((props, ref) => {
+const RadioControl = forwardRef((props, ref) => {
   const { getControlProps } = useFormGroupContext();
   const { getRadioControlProps, hasRadioSetProvider } = useRadioSetContext();
   let radioProps = getControlProps({
@@ -31,7 +31,7 @@ RadioControl.defaultProps = {
   className: undefined,
 };
 
-const FormRadio = React.forwardRef(({
+const FormRadio = forwardRef(({
   children,
   className,
   controlClassName,

--- a/src/Form/FormRadioSet.jsx
+++ b/src/Form/FormRadioSet.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useFormGroupContext } from './FormGroupContext';
 import { FormRadioSetContextProvider } from './FormRadioSetContext';

--- a/src/Form/FormRadioSetContext.jsx
+++ b/src/Form/FormRadioSetContext.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { callAllHandlers } from './fieldUtils';
 
 const identityFn = props => props;
 
-const FormRadioSetContext = React.createContext({
+const FormRadioSetContext = createContext({
   getRadioControlProps: identityFn,
   hasRadioSetProvider: false,
 });

--- a/src/Form/FormSwitch.jsx
+++ b/src/Form/FormSwitch.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import { forwardRef, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import FormCheckbox from './FormCheckbox';
 import { useFormGroupContext } from './FormGroupContext';
 
-const SwitchControl = React.forwardRef(
+const SwitchControl = forwardRef(
   ({ isIndeterminate, ...props }, ref) => {
-    const defaultRef = React.useRef();
+    const defaultRef = useRef();
     const resolvedRef = ref || defaultRef;
     const { getControlProps } = useFormGroupContext();
     const checkboxProps = getControlProps({
@@ -17,7 +17,7 @@ const SwitchControl = React.forwardRef(
       ),
     });
 
-    React.useEffect(() => {
+    useEffect(() => {
       // this if(resolvedRef.current) prevents console errors in testing
       if (resolvedRef.current) {
         resolvedRef.current.indeterminate = isIndeterminate;
@@ -46,7 +46,7 @@ SwitchControl.defaultProps = {
   className: undefined,
 };
 
-const FormSwitch = React.forwardRef(({
+const FormSwitch = forwardRef(({
   children,
   className,
   helperText,

--- a/src/Form/FormText.jsx
+++ b/src/Form/FormText.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../Icon';

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';

--- a/src/Form/tests/FormCheckbox.test.jsx
+++ b/src/Form/tests/FormCheckbox.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Form/tests/FormCheckboxSet.test.jsx
+++ b/src/Form/tests/FormCheckboxSet.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Form/tests/FormControlDecoratorGroup.test.jsx
+++ b/src/Form/tests/FormControlDecoratorGroup.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { FormGroupContext } from '../FormGroupContext';

--- a/src/Form/tests/FormControlFeedback.test.jsx
+++ b/src/Form/tests/FormControlFeedback.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import FormControlFeedback from '../FormControlFeedback';

--- a/src/Form/tests/FormGroup.test.jsx
+++ b/src/Form/tests/FormGroup.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import FormGroup from '../FormGroup';

--- a/src/Form/tests/FormRadioSet.test.jsx
+++ b/src/Form/tests/FormRadioSet.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Form/tests/FormSwitch.test.jsx
+++ b/src/Form/tests/FormSwitch.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import FormSwitch from '../FormSwitch';

--- a/src/Form/tests/FormText.test.jsx
+++ b/src/Form/tests/FormText.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import FormText, { resolveTextType, FORM_TEXT_TYPES } from '../FormText';

--- a/src/Form/tests/fieldUtils.test.jsx
+++ b/src/Form/tests/fieldUtils.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Form/tests/useCheckboxSetValues.test.jsx
+++ b/src/Form/tests/useCheckboxSetValues.test.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/button-has-type */
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Hyperlink/index.tsx
+++ b/src/Hyperlink/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import type { ComponentPropsWithRef, ReactNode, ElementType } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
@@ -11,11 +12,11 @@ import Icon from '../Icon';
 // @ts-ignore
 import { customPropTypeRequirement } from '../utils/propTypes/utils';
 
-export interface HyperlinkProps extends BsPrefixProps, Omit<React.ComponentPropsWithRef<'a'>, 'href' | 'target'> {
+export interface HyperlinkProps extends BsPrefixProps, Omit<ComponentPropsWithRef<'a'>, 'href' | 'target'> {
   /** specifies the URL */
   destination?: string;
   /** Content of the hyperlink */
-  children: React.ReactNode;
+  children: ReactNode;
   /** Custom class names for the hyperlink */
   className?: string;
   /** Alt text for the icon indicating that this link opens in a new tab, if target="_blank". e.g. _("in a new tab") */
@@ -134,7 +135,7 @@ Hyperlink.propTypes = {
   /** specifies the URL; required iff `as` prop is a standard anchor tag */
   destination: customPropTypeRequirement(
     PropTypes.string,
-    ({ as }: { as: React.ElementType }) => as && as === 'a',
+    ({ as }: { as: ElementType }) => as && as === 'a',
     // "[`destination` is required when]..."
     'the `as` prop is a standard anchor element (i.e., "a")',
   ),

--- a/src/Icon/Icon.test.tsx
+++ b/src/Icon/Icon.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import * as ParagonIcons from '../../icons';
 import { type IconName } from '../../icons';
@@ -18,7 +18,7 @@ function BlankSrc() {
 
 /** A compile time check. Whatever React elements this wraps won't run at runtime. */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function CompileCheck(_props: { children: React.ReactNode }) { return null; }
+function CompileCheck(_props: { children: ReactNode }) { return null; }
 
 describe('IconName type', () => {
   it('has correct typing', () => {

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/IconButton/IconButton.test.tsx
+++ b/src/IconButton/IconButton.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';

--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import type {
+  HTMLAttributes, ComponentType, MouseEventHandler, ReactNode,
+} from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { type Placement } from 'react-bootstrap/Overlay';
@@ -6,8 +9,8 @@ import { OverlayTrigger } from '../Overlay';
 import Tooltip from '../Tooltip';
 import Icon from '../Icon';
 
-interface Props extends React.HTMLAttributes<HTMLButtonElement> {
-  iconAs?: React.ComponentType<any>,
+interface Props extends HTMLAttributes<HTMLButtonElement> {
+  iconAs?: ComponentType<any>,
   /** Additional CSS class[es] to apply to this button */
   className?: string;
   /** Alt text for your icon. For best practice, avoid using alt text to describe
@@ -21,11 +24,11 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
    * */
   // Note: React.ComponentType is what we want here. React.ElementType would allow some element type strings like "div",
   // but we only want to allow components like 'Add' (a specific icon component function/class)
-  src?: React.ComponentType;
+  src?: ComponentType;
   /** Extra class names that will be added to the icon */
   iconClassNames?: string;
   /** Click handler for the button */
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   /** whether to show the `IconButton` in an active state, whose styling is distinct from default state */
   isActive?: boolean;
   /** @deprecated Using FontAwesome icons is deprecated. Instead, pass iconAs={Icon} src={...} */
@@ -38,7 +41,7 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   children?: never;
 }
 
-const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
+const IconButton = forwardRef<HTMLButtonElement, Props>(({
   className,
   alt,
   invertColors,
@@ -139,7 +142,7 @@ interface PropsWithTooltip extends Props {
   /** choose from https://popper.js.org/docs/v2/constructors/#options */
   tooltipPlacement: Placement,
   /** any content to pass to tooltip content area */
-  tooltipContent: React.ReactNode,
+  tooltipContent: ReactNode,
 }
 
 /**

--- a/src/IconButtonToggle/IconButtonToggle.test.jsx
+++ b/src/IconButtonToggle/IconButtonToggle.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/IconButtonToggle/index.jsx
+++ b/src/IconButtonToggle/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { Children, cloneElement, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -13,9 +13,9 @@ import PropTypes from 'prop-types';
  */
 function IconButtonToggle({ activeValue, onChange, children }) {
   const iconButtons = useMemo(
-    () => React.Children.map(children, iconButton => {
+    () => Children.map(children, iconButton => {
       const isActive = iconButton.props.value === activeValue;
-      return React.cloneElement(iconButton, {
+      return cloneElement(iconButton, {
         onClick: () => { onChange(iconButton.props.value); },
         isActive,
         'aria-selected': isActive,

--- a/src/Layout/Layout.test.jsx
+++ b/src/Layout/Layout.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Layout from '.';
 

--- a/src/Layout/index.jsx
+++ b/src/Layout/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef, Children, createElement } from 'react';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import PropTypes from 'prop-types';
@@ -6,15 +6,15 @@ import PropTypes from 'prop-types';
 const COL_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 'auto'];
 const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
 
-const LayoutElement = React.forwardRef((props, ref) => <div ref={ref} {...props} />);
+const LayoutElement = forwardRef((props, ref) => <div ref={ref} {...props} />);
 
-const Layout = React.forwardRef(({ children, ...props }, ref) => {
+const Layout = forwardRef(({ children, ...props }, ref) => {
   const childrenLength = children.length;
 
   const isValidDimensions = (dataList, validLength) => !dataList || dataList.length === validLength;
   const errors = {};
 
-  const layout = React.Children.map(children, (child, index) => {
+  const layout = Children.map(children, (child, index) => {
     const newProps = { ...child.props };
     SIZES.forEach(size => {
       const sizeProps = props[size];
@@ -28,7 +28,7 @@ const Layout = React.forwardRef(({ children, ...props }, ref) => {
       newProps[size] = { span, offset };
     });
     newProps.ref = child.ref;
-    return React.createElement(Col, newProps, child.props.children);
+    return createElement(Col, newProps, child.props.children);
   });
 
   Object.keys(errors).forEach(breakpoint => {

--- a/src/MailtoLink/MailtoLink.test.jsx
+++ b/src/MailtoLink/MailtoLink.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 

--- a/src/MailtoLink/index.jsx
+++ b/src/MailtoLink/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import emailPropType from 'email-prop-type';
 import isRequiredIf from 'react-proptype-conditional-require';
@@ -11,7 +11,7 @@ import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 export const MAIL_TO_LINK_EXTERNAL_LINK_ALTERNATIVE_TEXT = 'Dismiss';
 export const MAIL_TO_LINK_EXTERNAL_LINK_TITLE = 'Opens in a new tab';
 
-const MailtoLink = React.forwardRef((props, ref) => {
+const MailtoLink = forwardRef((props, ref) => {
   const {
     to,
     cc,

--- a/src/Menu/Menu.test.jsx
+++ b/src/Menu/Menu.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';

--- a/src/Menu/MenuItem.jsx
+++ b/src/Menu/MenuItem.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../Icon';
@@ -13,7 +13,7 @@ function MenuItem({
 }) {
   const className = classNames(props.className, 'pgn__menu-item');
 
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Menu/MenuItem.test.jsx
+++ b/src/Menu/MenuItem.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';

--- a/src/Menu/SelectMenu.jsx
+++ b/src/Menu/SelectMenu.jsx
@@ -1,4 +1,13 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import {
+  useRef,
+  useMemo,
+  createRef,
+  Children,
+  cloneElement,
+  useState,
+  useEffect,
+  useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { ExpandMore } from '../../icons';
@@ -21,9 +30,9 @@ function SelectMenu({
   const [triggerTarget, setTriggerTarget] = useState(null);
   // this ref is used to focus the menu open button after any menu option is clicked.
   // triggerTarget.current.focus() inside the onCLick() function didn't guarantee element focus.
-  const focusMenuRef = React.useRef(false);
-  const itemsCollection = React.useMemo(
-    () => Array.from({ length: children.length }).map(() => React.createRef()),
+  const focusMenuRef = useRef(false);
+  const itemsCollection = useMemo(
+    () => Array.from({ length: children.length }).map(() => createRef()),
     [children.length],
   );
 
@@ -39,7 +48,7 @@ function SelectMenu({
   const [selected, setSelected] = useState(defaultIndex());
   const [isOpen, open, close] = useToggle(false);
 
-  const createMenuItems = () => React.Children.map(children, (child, index) => {
+  const createMenuItems = () => Children.map(children, (child, index) => {
     const newProps = {
       onClick(e) {
         if (child.props.onClick) {
@@ -55,10 +64,10 @@ function SelectMenu({
     if (selected === index) {
       newProps['aria-current'] = 'page';
     }
-    return React.cloneElement(child, newProps);
+    return cloneElement(child, newProps);
   });
 
-  const prevOpenRef = React.useRef();
+  const prevOpenRef = useRef();
 
   useEffect(() => {
     if (isOpen && selected) {

--- a/src/Menu/SelectMenu.test.jsx
+++ b/src/Menu/SelectMenu.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from 'react-intl';
 import PropTypes from 'prop-types';
 import { render, screen } from '@testing-library/react';

--- a/src/Menu/__snapshots__/Menu.test.jsx.snap
+++ b/src/Menu/__snapshots__/Menu.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`Menu Item renders correctly renders as expected with menu items 1`] = `
 <div
   className="pgn__menu"
 >
+   
   <button
     className="pgn__menu-item"
   >
@@ -145,5 +146,6 @@ exports[`Menu Item renders correctly renders as expected with menu items 1`] = `
       </label>
     </div>
   </div>
+   
 </div>
 `;

--- a/src/Menu/index.jsx
+++ b/src/Menu/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import useArrowKeyNavigation from '../hooks/useArrowKeyNavigationHook';
@@ -12,7 +12,7 @@ function Menu({
   const parentRef = useArrowKeyNavigation({ selectors: arrowKeyNavigationSelector });
   const className = classNames(props.className, 'pgn__menu');
 
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,
@@ -21,9 +21,7 @@ function Menu({
     },
     (
       // eslint-disable-next-line react/jsx-no-useless-fragment
-      <>
-        {children}
-      </>
+      (<> {children} </>)
     ),
   );
 }

--- a/src/Modal/AlertModal.jsx
+++ b/src/Modal/AlertModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/Modal/FullscreenModal.jsx
+++ b/src/Modal/FullscreenModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import ModalDialog from './ModalDialog';
 

--- a/src/Modal/MarketingModal.jsx
+++ b/src/Modal/MarketingModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { requiredWhenNot } from '../utils/propTypes';

--- a/src/Modal/ModalCloseButton.jsx
+++ b/src/Modal/ModalCloseButton.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import { forwardRef, createElement, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ModalContext from './ModalContext';
 import Button from '../Button';
 
-const ModalCloseButton = React.forwardRef(({ as, children, ...props }, ref) => {
+const ModalCloseButton = forwardRef(({ as, children, ...props }, ref) => {
   const { onClose } = useContext(ModalContext);
   const type = as;
   const componentProps = {
@@ -21,7 +21,7 @@ const ModalCloseButton = React.forwardRef(({ as, children, ...props }, ref) => {
 
   // Use the non-jsx syntax to create this element so we can more
   // finely control the component type (defaulted to Button via defaultProps)
-  return React.createElement(type, componentProps, children);
+  return createElement(type, componentProps, children);
 });
 
 ModalCloseButton.propTypes = {

--- a/src/Modal/ModalContext.tsx
+++ b/src/Modal/ModalContext.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { createContext, useMemo } from 'react';
 
 interface ContextData {
   onClose: () => void;
@@ -6,7 +7,7 @@ interface ContextData {
   isBlocking: boolean;
 }
 
-const ModalContext = React.createContext<ContextData>({
+const ModalContext = createContext<ContextData>({
   onClose: () => {},
   isOpen: false,
   isBlocking: false,
@@ -21,7 +22,7 @@ function ModalContextProvider({
   onClose: () => void;
   isOpen: boolean;
   isBlocking?: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }) {
   const modalContextValue = useMemo<ContextData>(
     () => ({ onClose, isOpen, isBlocking }),

--- a/src/Modal/ModalDialog.tsx
+++ b/src/Modal/ModalDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import classNames from 'classnames';
 import { useMediaQuery } from 'react-responsive';
 import { useIntl } from 'react-intl';
@@ -22,7 +22,7 @@ import messages from './messages';
 
 interface Props {
   /** Specifies the content of the dialog */
-  children: React.ReactNode;
+  children: ReactNode;
   /** The aria-label of the dialog */
   title: string;
   /** A callback to close the modal dialog, e.g. when Escape is pressed */

--- a/src/Modal/ModalDialogBody.jsx
+++ b/src/Modal/ModalDialogBody.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import useIsVisible from '../hooks/useIsVisibleHook';
@@ -18,7 +18,7 @@ function ModalDialogBody({
       'pgn__modal-body-scroll-bottom': isScrolledToBottom,
     },
   );
-  return React.createElement(
+  return createElement(
     as,
     { ...props, className },
     (

--- a/src/Modal/ModalDialogFooter.jsx
+++ b/src/Modal/ModalDialogFooter.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,7 +7,7 @@ function ModalDialogFooter({
   children,
   ...props
 }) {
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Modal/ModalDialogHeader.tsx
+++ b/src/Modal/ModalDialogHeader.tsx
@@ -1,23 +1,25 @@
 /* eslint-disable react/require-default-props */
-import React from 'react';
+import type { ReactNode } from 'react';
+
+import { forwardRef, createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import type { ComponentWithAsProp } from '../utils/types/bootstrap';
 
 export interface Props {
   as?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }
 
 type HeaderType = ComponentWithAsProp<'div', Props>;
 
-const ModalDialogHeader: HeaderType = React.forwardRef<HTMLDivElement, Props>(({
+const ModalDialogHeader: HeaderType = forwardRef<HTMLDivElement, Props>(({
   as = 'div',
   children,
   ...props
 }, ref) => (
-  React.createElement(
+  createElement(
     as,
     {
       ...props,

--- a/src/Modal/ModalDialogHero.jsx
+++ b/src/Modal/ModalDialogHero.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ModalDialogHeroContent from './ModalDialogHeroContent';
@@ -9,7 +9,7 @@ function ModalDialogHero({
   children,
   ...props
 }) {
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Modal/ModalDialogHeroBackground.jsx
+++ b/src/Modal/ModalDialogHeroBackground.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -8,7 +8,7 @@ function ModalDialogHeroBackground({
   children,
   ...props
 }) {
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Modal/ModalDialogHeroContent.jsx
+++ b/src/Modal/ModalDialogHeroContent.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,7 +7,7 @@ function ModalDialogHeroContent({
   children,
   ...props
 }) {
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Modal/ModalDialogTitle.jsx
+++ b/src/Modal/ModalDialogTitle.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,7 +7,7 @@ function ModalDialogTitle({
   children,
   ...props
 }) {
-  return React.createElement(
+  return createElement(
     as,
     {
       ...props,

--- a/src/Modal/ModalLayer.tsx
+++ b/src/Modal/ModalLayer.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useEffect } from 'react';
 import classNames from 'classnames';
 import { FocusOn } from 'react-focus-on';
 import Portal from './Portal';
@@ -7,24 +8,26 @@ import { ModalContextProvider } from './ModalContext';
 // istanbul ignore next
 function ModalBackdrop({ onClick }: { onClick?: () => void }) {
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div
-      className="pgn__modal-backdrop"
-      onClick={onClick}
-      onKeyDown={onClick}
-      data-testid="modal-backdrop"
-    />
+    (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div
+        className="pgn__modal-backdrop"
+        onClick={onClick}
+        onKeyDown={onClick}
+        data-testid="modal-backdrop"
+      />
+    )
   );
 }
 
 // istanbul ignore next
-function ModalContentContainer({ children = null }: { children?: React.ReactNode }) {
+function ModalContentContainer({ children = null }: { children?: ReactNode }) {
   return <div className="pgn__modal-content-container">{children}</div>;
 }
 
 interface Props {
   /** Specifies the contents of the modal */
-  children: React.ReactNode;
+  children: ReactNode;
   /** A callback function for when the modal is dismissed */
   onClose: () => void;
   /** Is the modal dialog open or closed */

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FocusOn } from 'react-focus-on';
 import Portal from './Portal';
@@ -18,7 +18,7 @@ function ModalPopup({
   hasArrow,
   ...popperProps
 }) {
-  const RootComponent = withPortal ? Portal : React.Fragment;
+  const RootComponent = withPortal ? Portal : Fragment;
   const placementOffsetValue = PLACEMENT_OFFSETS[placement] || [0, 10];
 
   const popperParams = [

--- a/src/Modal/PopperElement.jsx
+++ b/src/Modal/PopperElement.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { usePopper } from 'react-popper';
 

--- a/src/Modal/Portal.tsx
+++ b/src/Modal/Portal.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+import { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-class Portal extends React.Component<Props> {
+class Portal extends Component<Props> {
   private rootName: string;
 
   private rootElement: HTMLElement | null;

--- a/src/Modal/StandardModal.jsx
+++ b/src/Modal/StandardModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import ModalDialog from './ModalDialog';
 

--- a/src/Modal/tests/AlertModal.test.jsx
+++ b/src/Modal/tests/AlertModal.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { IntlProvider } from 'react-intl';
@@ -6,14 +5,14 @@ import AlertModal from '../AlertModal';
 import { Info } from '../../../icons';
 
 /* eslint-disable react/prop-types */
-jest.mock('../Portal', () => function PortalMock(props) {
+jest.mock('../Portal', () => (function PortalMock(props) {
   const { children, ...otherProps } = props;
   return (
     <paragon-portal {...otherProps}>
       {children}
     </paragon-portal>
   );
-});
+}));
 
 jest.mock('react-focus-on', () => ({
   FocusOn: (props) => {

--- a/src/Modal/tests/ModalCloseButton.test.jsx
+++ b/src/Modal/tests/ModalCloseButton.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Modal/tests/ModalDialog.test.tsx
+++ b/src/Modal/tests/ModalDialog.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { IntlProvider } from 'react-intl';

--- a/src/Modal/tests/ModalLayer.test.tsx
+++ b/src/Modal/tests/ModalLayer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FocusOn } from 'react-focus-on';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -6,20 +5,20 @@ import userEvent from '@testing-library/user-event';
 import ModalLayer from '../ModalLayer';
 
 /* eslint-disable react/prop-types */
-jest.mock('../Portal', () => function PortalMock(props: any) {
+jest.mock('../Portal', () => (function PortalMock(props: any) {
   const { children, ...otherProps } = props;
   return (
     // @ts-ignore this fake element. (Property 'paragon-portal' does not exist on type 'JSX.IntrinsicElements')
-    <paragon-portal {...otherProps}>{children}</paragon-portal>
+    (<paragon-portal {...otherProps}>{children}</paragon-portal>)
   );
-});
+}));
 
 jest.mock('react-focus-on', () => ({
   FocusOn: jest.fn().mockImplementation((props) => {
     const { children, ...otherProps } = props;
     return (
       // @ts-ignore this fake element. (Property 'focus-on' does not exist on type 'JSX.IntrinsicElements')
-      <focus-on data-testid="focus-on" {...otherProps}>{children}</focus-on>
+      (<focus-on data-testid="focus-on" {...otherProps}>{children}</focus-on>)
     );
   }),
 }));

--- a/src/Modal/tests/ModalPopup.test.jsx
+++ b/src/Modal/tests/ModalPopup.test.jsx
@@ -1,16 +1,16 @@
-import React from 'react';
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import ModalPopup from '../ModalPopup';
 
 /* eslint-disable react/prop-types */
-jest.mock('../Portal', () => function PortalMock(props) {
+jest.mock('../Portal', () => (function PortalMock(props) {
   const { children, ...otherProps } = props;
   return (
     <paragon-portal data-testid="portal" {...otherProps}>
       {children}
     </paragon-portal>
   );
-});
+}));
 
 jest.mock('react-focus-on', () => ({
   FocusOn: (props) => {
@@ -48,7 +48,7 @@ const arrowPlacements = [
 ];
 
 describe('<ModalPopup />', () => {
-  const mockPositionRef = React.createRef();
+  const mockPositionRef = createRef();
 
   describe('when isOpen', () => {
     const isOpen = true;

--- a/src/Modal/tests/ModalPopupNoMock.test.jsx
+++ b/src/Modal/tests/ModalPopupNoMock.test.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { createRef } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ModalPopup from '../ModalPopup';
 
 describe('<ModalPopup />', () => {
-  const mockPositionRef = React.createRef();
+  const mockPositionRef = createRef();
 
   describe('when isOpen', () => {
     const isOpen = true;

--- a/src/Modal/tests/PopperElement.test.jsx
+++ b/src/Modal/tests/PopperElement.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { usePopper } from 'react-popper';

--- a/src/Modal/tests/Portal.test.tsx
+++ b/src/Modal/tests/Portal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Portal from '../Portal';
 

--- a/src/Nav/index.jsx
+++ b/src/Nav/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import BaseNav from 'react-bootstrap/Nav';
 import BaseNavDropdown from 'react-bootstrap/NavDropdown';
 import BaseNavItem from 'react-bootstrap/NavItem';

--- a/src/Navbar/index.jsx
+++ b/src/Navbar/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import BaseNavbar from 'react-bootstrap/Navbar';
 import BaseNavbarBrand from 'react-bootstrap/NavbarBrand';
 import BaseNavbarToggle from 'react-bootstrap/NavbarToggle';

--- a/src/OverflowScroll/OverflowScroll.jsx
+++ b/src/OverflowScroll/OverflowScroll.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useOverflowScroll } from './data';
 import OverflowScrollContext from './OverflowScrollContext';

--- a/src/OverflowScroll/data/tests/useOverflowScroll.test.jsx
+++ b/src/OverflowScroll/data/tests/useOverflowScroll.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act, renderHook } from '@testing-library/react';
 import useOverflowScroll from '../useOverflowScroll';
 import useOverflowScrollActions from '../useOverflowScrollActions';

--- a/src/OverflowScroll/tests/OverflowScroll.test.jsx
+++ b/src/OverflowScroll/tests/OverflowScroll.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import OverflowScroll from '../OverflowScroll';
 

--- a/src/Overlay/index.tsx
+++ b/src/Overlay/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import BaseOverlay, { type OverlayProps, type Placement } from 'react-bootstrap/Overlay';
 import BaseOverlayTrigger, { type OverlayTriggerProps, type OverlayTriggerType } from 'react-bootstrap/OverlayTrigger';
 import Fade from 'react-bootstrap/Fade';

--- a/src/PageBanner/PageBanner.test.jsx
+++ b/src/PageBanner/PageBanner.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/PageBanner/index.jsx
+++ b/src/PageBanner/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Close } from '../../icons';

--- a/src/Pagination/DefaultPagination.jsx
+++ b/src/Pagination/DefaultPagination.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import PaginationContext from './PaginationContext';
 import { ELLIPSIS } from './constants';

--- a/src/Pagination/MinimalPagination.jsx
+++ b/src/Pagination/MinimalPagination.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PreviousPageButton, NextPageButton } from './subcomponents';
 
 export default function MinimalPagination() {

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Context as ResponsiveContext } from 'react-responsive';
 import renderer from 'react-test-renderer';
 import {

--- a/src/Pagination/PaginationContext.jsx
+++ b/src/Pagination/PaginationContext.jsx
@@ -1,8 +1,5 @@
-import React, {
-  createContext,
-  useEffect,
-  useRef,
-  useState,
+import {
+  createContext, useEffect, useRef, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import { PAGINATION_VARIANTS } from './constants';

--- a/src/Pagination/ReducedPagination.jsx
+++ b/src/Pagination/ReducedPagination.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PreviousPageButton, NextPageButton, PaginationDropdown } from './subcomponents';
 
 export default function ReducedPagination() {

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 

--- a/src/Pagination/subcomponents/Ellipsis.jsx
+++ b/src/Pagination/subcomponents/Ellipsis.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import classNames from 'classnames';
 import { ELLIPSIS } from '../constants';
 

--- a/src/Pagination/subcomponents/NextPageButton.jsx
+++ b/src/Pagination/subcomponents/NextPageButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import classNames from 'classnames';
 import { PAGINATION_BUTTON_ICON_BUTTON_NEXT_ALT } from '../constants';
 import PaginationContext from '../PaginationContext';

--- a/src/Pagination/subcomponents/PageButton.jsx
+++ b/src/Pagination/subcomponents/PageButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from '../../Button';

--- a/src/Pagination/subcomponents/PageOfCountButton.jsx
+++ b/src/Pagination/subcomponents/PageOfCountButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import classNames from 'classnames';
 import PaginationContext from '../PaginationContext';
 

--- a/src/Pagination/subcomponents/PaginationDropdown.jsx
+++ b/src/Pagination/subcomponents/PaginationDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PaginationContext from '../PaginationContext';
 import Dropdown from '../../Dropdown';
 

--- a/src/Pagination/subcomponents/PreviousPageButton.jsx
+++ b/src/Pagination/subcomponents/PreviousPageButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import classNames from 'classnames';
 import { PAGINATION_BUTTON_ICON_BUTTON_PREV_ALT } from '../constants';
 import Button from '../../Button';

--- a/src/Pagination/subcomponents/ScreenReaderText.jsx
+++ b/src/Pagination/subcomponents/ScreenReaderText.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PaginationContext from '../PaginationContext';
 
 export default function PaginationScreenReaderText() {

--- a/src/Popover/Popover.test.jsx
+++ b/src/Popover/Popover.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import Popover from '.';

--- a/src/Popover/index.jsx
+++ b/src/Popover/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import BasePopover from 'react-bootstrap/Popover';
@@ -13,7 +13,7 @@ const PLACEMENT_VARIANTS = [
   'right',
 ];
 
-const Popover = React.forwardRef(({
+const Popover = forwardRef(({
   children,
   variant,
   ...props

--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import PropTypes from 'prop-types';
 import { createPopper } from '@popperjs/core';
@@ -10,7 +10,7 @@ import CheckpointBody from './CheckpointBody';
 import CheckpointHeader from './CheckpointHeader';
 import messages from './messages';
 
-const Checkpoint = React.forwardRef(({
+const Checkpoint = forwardRef(({
   body,
   dismissAltText,
   index,

--- a/src/ProductTour/Checkpoint.test.jsx
+++ b/src/ProductTour/Checkpoint.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';

--- a/src/ProductTour/CheckpointActionRow.jsx
+++ b/src/ProductTour/CheckpointActionRow.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
 import ActionRow from '../ActionRow';
 import Button from '../Button';
 
-const CheckpointActionRow = React.forwardRef(({
+const CheckpointActionRow = forwardRef(({
   advanceButtonText,
   backButtonText,
   endButtonText,

--- a/src/ProductTour/CheckpointBody.jsx
+++ b/src/ProductTour/CheckpointBody.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CheckpointBody = React.forwardRef(({ children }, ref) => {
+const CheckpointBody = forwardRef(({ children }, ref) => {
   if (!children) {
     return null;
   }

--- a/src/ProductTour/CheckpointHeader.jsx
+++ b/src/ProductTour/CheckpointHeader.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -8,7 +8,7 @@ import { Close } from '../../icons';
 import CheckpointTitle from './CheckpointTitle';
 import messages from './messages';
 
-const CheckpointHeader = React.forwardRef(({
+const CheckpointHeader = forwardRef(({
   dismissAltText, index, onDismiss, title, totalCheckpoints,
 }, ref) => {
   const intl = useIntl();

--- a/src/ProductTour/CheckpointTitle.jsx
+++ b/src/ProductTour/CheckpointTitle.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CheckpointTitle = React.forwardRef(({ children }, ref) => (
+const CheckpointTitle = forwardRef(({ children }, ref) => (
   <h2 id="pgn__checkpoint-title" ref={ref}>
     {children}
   </h2>

--- a/src/ProductTour/ProductTour.test.jsx
+++ b/src/ProductTour/ProductTour.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 
 import Checkpoint from './Checkpoint';
 
-const ProductTour = React.forwardRef(({ tours }, ref) => {
+const ProductTour = forwardRef(({ tours }, ref) => {
   const tourValue = tours.find((tour) => tour.enabled);
   const {
     enabled,

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import ProgressBarBase from 'react-bootstrap/ProgressBar';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -31,8 +31,8 @@ function ProgressBarAnnotated({
   thresholdHint,
   ...props
 }) {
-  const progressInfoRef = React.useRef();
-  const thresholdInfoRef = React.useRef();
+  const progressInfoRef = useRef();
+  const thresholdInfoRef = useRef();
   const thresholdPercent = (threshold || 0) - (now || 0);
   const isProgressHintAfter = now < HINT_SWAP_PERCENT;
   const isThresholdHintAfter = threshold < HINT_SWAP_PERCENT;

--- a/src/Scrollable/Scrollable.test.jsx
+++ b/src/Scrollable/Scrollable.test.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react'; // (or /dom, /vue, ...)
+import { render, screen } from '@testing-library/react';
 import useIsVisible from '../hooks/useIsVisibleHook';
 
 import Scrollable, { CLASSNAME_SCROLL_BOTTOM, CLASSNAME_SCROLL_TOP } from '.';

--- a/src/Scrollable/index.jsx
+++ b/src/Scrollable/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/SearchField/SearchField.test.jsx
+++ b/src/SearchField/SearchField.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useRef, createContext, useState, useEffect,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/SearchField/SearchFieldClearButton.jsx
+++ b/src/SearchField/SearchFieldClearButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import { SearchFieldContext } from './SearchFieldAdvanced';
 import Icon from '../Icon';

--- a/src/SearchField/SearchFieldInput.jsx
+++ b/src/SearchField/SearchFieldInput.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { FormControl } from '../Form';

--- a/src/SearchField/SearchFieldLabel.jsx
+++ b/src/SearchField/SearchFieldLabel.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/SearchField/SearchFieldSubmitButton.jsx
+++ b/src/SearchField/SearchFieldSubmitButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { SearchFieldContext } from './SearchFieldAdvanced';

--- a/src/SearchField/index.jsx
+++ b/src/SearchField/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { Search, Close } from '../../icons';

--- a/src/SelectableBox/SelectableBoxSet.jsx
+++ b/src/SelectableBox/SelectableBoxSet.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef, createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { getInputType } from './utils';
@@ -11,7 +11,7 @@ const INPUT_TYPES = [
 
 const DEFAULT_COLUMNS_NUMBER = 2;
 
-const SelectableBoxSet = React.forwardRef(({
+const SelectableBoxSet = forwardRef(({
   children,
   name,
   value,
@@ -26,7 +26,7 @@ const SelectableBoxSet = React.forwardRef(({
 }, ref) => {
   const inputType = getInputType('SelectableBoxSet', type);
 
-  return React.createElement(
+  return createElement(
     inputType,
     {
       name,

--- a/src/SelectableBox/index.jsx
+++ b/src/SelectableBox/index.jsx
@@ -1,4 +1,6 @@
-import React, { useRef, useEffect } from 'react';
+import {
+  forwardRef, createElement, useRef, useEffect,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import SelectableBoxSet from './SelectableBoxSet';
@@ -11,7 +13,7 @@ const INPUT_TYPES = [
   'checkbox',
 ];
 
-const SelectableBox = React.forwardRef(({
+const SelectableBox = forwardRef(({
   type,
   value,
   checked,
@@ -41,7 +43,7 @@ const SelectableBox = React.forwardRef(({
   };
 
   const inputRef = useRef(null);
-  const input = React.createElement(inputType, {
+  const input = createElement(inputType, {
     value,
     checked,
     hidden: inputHidden,

--- a/src/SelectableBox/tests/SelectableBox.test.jsx
+++ b/src/SelectableBox/tests/SelectableBox.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderer from 'react-test-renderer';

--- a/src/SelectableBox/tests/SelectableBoxSet.test.jsx
+++ b/src/SelectableBox/tests/SelectableBoxSet.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -1,18 +1,17 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 
 import Sheet, { POSITIONS, VARIANTS } from '.';
 
 /* eslint-disable react/prop-types */
-jest.mock('./SheetContainer', () => function SheetContainerMock(props) {
+jest.mock('./SheetContainer', () => (function SheetContainerMock(props) {
   const { children, ...otherProps } = props;
   return (
     <sheet-container {...otherProps}>
       {children}
     </sheet-container>
   );
-});
+}));
 
 jest.mock('react-focus-on', () => ({
   FocusOn: (props) => {

--- a/src/Sheet/SheetContainer.jsx
+++ b/src/Sheet/SheetContainer.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { Component } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-class SheetContainer extends React.Component {
+class SheetContainer extends Component {
   constructor(props) {
     super(props);
     this.sheetRootName = 'sheet-root';

--- a/src/Sheet/SheetContainer.test.jsx
+++ b/src/Sheet/SheetContainer.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import SheetContainer from './SheetContainer';
 

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createRef, Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FocusOn } from 'react-focus-on';
@@ -17,11 +17,11 @@ export const VARIANTS = {
   dark: 'dark',
 };
 
-class Sheet extends React.Component {
+class Sheet extends Component {
   constructor(props) {
     super(props);
 
-    this.wrapperRef = React.createRef();
+    this.wrapperRef = createRef();
     this.renderSheet = this.renderSheet.bind(this);
   }
 

--- a/src/Spinner/Spinner.test.tsx
+++ b/src/Spinner/Spinner.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Spinner from '.';

--- a/src/Spinner/index.tsx
+++ b/src/Spinner/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode, ForwardedRef } from 'react';
+import { forwardRef } from 'react';
 import classNames from 'classnames';
 import BaseSpinner, { type SpinnerProps as BaseSpinnerProps } from 'react-bootstrap/Spinner';
 
@@ -6,15 +7,15 @@ interface SpinnerProps extends BaseSpinnerProps {
   /** Optionally specify additional CSS classes to give this spinner's `<div>`. */
   className?: string;
   /** Specifies the screen reader content for a11y. */
-  screenReaderText?: React.ReactNode;
+  screenReaderText?: ReactNode;
 }
 
 /** A spinning animation that indicates loading. */
-const Spinner = React.forwardRef(({
+const Spinner = forwardRef(({
   className,
   screenReaderText,
   ...attrs
-}: SpinnerProps, ref: React.ForwardedRef<HTMLDivElement>) => {
+}: SpinnerProps, ref: ForwardedRef<HTMLDivElement>) => {
   const spinnerProps = {
     ...attrs,
     className: classNames('pgn__spinner', className),

--- a/src/Stack/Stack.test.jsx
+++ b/src/Stack/Stack.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 

--- a/src/Stack/index.jsx
+++ b/src/Stack/index.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/StatefulButton/StatefulButtontest.test.jsx
+++ b/src/StatefulButton/StatefulButtontest.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 
 import StatefulButton from './index';

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Cancel, CheckCircleOutline, SpinnerSimple } from '../../icons';

--- a/src/Stepper/Stepper.jsx
+++ b/src/Stepper/Stepper.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import StepperStep from './StepperStep';
 import StepperHeader from './StepperHeader';

--- a/src/Stepper/StepperActionRow.jsx
+++ b/src/Stepper/StepperActionRow.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { createElement, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { StepperContext } from './StepperContext';
 import ActionRow from '../ActionRow';
@@ -16,7 +16,7 @@ function StepperActionRow({
     return null;
   }
 
-  return React.createElement(as, props, children);
+  return createElement(as, props, children);
 }
 
 StepperActionRow.propTypes = {

--- a/src/Stepper/StepperContext.jsx
+++ b/src/Stepper/StepperContext.jsx
@@ -1,9 +1,9 @@
-import React, {
-  useCallback, useEffect, useReducer, useState,
+import {
+  createContext, useCallback, useEffect, useReducer, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 
-export const StepperContext = React.createContext({
+export const StepperContext = createContext({
   activeKey: '',
 });
 

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { Fragment, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import StepperHeaderStep from './StepperHeaderStep';
@@ -12,20 +12,22 @@ function StepListSeparator() {
 
 function StepList({ steps, activeKey }) {
   return (
-    <ul className="pgn__stepper-header-step-list">
-      {steps.map(({ label, ...stepProps }, index) => (
-        <React.Fragment key={stepProps.eventKey}>
-          {index !== 0 && <StepListSeparator />}
-          <StepperHeaderStep
-            {...stepProps}
-            index={index}
-            isActive={activeKey === stepProps.eventKey}
-          >
-            {label}
-          </StepperHeaderStep>
-        </React.Fragment>
-      ))}
-    </ul>
+    (
+      <ul className="pgn__stepper-header-step-list">
+        {steps.map(({ label, ...stepProps }, index) => (
+          <Fragment key={stepProps.eventKey}>
+            {index !== 0 && <StepListSeparator />}
+            <StepperHeaderStep
+              {...stepProps}
+              index={index}
+              isActive={activeKey === stepProps.eventKey}
+            >
+              {label}
+            </StepperHeaderStep>
+          </Fragment>
+        ))}
+      </ul>
+    )
   );
 }
 

--- a/src/Stepper/StepperHeaderStep.jsx
+++ b/src/Stepper/StepperHeaderStep.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/Stepper/StepperStep.jsx
+++ b/src/Stepper/StepperStep.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { StepperContext } from './StepperContext';

--- a/src/Stepper/tests/Stepper.test.jsx
+++ b/src/Stepper/tests/Stepper.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/Sticky/Sticky.test.jsx
+++ b/src/Sticky/Sticky.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 

--- a/src/Sticky/index.jsx
+++ b/src/Sticky/index.jsx
@@ -1,4 +1,6 @@
-import React, { useLayoutEffect, useState } from 'react';
+import {
+  forwardRef, useRef, useLayoutEffect, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,7 +9,7 @@ const POSITION_VARIANTS = [
   'bottom',
 ];
 
-const Sticky = React.forwardRef(({
+const Sticky = forwardRef(({
   position,
   children,
   offset,
@@ -15,7 +17,7 @@ const Sticky = React.forwardRef(({
   ...rest
 }, ref) => {
   const [isSticky, setIsSticky] = useState(false);
-  const defaultRef = React.useRef();
+  const defaultRef = useRef();
   const resolvedRef = ref || defaultRef;
 
   // eslint-disable-next-line consistent-return

--- a/src/Tabs/Tab.jsx
+++ b/src/Tabs/Tab.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import BaseTab from 'react-bootstrap/Tab';
 

--- a/src/Tabs/Tabs.test.jsx
+++ b/src/Tabs/Tabs.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, waitFor, act } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -1,4 +1,7 @@
-import React, {
+import {
+  Children,
+  isValidElement,
+  cloneElement,
   useEffect,
   useMemo,
   useRef,
@@ -81,14 +84,14 @@ function Tabs({
         handleDropdownTabClick(eventKey);
       }
     };
-    const childrenList = React.Children.map(children, (child, index) => {
+    const childrenList = Children.map(children, (child, index) => {
       if (child?.type?.name !== 'Tab' && process.env.NODE_ENV === 'development') {
         // eslint-disable-next-line no-console
         console.error(
           `Tabs children can only be of type Tab. ${children[index]} was passed instead.`,
         );
       }
-      if (!React.isValidElement(child)) {
+      if (!isValidElement(child)) {
         return child;
       }
       const {
@@ -114,7 +117,7 @@ function Tabs({
         newTitle = title;
       }
       const tabClass = index > indexOfLastVisibleChild ? 'pgn__tab_invisible' : '';
-      const modifiedTab = React.cloneElement(child, {
+      const modifiedTab = cloneElement(child, {
         ...rest,
         title: newTitle,
         tabClassName: classNames(tabClass, tabClassName),

--- a/src/Toast/index.tsx
+++ b/src/Toast/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { MouseEvent } from 'react';
+import { useState } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import BaseToast from 'react-bootstrap/Toast';
@@ -16,7 +17,7 @@ export const TOAST_DELAY = 5000;
 interface ToastAction {
   label: string;
   href?: string;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+  onClick?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
 }
 
 interface ToastProps {

--- a/src/Tooltip/Tooltip.test.tsx
+++ b/src/Tooltip/Tooltip.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import Tooltip from '.';

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import BaseTooltip, { type TooltipProps as BaseTooltipProps } from 'react-bootstrap/Tooltip';
@@ -27,7 +27,7 @@ const PLACEMENT_VARIANTS: Placement[] = [
   'left-start',
 ];
 
-const Tooltip: ComponentWithAsProp<'div', TooltipProps> = React.forwardRef(({
+const Tooltip: ComponentWithAsProp<'div', TooltipProps> = forwardRef(({
   children,
   variant,
   ...props

--- a/src/TransitionReplace/TransitionReplace.test.jsx
+++ b/src/TransitionReplace/TransitionReplace.test.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-plusplus, react/prop-types */
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import TransitionReplace from '.';

--- a/src/TransitionReplace/index.jsx
+++ b/src/TransitionReplace/index.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import { Children, Component } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import classNames from 'classnames';
 
-class TransitionReplace extends React.Component {
+class TransitionReplace extends Component {
   constructor(props) {
     super(props);
 
@@ -117,17 +117,19 @@ class TransitionReplace extends React.Component {
 
   render() {
     return (
-      <TransitionGroup
-        className={classNames(
-          'pgn-transition-replace-group',
-          'position-relative',
-          { 'overflow-hidden': this.state.height !== null },
-          this.props.className,
-        )}
-        style={{ height: this.state.height }}
-      >
-        {React.Children.map(this.props.children, this.renderChildTransition, this)}
-      </TransitionGroup>
+      (
+        <TransitionGroup
+          className={classNames(
+            'pgn-transition-replace-group',
+            'position-relative',
+            { 'overflow-hidden': this.state.height !== null },
+            this.props.className,
+          )}
+          style={{ height: this.state.height }}
+        >
+          {Children.map(this.props.children, this.renderChildTransition, this)}
+        </TransitionGroup>
+      )
     );
   }
 }

--- a/src/Truncate/Truncate.test.jsx
+++ b/src/Truncate/Truncate.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Truncate from '.';
 

--- a/src/Truncate/index.jsx
+++ b/src/Truncate/index.jsx
@@ -1,5 +1,5 @@
-import React, {
-  useLayoutEffect, useRef, useEffect,
+import {
+  createElement, useLayoutEffect, useRef, useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { truncateLines } from './utils';
@@ -34,7 +34,7 @@ function TruncateDeprecated({
     }
   }, [children, ellipsis, lines, onTruncate, whiteSpace, width]);
 
-  return React.createElement(elementType, {
+  return createElement(elementType, {
     ref: textContainer,
     className,
   });

--- a/src/ValidationMessage/ValidationMessage.test.jsx
+++ b/src/ValidationMessage/ValidationMessage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import ValidationMessage from '.';

--- a/src/ValidationMessage/index.jsx
+++ b/src/ValidationMessage/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -26,7 +26,7 @@ const defaultProps = {
   variantIconDescription: '',
 };
 
-class ValidationMessage extends React.Component {
+class ValidationMessage extends Component {
   getVariantFeedbackClassName() {
     const { variant } = this.props;
     let className;

--- a/src/__mocks__/reactResponsive.mock.js
+++ b/src/__mocks__/reactResponsive.mock.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { MediaQueryProps } from 'react-responsive';
 
 // We have to rename the below variables to start with `mock` so

--- a/src/asInput/asInput.test.jsx
+++ b/src/asInput/asInput.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-prop-types */
-import React from 'react';
+import { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -63,7 +63,7 @@ export const defaultProps = {
 };
 
 const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => {
-  class NewComponent extends React.Component {
+  class NewComponent extends Component {
     constructor(props) {
       super(props);
       this.handleChange = this.handleChange.bind(this);
@@ -136,15 +136,17 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
     getLabel() {
       return (
         // eslint-disable-next-line jsx-a11y/label-has-for
-        <label
-          id={`label-${this.state.id}`}
-          htmlFor={this.state.id}
-          className={classNames({
-            'form-check-label': this.isGroupedInput(),
-          })}
-        >
-          {this.props.label}
-        </label>
+        (
+          <label
+            id={`label-${this.state.id}`}
+            htmlFor={this.state.id}
+            className={classNames({
+              'form-check-label': this.isGroupedInput(),
+            })}
+          >
+            {this.props.label}
+          </label>
+        )
       );
     }
 
@@ -182,7 +184,7 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
 
     getAddons({ addonElements, type }) {
       if (Array.isArray(addonElements)) {
-        return addonElements.map((addon, index) => React.cloneElement(
+        return addonElements.map((addon, index) => cloneElement(
           addon,
           { key: this.generateInputGroupAddonKey({ prefix: type, index }) },
         ));

--- a/src/hooks/tests/useIndexOfLastVisibleChild.test.tsx
+++ b/src/hooks/tests/useIndexOfLastVisibleChild.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useRef } from 'react';
 import { render } from '@testing-library/react';
 import { useIndexOfLastVisibleChild } from '../..';
 
@@ -12,8 +12,8 @@ window.ResizeObserver = window.ResizeObserver
   }));
 
 function TestComponent() {
-  const [containerElementRef, setContainerElementRef] = React.useState<HTMLDivElement | null>(null);
-  const overflowElementRef = React.useRef<HTMLDivElement>(null);
+  const [containerElementRef, setContainerElementRef] = useState<HTMLDivElement | null>(null);
+  const overflowElementRef = useRef<HTMLDivElement>(null);
   const indexOfLastVisibleChild = useIndexOfLastVisibleChild(containerElementRef, overflowElementRef.current);
 
   return (

--- a/src/hooks/tests/useToggle.test.tsx
+++ b/src/hooks/tests/useToggle.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/button-has-type */
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/hooks/tests/useWindowSize.test.tsx
+++ b/src/hooks/tests/useWindowSize.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { useWindowSize } from '../..';

--- a/src/hooks/useIsVisibleHook.tsx
+++ b/src/hooks/useIsVisibleHook.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useState, useEffect } from 'react';
+import type { MutableRefObject } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 const useIsVisible = (defaultIsVisible = true): [
   isVisible: boolean,
-  sentinelRef: React.MutableRefObject<HTMLElement | null>,
+  sentinelRef: MutableRefObject<HTMLElement | null>,
 ] => {
   const sentinelRef = useRef<HTMLElement | null>(null);
   const [isVisible, setIsVisible] = useState(defaultIsVisible);

--- a/src/utils/types/bootstrap.test.tsx
+++ b/src/utils/types/bootstrap.test.tsx
@@ -1,16 +1,20 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
+import type {
+  ElementType, FC, MouseEventHandler, RefObject,
+} from 'react';
+
+import { forwardRef } from 'react';
 import type { BsPropsWithAs, ComponentWithAsProp } from './bootstrap';
 
 // Note: these are type-only tests. They don't actually do much at runtime; the important checks are at transpile time.
 
 describe('BsPropsWithAs', () => {
-  interface Props<As extends React.ElementType = 'table'> extends BsPropsWithAs<As> {
+  interface Props<As extends ElementType = 'table'> extends BsPropsWithAs<As> {
     otherProp?: number;
   }
 
   it('defines optional bsPrefix, className, and as but no other props', () => {
-    const checkProps = <As extends React.ElementType = 'table'>(_props: Props<As>) => {};
+    const checkProps = <As extends ElementType = 'table'>(_props: Props<As>) => {};
     // These are all valid props per the prop definition:
     checkProps({ });
     checkProps({ bsPrefix: 'bs' });
@@ -34,43 +38,43 @@ describe('ComponentWithAsProp', () => {
     customProp?: string;
   }
   const MyComponent: ComponentWithAsProp<'div', MyProps> = (
-    React.forwardRef<HTMLDivElement, MyProps>(
+    forwardRef<HTMLDivElement, MyProps>(
       ({ as: Inner = 'div', ...props }, ref) => <Inner {...props} ref={ref} />,
     )
   );
 
   // eslint-disable-next-line react/function-component-definition
-  const CustomComponent: React.FC<{ requiredProp: string }> = () => <span />;
+  const CustomComponent: FC<{ requiredProp: string }> = () => <span />;
 
   it('is defined to wrap a <div> by default, and accepts related props', () => {
     // This is valid - by default it is a DIV so accepts props and ref related to DIV:
-    const divClick: React.MouseEventHandler<HTMLDivElement> = () => {};
-    const divRef: React.RefObject<HTMLDivElement> = { current: null };
+    const divClick: MouseEventHandler<HTMLDivElement> = () => {};
+    const divRef: RefObject<HTMLDivElement> = { current: null };
     const valid = <MyComponent ref={divRef} onClick={divClick} customProp="foo" />;
   });
 
   it('is defined to wrap a <div> by default, and rejects unrelated props', () => {
-    const btnRef: React.RefObject<HTMLButtonElement> = { current: null };
+    const btnRef: RefObject<HTMLButtonElement> = { current: null };
     // @ts-expect-error because the ref is to a <button> ref, but this is wrapping a <div>
     const invalidRef = <MyComponent ref={btnRef} customProp="foo" />;
 
-    const btnClick: React.MouseEventHandler<HTMLButtonElement> = () => {};
+    const btnClick: MouseEventHandler<HTMLButtonElement> = () => {};
     // @ts-expect-error because the handler is for a <button> event, but this is wrapping a <div>
     const invalidClick = <MyComponent onClick={btnClick} />;
   });
 
   it('can be changed to wrap a <canvas>, and accepts related props', () => {
-    const canvasClick: React.MouseEventHandler<HTMLCanvasElement> = () => {};
-    const canvasRef: React.RefObject<HTMLCanvasElement> = { current: null };
+    const canvasClick: MouseEventHandler<HTMLCanvasElement> = () => {};
+    const canvasRef: RefObject<HTMLCanvasElement> = { current: null };
     const valid = <MyComponent as="canvas" ref={canvasRef} onClick={canvasClick} customProp="foo" />;
   });
 
   it('can be changed to wrap a <canvas>, and rejects unrelated props', () => {
-    const btnRef: React.RefObject<HTMLButtonElement> = { current: null };
+    const btnRef: RefObject<HTMLButtonElement> = { current: null };
     // @ts-expect-error because the ref is to a <button> ref, but this is wrapping an <canvas>
     const invalidRef = <MyComponent as="canvas" ref={btnRef} customProp="foo" />;
 
-    const btnClick: React.MouseEventHandler<HTMLButtonElement> = () => {};
+    const btnClick: MouseEventHandler<HTMLButtonElement> = () => {};
     // @ts-expect-error because the handler is for a <button> event, but this is wrapping an <canvas>
     const invalidClick = <MyComponent as="canvas" onClick={btnClick} />;
   });

--- a/src/utils/types/bootstrap.ts
+++ b/src/utils/types/bootstrap.ts
@@ -1,7 +1,7 @@
 /**
  * Types related to bootstrap components
  */
-import React from 'react';
+import type { ElementType } from 'react';
 
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from 'react-bootstrap/esm/helpers';
 
@@ -14,7 +14,7 @@ import type { BsPrefixProps, BsPrefixRefForwardingComponent } from 'react-bootst
  *
  * This type assumes no `children` are allowed, but you can extend it to allow children.
  */
-export type BsPropsWithAs<As extends React.ElementType = React.ElementType> = BsPrefixProps<As>;
+export type BsPropsWithAs<As extends ElementType = ElementType> = BsPrefixProps<As>;
 
 /**
  * This is a helper that can be used to define the type of a Paragon component
@@ -39,5 +39,5 @@ export type BsPropsWithAs<As extends React.ElementType = React.ElementType> = Bs
  * ```
  * Note that you need to define the default (e.g. `'div'`) in three different places.
  */
-export type ComponentWithAsProp<DefaultElementType extends React.ElementType, Props>
+export type ComponentWithAsProp<DefaultElementType extends ElementType, Props>
   = BsPrefixRefForwardingComponent<DefaultElementType, Props>;

--- a/src/withDeprecatedProps.tsx
+++ b/src/withDeprecatedProps.tsx
@@ -1,5 +1,7 @@
 /* eslint no-console: 0 */
-import React from 'react';
+import type { ComponentType } from 'react';
+
+import { Component } from 'react';
 
 export enum DeprTypes {
   MOVED = 'MOVED',
@@ -17,11 +19,11 @@ export interface DeprecatedProps extends Record<string, any> {
 }
 
 function withDeprecatedProps<T extends Record<string, any>>(
-  WrappedComponent: React.ComponentType<any>,
+  WrappedComponent: ComponentType<any>,
   componentName: string,
   deprecatedProps: Record<string, DeprecatedProps>,
 ) : any {
-  class WithDeprecatedProps extends React.Component<T> {
+  class WithDeprecatedProps extends Component<T> {
     // eslint-disable-next-line react/static-property-placement
     public static displayName = `withDeprecatedProps(${componentName})`;
 

--- a/www/playroom/FrameComponent.jsx
+++ b/www/playroom/FrameComponent.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { IntlProvider } from 'react-intl';

--- a/www/src/components/AddThemeModal.tsx
+++ b/www/src/components/AddThemeModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { RefObject, FC } from 'react';
+import { useState } from 'react';
 import {
   Button,
   ActionRow,
@@ -14,11 +15,11 @@ interface AddThemeModalProps {
   onClose: () => void;
   onSave: () => void;
   existingThemes: Theme[];
-  formRef: React.RefObject<CustomThemesFormRef>;
+  formRef: RefObject<CustomThemesFormRef>;
   onSaveTheme: (theme: ThemeConfig) => void;
 }
 
-const AddThemeModal: React.FC<AddThemeModalProps> = ({
+const AddThemeModal: FC<AddThemeModalProps> = ({
   isOpen,
   onClose,
   onSave,

--- a/www/src/components/AutoToc.tsx
+++ b/www/src/components/AutoToc.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import slugify from 'slugify';

--- a/www/src/components/CodeBlock.tsx
+++ b/www/src/components/CodeBlock.tsx
@@ -1,4 +1,6 @@
-import React, {
+import type { ReactNode, ChangeEvent, MouseEvent } from 'react';
+
+import {
   useCallback,
   useContext,
   useEffect,
@@ -8,6 +10,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+
 import { Link } from 'gatsby';
 import axios from 'axios';
 import classNames from 'classnames';
@@ -36,9 +39,9 @@ const {
 } = ParagonReact;
 
 export type CollapsibleLiveEditorTypes = {
-  children: React.ReactNode;
+  children: ReactNode;
   clickToCopy: () => void;
-  handleCodeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleCodeChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 };
 
 function CollapsibleLiveEditor({ children, clickToCopy, handleCodeChange }: CollapsibleLiveEditorTypes) {
@@ -64,7 +67,7 @@ function CollapsibleLiveEditor({ children, clickToCopy, handleCodeChange }: Coll
     return node;
   };
 
-  const submitSegmentEvent = (e: React.MouseEvent & { target: HTMLElement }) => {
+  const submitSegmentEvent = (e: MouseEvent & { target: HTMLElement }) => {
     const componentNameAndCategory = window.location.pathname.replace(/\//g, '.')
       .replace(/.components./gi, '');
     const headingElement = getCodeBlockHeading(e.target);

--- a/www/src/components/ComponentVariablesTable.tsx
+++ b/www/src/components/ComponentVariablesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DataTable, Skeleton } from '~paragon-react';
 import { useCurrentTheme } from '../hooks';
 

--- a/www/src/components/ComponentsList.tsx
+++ b/www/src/components/ComponentsList.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
 import { Container } from '~paragon-react';
 import { ComponentNavItem, IComponentNavItem } from './Menu';

--- a/www/src/components/CustomThemesForm.tsx
+++ b/www/src/components/CustomThemesForm.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useRef,
-  useEffect,
-  useImperativeHandle,
-  forwardRef,
-} from 'react';
+import { useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import {
   Form,

--- a/www/src/components/EditThemeModal.tsx
+++ b/www/src/components/EditThemeModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { RefObject, FC } from 'react';
+import { useState } from 'react';
 import {
   Button,
   ActionRow,
@@ -16,11 +17,11 @@ interface EditThemeModalProps {
   onRemove: () => void;
   editingTheme: Theme;
   existingThemes: Theme[];
-  formRef: React.RefObject<CustomThemesFormRef>;
+  formRef: RefObject<CustomThemesFormRef>;
   onSaveTheme: (theme: ThemeConfig) => void;
 }
 
-const EditThemeModal: React.FC<EditThemeModalProps> = ({
+const EditThemeModal: FC<EditThemeModalProps> = ({
   isOpen,
   onClose,
   onSave,

--- a/www/src/components/IconsTable.tsx
+++ b/www/src/components/IconsTable.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import type { RefObject, FC } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import debounce from 'lodash.debounce';
 import * as IconComponents from '~paragon-icons';
 import { type IconName } from '~paragon-icons';
@@ -13,10 +14,10 @@ const COLUMN_WIDTH = 150;
 interface TableCellProps {
   iconName: IconName;
   setCurrentIcon: (name: IconName) => void;
-  previewRef: React.RefObject<HTMLDivElement>;
+  previewRef: RefObject<HTMLDivElement>;
 }
 
-const TableCell: React.FC<TableCellProps> = ({
+const TableCell: FC<TableCellProps> = ({
   iconName,
   setCurrentIcon,
   previewRef,
@@ -57,7 +58,7 @@ interface TableRowProps {
   data: Pick<TableCellProps, 'previewRef' | 'setCurrentIcon'>
 }
 
-const TableRow: React.FC<TableRowProps> = ({
+const TableRow: FC<TableRowProps> = ({
   rowIndex, columnsCount, iconsList, data,
 }) => {
   const startIndex = rowIndex * columnsCount;
@@ -84,9 +85,9 @@ const TableRow: React.FC<TableRowProps> = ({
 };
 
 function IconsTable({ iconNames }: { iconNames: IconName[] }) {
-  const previewRef = React.useRef<HTMLDivElement>(null);
-  const tableRef = React.useRef<HTMLDivElement>(null);
-  const tableBottom = React.useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLDivElement>(null);
+  const tableBottom = useRef<HTMLDivElement>(null);
   const [searchValue, setSearchValue] = useState('');
   const [tableWidth, setTableWidth] = useState(0);
   const [data, setData] = useState({ iconsList: iconNames, rowsCount: ROWS_PER_WINDOW });

--- a/www/src/components/LayoutGenerator.tsx
+++ b/www/src/components/LayoutGenerator.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FormGroup, FormControl, FormLabel } from '~paragon-react';
@@ -16,7 +17,7 @@ function Column({
   index, width, onChangeWidth, offset, onChangeOffset,
 }: IColumn) {
   return (
-    <div
+    (<div
       className={classNames('col mb-4', {
         [`col-${width}`]: width > 0,
         [`offset-${offset}`]: offset > 0,
@@ -40,7 +41,7 @@ function Column({
             min={0}
             step={1}
             max={12}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeWidth(index, e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onChangeWidth(index, e.target.value)}
           />
         </FormGroup>
         <FormGroup className="form-inline m-2">
@@ -57,11 +58,11 @@ function Column({
             min={0}
             step={1}
             max={11}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChangeOffset(index, e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onChangeOffset(index, e.target.value)}
           />
         </FormGroup>
       </div>
-    </div>
+    </div>)
   );
 }
 
@@ -87,7 +88,7 @@ function LayoutGenerator() {
   const [columnWidths, setColumnWidths] = useState<StateKeyTypes>({ 0: 3, 1: 6, 2: 3 });
   const [columnOffsets, setColumnOffsets] = useState<StateKeyTypes>({});
 
-  const columns: Array<React.ReactNode> = [];
+  const columns: Array<ReactNode> = [];
 
   for (let i = 0; i < numColumns; i++) {
     columns.push(
@@ -127,31 +128,29 @@ ${columnsString.join('').slice(0, -1)}
     return rowString;
   };
 
-  return (
-    <>
-      <p>
-        Drag the slider to add or remove columns. Edit the width and offset
-        values for each column and see the output below.
-      </p>
-      <FormGroup className="form-inline mb-4">
-        <FormLabel isInline className="mr-3" htmlFor="num-cols-range">
-          Number of Columns: {numColumns}
-        </FormLabel>
-        <FormControl
-          id="num-cols-range"
-          type="range"
-          value={numColumns}
-          min={1}
-          step={1}
-          max={12}
-          style={{ width: '10rem' }}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setColumns(parseInt(e.target.value, 10))}
-        />
-      </FormGroup>
-      <div className="row">{columns}</div>
-      <CodeBlock className="language-jsx">{renderMarkupString()}</CodeBlock>
-    </>
-  );
+  return (<>
+    <p>
+      Drag the slider to add or remove columns. Edit the width and offset
+      values for each column and see the output below.
+    </p>
+    <FormGroup className="form-inline mb-4">
+      <FormLabel isInline className="mr-3" htmlFor="num-cols-range">
+        Number of Columns: {numColumns}
+      </FormLabel>
+      <FormControl
+        id="num-cols-range"
+        type="range"
+        value={numColumns}
+        min={1}
+        step={1}
+        max={12}
+        style={{ width: '10rem' }}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setColumns(parseInt(e.target.value, 10))}
+      />
+    </FormGroup>
+    <div className="row">{columns}</div>
+    <CodeBlock className="language-jsx">{renderMarkupString()}</CodeBlock>
+  </>);
 }
 
 export default LayoutGenerator;

--- a/www/src/components/LeaveFeedback.tsx
+++ b/www/src/components/LeaveFeedback.tsx
@@ -1,4 +1,4 @@
-import React, { AnchorHTMLAttributes } from 'react';
+import { AnchorHTMLAttributes } from 'react';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { Nav, Button, Hyperlink } from '~paragon-react';
 import { LEAVE_FEEDBACK_CLICKED_EVENT, sendUserAnalyticsEvent } from '../../segment-events';

--- a/www/src/components/LinkedHeading.tsx
+++ b/www/src/components/LinkedHeading.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 
 export interface ILinkedHeading {
   h: string,
-  children: React.ReactNode,
+  children: ReactNode,
   id: string,
 }
 

--- a/www/src/components/MeasuredItem.tsx
+++ b/www/src/components/MeasuredItem.tsx
@@ -1,8 +1,5 @@
-import React, {
-  useState,
-  useRef,
-  useEffect,
-} from 'react';
+import type { ReactNode, ReactElement } from 'react';
+import { cloneElement, useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { useCurrentTheme } from '../hooks';
@@ -11,7 +8,7 @@ export interface IMeasuredItem {
   properties: string[],
   renderBefore?: Function,
   renderAfter?: Function,
-  children: React.ReactNode,
+  children: ReactNode,
 }
 
 const initialMeasurements = {};
@@ -45,13 +42,11 @@ function MeasuredItem({
     [currentTheme.name, properties],
   );
 
-  return (
-    <>
-      {renderBefore?.(measurements)}
-      {React.cloneElement(children as React.ReactElement, { ref: itemRef })}
-      {renderAfter?.(measurements)}
-    </>
-  );
+  return (<>
+    {renderBefore?.(measurements)}
+    {cloneElement(children as ReactElement, { ref: itemRef })}
+    {renderAfter?.(measurements)}
+  </>);
 }
 
 MeasuredItem.propTypes = {

--- a/www/src/components/Menu.tsx
+++ b/www/src/components/Menu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { useLocation } from '@gatsbyjs/reach-router';
 import PropTypes from 'prop-types';
 import { Link, graphql, useStaticQuery } from 'gatsby';
@@ -124,7 +124,7 @@ ComponentNavItem.defaultProps = {
 };
 
 export type MenuComponentListTypes = {
-  children: React.ReactNode,
+  children: ReactNode,
 };
 
 function MenuComponentList({ children }: MenuComponentListTypes) {
@@ -138,7 +138,7 @@ MenuComponentList.propTypes = {
 };
 
 export interface IMenuComponentListCategory {
-  children: React.ReactNode,
+  children: ReactNode,
   title: string,
 }
 

--- a/www/src/components/PageEditBtn/index.tsx
+++ b/www/src/components/PageEditBtn/index.tsx
@@ -1,4 +1,4 @@
-import React, { AnchorHTMLAttributes } from 'react';
+import { AnchorHTMLAttributes } from 'react';
 import { Button, Hyperlink, Nav } from '~paragon-react';
 import { PAGE_EDIT_BTN_CLICKED_EVENT, sendUserAnalyticsEvent } from '../../../segment-events';
 

--- a/www/src/components/PageLayout.tsx
+++ b/www/src/components/PageLayout.tsx
@@ -5,7 +5,7 @@
  * See: https://www.gatsbyjs.com/docs/use-static-query/
  */
 
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, Link } from 'gatsby';
@@ -30,7 +30,7 @@ import AutoToc from './AutoToc';
 import PageEditBtn from './PageEditBtn';
 
 export interface ILayout {
-  children: React.ReactNode,
+  children: ReactNode,
   showMinimizedTitle: boolean,
   hideFooterComponentMenu: boolean,
   isMdx: boolean,

--- a/www/src/components/PropType.tsx
+++ b/www/src/components/PropType.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Badge } from '~paragon-react';
 
 export type RequiredBadgeTypes = {

--- a/www/src/components/PropsTable.tsx
+++ b/www/src/components/PropsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Markdown from 'react-markdown';
 import { Badge, Card, Hyperlink } from '~paragon-react';

--- a/www/src/components/RemoveThemeModal.tsx
+++ b/www/src/components/RemoveThemeModal.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useEffect } from 'react';
+import type { FC } from 'react';
+import { useRef, useEffect } from 'react';
 import {
   Button,
   ActionRow,
@@ -12,7 +13,7 @@ interface RemoveThemeModalProps {
   themeName: string;
 }
 
-const RemoveThemeModal: React.FC<RemoveThemeModalProps> = ({
+const RemoveThemeModal: FC<RemoveThemeModalProps> = ({
   isOpen,
   onClose,
   onConfirm,

--- a/www/src/components/ResetThemesModal.tsx
+++ b/www/src/components/ResetThemesModal.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useEffect } from 'react';
+import type { FC } from 'react';
+import { useRef, useEffect } from 'react';
 import {
   Button,
   ActionRow,
@@ -11,7 +12,7 @@ interface ResetThemesModalProps {
   onConfirm: () => void;
 }
 
-const ResetThemesModal: React.FC<ResetThemesModalProps> = ({
+const ResetThemesModal: FC<ResetThemesModalProps> = ({
   isOpen,
   onClose,
   onConfirm,

--- a/www/src/components/SEO.tsx
+++ b/www/src/components/SEO.tsx
@@ -5,7 +5,6 @@
  * See: https://www.gatsbyjs.com/docs/use-static-query/
  */
 
-import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';

--- a/www/src/components/Search/HitComponent.jsx
+++ b/www/src/components/Search/HitComponent.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import AlgoliaClient from './client';
 

--- a/www/src/components/Search/index.jsx
+++ b/www/src/components/Search/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { DocSearch } from '@docsearch/react';
 

--- a/www/src/components/Settings.tsx
+++ b/www/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'gatsby';
-import React, { useContext } from 'react';
+import type { ChangeEvent } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Close } from '~paragon-icons';
 import {
@@ -28,7 +29,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
   } = useContext(SettingsContext);
 
   return (
-    <Sheet
+    (<Sheet
       position="right"
       show={showSettings}
       variant="light"
@@ -50,7 +51,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
             <Form.Label className="pgn-doc__settings-label">Text direction</Form.Label>
             <Form.RadioSet
               name="direction"
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleSettingsChange('direction', e.target.value)}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => handleSettingsChange('direction', e.target.value)}
               value={settings.direction}
             >
               <Form.Radio value="ltr">Left to right</Form.Radio>
@@ -80,7 +81,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
               <Form.Control
                 as="select"
                 value={settings.containerWidth}
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleSettingsChange('containerWidth', e.target.value)}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => handleSettingsChange('containerWidth', e.target.value)}
               >
                 <option value="xs">xs</option>
                 <option value="sm">sm</option>
@@ -104,7 +105,7 @@ function Settings({ showMinimizedTitle }: ISetting) {
           </Nav>
         </Stack>
       </div>
-    </Sheet>
+    </Sheet>)
   );
 }
 

--- a/www/src/components/TableCells.tsx
+++ b/www/src/components/TableCells.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MeasuredItem from './MeasuredItem';
 import measuredTypeProps from './typography-page/measuredTypeProps';
 

--- a/www/src/components/ThemeDisplay.tsx
+++ b/www/src/components/ThemeDisplay.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type { FC } from 'react';
 import { type Theme } from '../types/types';
 
 interface ThemeDisplayProps {
   currentTheme: Theme;
 }
 
-const ThemeDisplay: React.FC<ThemeDisplayProps> = ({ currentTheme }) => (
+const ThemeDisplay: FC<ThemeDisplayProps> = ({ currentTheme }) => (
   <div>
     <div className="small">Current theme:</div>
     <div className="font-weight-bold">

--- a/www/src/components/ThemeOptions.tsx
+++ b/www/src/components/ThemeOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent, MutableRefObject, RefObject, FC } from 'react';
 import {
   Button,
   Stack,
@@ -11,16 +11,16 @@ import { hasUrls } from '../utils/themeUtils';
 interface ThemeOptionsProps {
   themes: Theme[];
   currentThemeValue: string;
-  onThemeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onThemeChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onEditTheme: (themeIndex: number) => void;
   hasCustomThemes: boolean;
   onResetClick: () => void;
   onAddClick: () => void;
-  radioRefs: React.MutableRefObject<(HTMLInputElement | null)[]>;
-  addButtonRef?: React.RefObject<HTMLButtonElement>;
+  radioRefs: MutableRefObject<(HTMLInputElement | null)[]>;
+  addButtonRef?: RefObject<HTMLButtonElement>;
 }
 
-const ThemeOptions: React.FC<ThemeOptionsProps> = ({
+const ThemeOptions: FC<ThemeOptionsProps> = ({
   themes,
   currentThemeValue,
   onThemeChange,

--- a/www/src/components/ThemeSelector.tsx
+++ b/www/src/components/ThemeSelector.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from 'react';
+import type { ChangeEvent } from 'react';
+import { useRef } from 'react';
 import {
   Stack,
   Collapsible,
@@ -107,7 +108,7 @@ export default function ThemeSelector() {
     handleResetConfirm,
   } = useResetModal(resetThemes, handleResetComplete);
 
-  const handleThemeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleThemeChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     const themeIndex = parseInt(value, 10);
     setCurrentTheme(themeIndex);

--- a/www/src/components/Toc.tsx
+++ b/www/src/components/Toc.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Sticky } from '~paragon-react';

--- a/www/src/components/css-utilities-table/Declaration.tsx
+++ b/www/src/components/css-utilities-table/Declaration.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { MouseEvent } from 'react';
 import PropTypes from 'prop-types';
 import { colorCSSDeclaration, containsCSSVariable } from './utils';
 
@@ -7,17 +7,17 @@ export default function CSSDeclaration({ declaration, handleMouseEnter, handleMo
 
   if (containsCSSVariable(value)) {
     return (
-      <code style={{ fontSize: '14px' }} key={declaration} className="mb-0 text-muted">
+      (<code style={{ fontSize: '14px' }} key={declaration} className="mb-0 text-muted">
         <span>{attribute}: </span>
         <span
-          onMouseEnter={(e: React.MouseEvent) => handleMouseEnter(e, declaration)}
+          onMouseEnter={(e: MouseEvent) => handleMouseEnter(e, declaration)}
           onMouseLeave={() => handleMouseLeave()}
           style={{ cursor: 'pointer', textDecoration: 'underline dotted' }}
         >
           {colorCSSDeclaration(value.trim())}
         </span>
         {importantFlag && <span> !important;</span>}
-      </code>
+      </code>)
     );
   }
 
@@ -30,7 +30,7 @@ export default function CSSDeclaration({ declaration, handleMouseEnter, handleMo
 
 interface DeclarationData {
   declaration: string,
-  handleMouseEnter: (e: React.MouseEvent, declaration: string) => void,
+  handleMouseEnter: (e: MouseEvent, declaration: string) => void,
   handleMouseLeave: () => void,
 }
 

--- a/www/src/components/css-utilities-table/index.tsx
+++ b/www/src/components/css-utilities-table/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import type { MouseEvent } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 // @ts-ignore
 import { DataTable, Overlay, Popover } from '~paragon-react'; // eslint-disable-line
@@ -20,7 +21,7 @@ function CSSUtilitiesTable({ selectors }: CSSUtilities) {
     return () => { document.body.removeChild(dummyDiv); };
   }, []);
 
-  const handleCSSVariableMouseEnter = (e: React.MouseEvent, declaration: string) => {
+  const handleCSSVariableMouseEnter = (e: MouseEvent, declaration: string) => {
     setPopoverTarget(e.target as HTMLElement);
     setShowPopover(true);
 

--- a/www/src/components/css-utilities-table/utils.tsx
+++ b/www/src/components/css-utilities-table/utils.tsx
@@ -1,8 +1,3 @@
-import React from 'react';
-
-/**
- * Convert hex value to [r, g, b] array, hex value must be a string of 6 characters without leading #.
- */
 function convertHexToRgb(hexColor: string) {
   if (hexColor.length !== 6) {
     throw new Error('Invalid HEX color, it must contain only 6 digits and be without starting #.');

--- a/www/src/components/doc-elements.tsx
+++ b/www/src/components/doc-elements.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 export interface IComponentStatus {

--- a/www/src/components/exampleComponents/ExamplePropsForm.tsx
+++ b/www/src/components/exampleComponents/ExamplePropsForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Form, Badge } from '~paragon-react';
 

--- a/www/src/components/exampleComponents/HipsterIpsum.tsx
+++ b/www/src/components/exampleComponents/HipsterIpsum.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 /**
  * Randomly shuffle an array
@@ -77,7 +77,7 @@ const useHipsterIpsumContent = ({
   return getHipsterIpsumContent(shuffledParagraphs, numParagraphs);
 };
 
-const HipsterIpsum: React.FC<HipsterIpsumType> = ({
+const HipsterIpsum: FC<HipsterIpsumType> = ({
   numParagraphs = 2,
   numShortParagraphs,
 }) => {

--- a/www/src/components/exampleComponents/MiyazakiCard.tsx
+++ b/www/src/components/exampleComponents/MiyazakiCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '~paragon-react';
 

--- a/www/src/components/header/Header.tsx
+++ b/www/src/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useState } from 'react';
+import { useEffect, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   useToggle,

--- a/www/src/components/header/Navbar.tsx
+++ b/www/src/components/header/Navbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { SetStateAction, Dispatch } from 'react';
 import PropTypes from 'prop-types';
 import { MenuIcon, Close, Settings } from '~paragon-icons';
 import {
@@ -16,7 +16,7 @@ import Search from '../Search';
 export interface INavbar {
   siteTitle: string,
   onMenuClick: () => void,
-  setTarget: React.Dispatch<React.SetStateAction<HTMLButtonElement | null>>,
+  setTarget: Dispatch<SetStateAction<HTMLButtonElement | null>>,
   onSettingsClick?: () => void,
   menuIsOpen?: boolean,
   showMinimizedTitle?: boolean,

--- a/www/src/components/header/SiteTitle.tsx
+++ b/www/src/components/header/SiteTitle.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link } from 'gatsby';

--- a/www/src/components/insights/ComponentUsage.tsx
+++ b/www/src/components/insights/ComponentUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable } from '~paragon-react';
 import ComponentUsageExamples, { IComponentUsageExamples } from './ComponentUsageExamples';

--- a/www/src/components/insights/ComponentUsageExamples.tsx
+++ b/www/src/components/insights/ComponentUsageExamples.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import UsagesList from './UsagesList';
 

--- a/www/src/components/insights/ComponentsUsage.tsx
+++ b/www/src/components/insights/ComponentsUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ComponentUsage from './ComponentUsage';
 
 import componentsUsage from '../../utils/componentsUsage';

--- a/www/src/components/insights/HooksUsage.tsx
+++ b/www/src/components/insights/HooksUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ComponentUsage from './ComponentUsage';
 
 import componentsUsage from '../../utils/componentsUsage';

--- a/www/src/components/insights/IconsUsage.tsx
+++ b/www/src/components/insights/IconsUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ComponentUsage from './ComponentUsage';
 
 import componentsUsage from '../../utils/componentsUsage';

--- a/www/src/components/insights/ProjectUsageExamples.tsx
+++ b/www/src/components/insights/ProjectUsageExamples.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import UsagesList from './UsagesList';
 

--- a/www/src/components/insights/ProjectsUsage.tsx
+++ b/www/src/components/insights/ProjectsUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DataTable } from '~paragon-react';
 import ProjectUsageExamples, { IProjectUsageExamples } from './ProjectUsageExamples';
 

--- a/www/src/components/insights/SummaryUsage.tsx
+++ b/www/src/components/insights/SummaryUsage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import {
   DataTable,
   TextFilter,

--- a/www/src/components/insights/SummaryUsageExamples.tsx
+++ b/www/src/components/insights/SummaryUsageExamples.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import UsagesList from './UsagesList';
 

--- a/www/src/components/insights/UsagesList.tsx
+++ b/www/src/components/insights/UsagesList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Hyperlink } from '~paragon-react';
 import { USAGE_INSIGHTS_EVENTS, sendUserAnalyticsEvent } from '../../../segment-events';

--- a/www/src/components/insights/UtilsUsage.tsx
+++ b/www/src/components/insights/UtilsUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ComponentUsage from './ComponentUsage';
 
 import componentsUsage from '../../utils/componentsUsage';

--- a/www/src/components/typography-page/Alignment.tsx
+++ b/www/src/components/typography-page/Alignment.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-// @ts-ignore
 import { DataTable } from '~paragon-react';
 import { ClassNameCell, StyleCell } from '../TableCells';
 

--- a/www/src/components/typography-page/Body.tsx
+++ b/www/src/components/typography-page/Body.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DataTable } from '~paragon-react';
 
 import { DesktopMeasuredCell, ClassNameCell, ClassNameRowType } from '../TableCells';

--- a/www/src/components/typography-page/DecorationAndEmphasis.tsx
+++ b/www/src/components/typography-page/DecorationAndEmphasis.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-// @ts-ignore
 import { DataTable } from '~paragon-react';
 import { ClassNameCell, StyleCell } from '../TableCells';
 

--- a/www/src/components/typography-page/Display.tsx
+++ b/www/src/components/typography-page/Display.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-// @ts-ignore
 import { DataTable } from '~paragon-react';
 
 import { ClassNameCell, DesktopMeasuredCell, MobileMeasuredCell } from '../TableCells';

--- a/www/src/components/typography-page/Headings.tsx
+++ b/www/src/components/typography-page/Headings.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-// @ts-ignore
 import { DataTable } from '~paragon-react';
 
 import { MobileMeasuredCell, ClassNameCell, DesktopMeasuredCell } from '../TableCells';

--- a/www/src/components/typography-page/Links.tsx
+++ b/www/src/components/typography-page/Links.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-// @ts-ignore
 import { DataTable, Alert } from '~paragon-react';
 import { Info } from '~paragon-icons';
 import { TextCell } from '../TableCells';

--- a/www/src/components/typography-page/measuredTypeProps.tsx
+++ b/www/src/components/typography-page/measuredTypeProps.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const weightLabels: Record<string, string> = {
   200: 'Light',
   300: 'Light',

--- a/www/src/context/InsightsContext.tsx
+++ b/www/src/context/InsightsContext.tsx
@@ -1,6 +1,4 @@
-import React, {
-  createContext, useState, useEffect, useMemo,
-} from 'react';
+import { createContext, useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as Icons from '~paragon-icons';
 import * as Components from '~paragon-react';

--- a/www/src/context/SettingsContext.tsx
+++ b/www/src/context/SettingsContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useEffect } from 'react';
+import type { SyntheticEvent, ReactNode } from 'react';
+import { createContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { messages, type ContainerSize } from '~paragon-react';
@@ -21,7 +22,7 @@ export interface IDefaultValue {
   updateTheme: Function,
   removeTheme: Function,
   resetThemes: Function,
-  showSettings?: React.SyntheticEvent | React.ReactNode,
+  showSettings?: SyntheticEvent | ReactNode,
   closeSettings?: () => void,
   openSettings?: () => void,
 }

--- a/www/src/context/ThemeFormContext.tsx
+++ b/www/src/context/ThemeFormContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, ReactNode } from 'react';
+import type { FC } from 'react';
+import { createContext, useContext, ReactNode } from 'react';
 import { type Theme, type ThemeConfig } from '../types/types';
 
 interface ThemeFormContextValue {
@@ -14,7 +15,7 @@ interface ThemeFormProviderProps {
   onSaveTheme: (theme: ThemeConfig) => void;
 }
 
-export const ThemeFormProvider: React.FC<ThemeFormProviderProps> = ({
+export const ThemeFormProvider: FC<ThemeFormProviderProps> = ({
   children,
   existingThemes,
   onSaveTheme,

--- a/www/src/pages/404.tsx
+++ b/www/src/pages/404.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import Layout from '../components/PageLayout';

--- a/www/src/pages/foundations/colors.tsx
+++ b/www/src/pages/foundations/colors.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/www/src/pages/foundations/css-utilities.tsx
+++ b/www/src/pages/foundations/css-utilities.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { graphql, type PageProps } from 'gatsby';
 import PageTemplate, { type StandardContext } from '../../templates/default-mdx-page-template';
 

--- a/www/src/pages/foundations/elevation.tsx
+++ b/www/src/pages/foundations/elevation.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Close, WbSunny, DoDisturb } from '~paragon-icons';
 import {
@@ -117,7 +118,7 @@ function BoxShadowToolkit({
   };
 
   return (
-    <section className="pgn-doc__box-shadow-toolkit--controls-box">
+    (<section className="pgn-doc__box-shadow-toolkit--controls-box">
       {controlsProps.map(({ key, name }) => (
         <Form.Group key={key}>
           <Form.Label
@@ -132,7 +133,7 @@ function BoxShadowToolkit({
             max="100"
             type={key === 'color' ? 'color' : 'range'}
             defaultValue="0"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateBoxShadowModel(key, e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => updateBoxShadowModel(key, e.target.value)}
             disabled={isDisabled}
           />
         </Form.Group>
@@ -183,7 +184,7 @@ function BoxShadowToolkit({
           )}
         </div>
       </div>
-    </section>
+    </section>)
   );
 }
 

--- a/www/src/pages/foundations/layout.tsx
+++ b/www/src/pages/foundations/layout.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { graphql, type PageProps } from 'gatsby';
 import PageTemplate, { type StandardContext } from '../../templates/default-mdx-page-template';
 

--- a/www/src/pages/foundations/responsive.tsx
+++ b/www/src/pages/foundations/responsive.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { QuestionMark } from '~paragon-icons';
 import {

--- a/www/src/pages/foundations/spacing.tsx
+++ b/www/src/pages/foundations/spacing.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Form, DataTable, Container } from '~paragon-react'; // eslint-disable-line
@@ -106,7 +107,7 @@ export default function SpacingPage({ pageContext }) {
   });
 
   return (
-    <Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
+    (<Layout isAutoToc githubEditPath={pageContext.githubEditPath}>
       {/* eslint-disable-next-line react/jsx-pascal-case */}
       <SEO title="Spacing" />
       <Container size={settings.containerWidth} className="py-5">
@@ -139,7 +140,7 @@ export default function SpacingPage({ pageContext }) {
                 name="direction-selector"
                 value={direction}
                 isInline
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDirection(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setDirection(e.target.value)}
               >
                 {directions.map(({ key, name }) => (
                   <Form.Radio
@@ -170,7 +171,7 @@ export default function SpacingPage({ pageContext }) {
                   step={0.5}
                   max={6}
                   value={size}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSize(parseInt(e.target.value, 10))}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setSize(parseInt(e.target.value, 10))}
                 />
                 6
               </div>
@@ -231,7 +232,7 @@ export default function SpacingPage({ pageContext }) {
           <DataTable.Table />
         </DataTable>
       </Container>
-    </Layout>
+    </Layout>)
   );
 }
 

--- a/www/src/pages/foundations/typography.tsx
+++ b/www/src/pages/foundations/typography.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Container } from '~paragon-react';
 import Layout from '../../components/PageLayout';

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from '~paragon-react';
 import Layout from '../components/PageLayout';
 import SEO from '../components/SEO';

--- a/www/src/pages/insights.tsx
+++ b/www/src/pages/insights.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { navigate } from 'gatsby';
 import PropTypes from 'prop-types';
 import {

--- a/www/src/pages/playground.tsx
+++ b/www/src/pages/playground.tsx
@@ -1,6 +1,6 @@
 import { navigate } from 'gatsby';
 import localforage from 'localforage';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ContentCopy, Check } from '~paragon-icons';
 import {

--- a/www/src/pages/status.tsx
+++ b/www/src/pages/status.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
 import { DataTable, Container } from '~paragon-react'; // eslint-disable-line

--- a/www/src/templates/component-page-template.tsx
+++ b/www/src/templates/component-page-template.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { graphql, Link } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import classNames from 'classnames';
@@ -43,13 +44,13 @@ export interface IPageTemplate {
     componentsUsageInsights: string[],
     githubEditPath: string,
   },
-  children: React.ReactNode,
+  children: ReactNode,
 }
 
 interface HProps {
   // We know that our heading elements (<h1>, <h2>, etc.) will always have content (children) and IDs:
   id: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const customMdxComponents = {

--- a/www/src/templates/default-mdx-page-template.tsx
+++ b/www/src/templates/default-mdx-page-template.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import type { ReactNode } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { MDXProvider } from '@mdx-js/react';
 import { Link } from 'gatsby';
@@ -12,7 +13,7 @@ import { SettingsContext } from '../context/SettingsContext';
 interface HProps {
   // We know that our heading elements (<h1>, <h2>, etc.) will always have content (children) and IDs:
   id: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const shortcodes = {
@@ -34,7 +35,7 @@ export interface StandardContext {
 }
 
 export interface IPageTemplateType {
-  children: React.ReactNode;
+  children: ReactNode;
   pageContext: StandardContext;
 }
 


### PR DESCRIPTION
## Description

Removing React imports that are not required anymore on newer versions. Some of the imports were deconstructed to remove the usage of the global React object.
Most of the modifications were performed using the [react/update-react-imports codemod](https://app.codemod.com/registry/react/update-react-imports).
Also modified the babel config file to use the JSX Transform (introduced in React 17).
Closes https://github.com/openedx/paragon/issues/3796


### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
