### PR TITLE
feat: adding classname prop to sheet component

### DIFF
--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -55,9 +55,9 @@ describe('<Sheet />', () => {
       expect(container2.firstChild).not.toBeNull();
     });
 
-    it('renders with custom sheetClassName', () => {
+    it('renders with custom className', () => {
       const customClassName = 'custom-class';
-      const { container } = render(<Sheet sheetClassName={customClassName} />);
+      const { container } = render(<Sheet className={customClassName} />);
       const sheetElement = container.querySelector('.pgn__sheet-component');
 
       expect(sheetElement).toBeInTheDocument();
@@ -65,9 +65,9 @@ describe('<Sheet />', () => {
       expect(sheetElement).toHaveClass(customClassName);
     });
 
-    it('handles multiple custom sheetClassName', () => {
+    it('handles multiple custom className', () => {
       const customClasses = 'class-one class-two';
-      const { container } = render(<Sheet sheetClassName={customClasses} />);
+      const { container } = render(<Sheet className={customClasses} />);
       const sheetElement = container.querySelector('.pgn__sheet-component');
 
       expect(sheetElement).toHaveClass('pgn__sheet-component');
@@ -77,7 +77,7 @@ describe('<Sheet />', () => {
 
     it('renders with custom className on SheetContainer', () => {
       const customClassName = 'custom-container-class';
-      const { getByTestId } = render(<Sheet className={customClassName} />);
+      const { getByTestId } = render(<Sheet containerClassName={customClassName} />);
       const sheetContainer = getByTestId('sheet-container');
 
       expect(sheetContainer).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('<Sheet />', () => {
 
     it('handles multiple custom className values on SheetContainer', () => {
       const customClasses = 'container-one container-two';
-      const { getByTestId } = render(<Sheet className={customClasses} />);
+      const { getByTestId } = render(<Sheet containerClassName={customClasses} />);
       const sheetContainer = getByTestId('sheet-container');
 
       expect(sheetContainer).toBeInTheDocument();
@@ -96,11 +96,11 @@ describe('<Sheet />', () => {
       expect(sheetContainer).toHaveClass('container-two');
     });
 
-    it('handles className and sheetClassName simultaneously', () => {
+    it('handles className and containerClassName simultaneously', () => {
       const containerClass = 'container-class';
       const sheetClass = 'sheet-class';
       const { getByTestId, container } = render(
-        <Sheet className={containerClass} sheetClassName={sheetClass} />,
+        <Sheet containerClassName={containerClass} className={sheetClass} />,
       );
       const sheetContainer = getByTestId('sheet-container');
       const sheetElement = container.querySelector('.pgn__sheet-component');

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -6,11 +6,12 @@ import Sheet, { POSITIONS, VARIANTS } from '.';
 
 /* eslint-disable react/prop-types */
 jest.mock('./SheetContainer', () => function SheetContainerMock(props) {
-  const { children, ...otherProps } = props;
+  const { children, className, ...otherProps } = props;
+  const allClasses = ['sheet-container', className].filter(Boolean).join(' ');
   return (
-    <sheet-container {...otherProps}>
+    <div data-testid="sheet-container" className={allClasses} {...otherProps}>
       {children}
-    </sheet-container>
+    </div>
   );
 });
 
@@ -52,6 +53,65 @@ describe('<Sheet />', () => {
       expect(container.firstChild).toBeNull();
       const { container: container2 } = render(<Sheet />);
       expect(container2.firstChild).not.toBeNull();
+    });
+
+    it('renders with custom sheetClassName', () => {
+      const customClassName = 'custom-class';
+      const { container } = render(<Sheet sheetClassName={customClassName} />);
+      const sheetElement = container.querySelector('.pgn__sheet-component');
+
+      expect(sheetElement).toBeInTheDocument();
+      expect(sheetElement).toHaveClass('pgn__sheet-component');
+      expect(sheetElement).toHaveClass(customClassName);
+    });
+
+    it('handles multiple custom sheetClassName', () => {
+      const customClasses = 'class-one class-two';
+      const { container } = render(<Sheet sheetClassName={customClasses} />);
+      const sheetElement = container.querySelector('.pgn__sheet-component');
+
+      expect(sheetElement).toHaveClass('pgn__sheet-component');
+      expect(sheetElement).toHaveClass('class-one');
+      expect(sheetElement).toHaveClass('class-two');
+    });
+
+    it('renders with custom className on SheetContainer', () => {
+      const customClassName = 'custom-container-class';
+      const { getByTestId } = render(<Sheet className={customClassName} />);
+      const sheetContainer = getByTestId('sheet-container');
+
+      expect(sheetContainer).toBeInTheDocument();
+      expect(sheetContainer).toHaveClass('sheet-container');
+      expect(sheetContainer).toHaveClass(customClassName);
+    });
+
+    it('handles multiple custom className values on SheetContainer', () => {
+      const customClasses = 'container-one container-two';
+      const { getByTestId } = render(<Sheet className={customClasses} />);
+      const sheetContainer = getByTestId('sheet-container');
+
+      expect(sheetContainer).toBeInTheDocument();
+      expect(sheetContainer).toHaveClass('sheet-container');
+      expect(sheetContainer).toHaveClass('container-one');
+      expect(sheetContainer).toHaveClass('container-two');
+    });
+
+    it('handles className and sheetClassName simultaneously', () => {
+      const containerClass = 'container-class';
+      const sheetClass = 'sheet-class';
+      const { getByTestId, container } = render(
+        <Sheet className={containerClass} sheetClassName={sheetClass} />,
+      );
+      const sheetContainer = getByTestId('sheet-container');
+      const sheetElement = container.querySelector('.pgn__sheet-component');
+
+      expect(sheetContainer).toBeInTheDocument();
+      expect(sheetContainer).toHaveClass('sheet-container');
+      expect(sheetContainer).toHaveClass(containerClass);
+
+      expect(sheetElement).toBeInTheDocument();
+      expect(sheetElement).toHaveClass('pgn__sheet-component');
+      expect(sheetElement).toHaveClass(sheetClass);
     });
   });
 });

--- a/src/Sheet/SheetContainer.jsx
+++ b/src/Sheet/SheetContainer.jsx
@@ -19,6 +19,7 @@ class SheetContainer extends React.Component {
   updateRootElement = () => {
     const { className } = this.props;
 
+    /* istanbul ignore next */
     if (typeof document === 'undefined') {
       this.rootElement = null;
       return;

--- a/src/Sheet/SheetContainer.jsx
+++ b/src/Sheet/SheetContainer.jsx
@@ -1,23 +1,43 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 class SheetContainer extends React.Component {
   constructor(props) {
     super(props);
     this.sheetRootName = 'sheet-root';
-    if (typeof document === 'undefined') {
-      this.rootElement = null;
-    } else if (document.getElementById(this.sheetRootName)) {
-      this.rootElement = document.getElementById(this.sheetRootName);
-    } else {
-      const rootElement = document.createElement('div');
-      rootElement.setAttribute('id', this.sheetRootName);
-      rootElement.setAttribute('class', 'sheet-container');
-      rootElement.setAttribute('data-testid', 'sheet-container');
-      this.rootElement = document.body.appendChild(rootElement);
+    this.updateRootElement();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.className !== this.props.className) {
+      this.updateRootElement();
     }
   }
+
+  updateRootElement = () => {
+    const { className } = this.props;
+
+    if (typeof document === 'undefined') {
+      this.rootElement = null;
+      return;
+    }
+
+    let rootElement = document.getElementById(this.sheetRootName);
+
+    if (!rootElement) {
+      rootElement = document.createElement('div');
+      rootElement.setAttribute('id', this.sheetRootName);
+      rootElement.setAttribute('data-testid', 'sheet-container');
+      document.body.appendChild(rootElement);
+    }
+
+    const classes = classNames('sheet-container', className);
+    rootElement.setAttribute('class', classes);
+
+    this.rootElement = rootElement;
+  };
 
   render() {
     if (this.rootElement) {
@@ -32,6 +52,12 @@ class SheetContainer extends React.Component {
 
 SheetContainer.propTypes = {
   children: PropTypes.node.isRequired,
+  /** Additional CSS classes to apply to the sheet container */
+  className: PropTypes.string,
+};
+
+SheetContainer.defaultProps = {
+  className: undefined,
 };
 
 export default SheetContainer;

--- a/src/Sheet/SheetContainer.test.jsx
+++ b/src/Sheet/SheetContainer.test.jsx
@@ -31,4 +31,13 @@ describe('<SheetContainer />', () => {
     const childEl2 = screen.getByText(childContent2);
     expect(childEl2).toBeTruthy();
   });
+
+  it('applies custom className if provided', () => {
+    const customClass = 'custom-class';
+    render(<SheetContainer className={customClass}>{child1}</SheetContainer>);
+    const rootEl = screen.getByTestId('sheet-container');
+    expect(rootEl).toBeTruthy();
+    expect(rootEl.className).toContain('sheet-container');
+    expect(rootEl.className).toContain(customClass);
+  });
 });

--- a/src/Sheet/SheetContainer.test.jsx
+++ b/src/Sheet/SheetContainer.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import SheetContainer from './SheetContainer';
 
 const childId1 = 'sheet-container-TEST-child1';
@@ -39,5 +39,29 @@ describe('<SheetContainer />', () => {
     expect(rootEl).toBeTruthy();
     expect(rootEl.className).toContain('sheet-container');
     expect(rootEl.className).toContain(customClass);
+  });
+
+  it('calls updateRootElement when className changes (componentDidUpdate)', () => {
+    const { rerender } = render(
+      <SheetContainer className="first-class">
+        <div>Content</div>
+      </SheetContainer>,
+    );
+
+    const sheetRoot = document.getElementById('sheet-root');
+    expect(sheetRoot).toHaveClass('sheet-container');
+    expect(sheetRoot).toHaveClass('first-class');
+
+    act(() => {
+      rerender(
+        <SheetContainer className="second-class">
+          <div>Content</div>
+        </SheetContainer>,
+      );
+    });
+
+    expect(sheetRoot).toHaveClass('sheet-container');
+    expect(sheetRoot).toHaveClass('second-class');
+    expect(sheetRoot).not.toHaveClass('first-class');
   });
 });

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
-<sheet-container>
+<div
+  className="sheet-container"
+  data-testid="sheet-container"
+>
   <div
     className="pgn__sheet-skrim"
     role="presentation"
@@ -28,11 +31,14 @@ exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
       />
     </div>
   </focus-on>
-</sheet-container>
+</div>
 `;
 
 exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
-<sheet-container>
+<div
+  className="sheet-container"
+  data-testid="sheet-container"
+>
   <div
     className="pgn__sheet-skrim hidden"
     role="presentation"
@@ -59,11 +65,14 @@ exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
       />
     </div>
   </focus-on>
-</sheet-container>
+</div>
 `;
 
 exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
-<sheet-container>
+<div
+  className="sheet-container"
+  data-testid="sheet-container"
+>
   <div
     className="pgn__sheet-skrim hidden"
     role="presentation"
@@ -96,5 +105,5 @@ exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
       </div>
     </div>
   </focus-on>
-</sheet-container>
+</div>
 `;

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -27,7 +27,7 @@ class Sheet extends React.Component {
 
   renderSheet() {
     const {
-      children, position, variant, sheetClassName,
+      children, position, variant, className,
     } = this.props;
     return (
       <div
@@ -35,7 +35,7 @@ class Sheet extends React.Component {
           'pgn__sheet-component',
           `pgn__sheet__${variant}`,
           position,
-          sheetClassName,
+          className,
         )}
         role="alert"
         aria-live="polite"
@@ -53,13 +53,13 @@ class Sheet extends React.Component {
       blocking,
       show,
       onClose,
-      className,
+      containerClassName,
     } = this.props;
     if (!show) {
       return null;
     }
     return (
-      <SheetContainer className={classNames(className)}>
+      <SheetContainer className={classNames(containerClassName)}>
         <div
           className={classNames(
             'pgn__sheet-skrim',
@@ -84,6 +84,10 @@ Sheet.propTypes = {
   blocking: PropTypes.bool,
   /** an element rendered inside the sheet */
   children: PropTypes.node,
+  /** A class that is appended to the sheet container element. */
+  containerClassName: PropTypes.string,
+  /** A class that is appended to the sheet element. */
+  className: PropTypes.string,
   /** a string designating the sheet's position on the window */
   position: PropTypes.oneOf([
     POSITIONS.left,
@@ -97,10 +101,6 @@ Sheet.propTypes = {
   onClose: PropTypes.func,
   /** a string designating which version of the sheet to show (light vs dark) */
   variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark]),
-  /** A class that is appended to the base element. */
-  className: PropTypes.string,
-  /** A class that is appended to the sheet element. */
-  sheetClassName: PropTypes.string,
 };
 
 Sheet.defaultProps = {
@@ -110,8 +110,8 @@ Sheet.defaultProps = {
   show: true,
   onClose: () => {},
   variant: VARIANTS.light,
+  containerClassName: undefined,
   className: undefined,
-  sheetClassName: undefined,
 };
 
 export default Sheet;

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -26,13 +26,16 @@ class Sheet extends React.Component {
   }
 
   renderSheet() {
-    const { children, position, variant } = this.props;
+    const {
+      children, position, variant, sheetClassName,
+    } = this.props;
     return (
       <div
         className={classNames(
           'pgn__sheet-component',
           `pgn__sheet__${variant}`,
           position,
+          sheetClassName,
         )}
         role="alert"
         aria-live="polite"
@@ -50,12 +53,13 @@ class Sheet extends React.Component {
       blocking,
       show,
       onClose,
+      className,
     } = this.props;
     if (!show) {
       return null;
     }
     return (
-      <SheetContainer>
+      <SheetContainer className={classNames(className)}>
         <div
           className={classNames(
             'pgn__sheet-skrim',
@@ -93,6 +97,10 @@ Sheet.propTypes = {
   onClose: PropTypes.func,
   /** a string designating which version of the sheet to show (light vs dark) */
   variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark]),
+  /** A class that is appended to the base element. */
+  className: PropTypes.string,
+  /** A class that is appended to the sheet element. */
+  sheetClassName: PropTypes.string,
 };
 
 Sheet.defaultProps = {
@@ -102,6 +110,8 @@ Sheet.defaultProps = {
   show: true,
   onClose: () => {},
   variant: VARIANTS.light,
+  className: undefined,
+  sheetClassName: undefined,
 };
 
 export default Sheet;


### PR DESCRIPTION
## Description

Adding classname props to Sheet component, the props added are:

- sheetClassName: to specify custom classes to the sheet element
- className: to specify custom classes to the base/container element

Also created the unit tests to support these additions.
It closes https://github.com/openedx/paragon/issues/3750

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
