### PR TITLE
fix: allow DataTable filters to use different name and value in filterChoices

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -423,17 +423,17 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
           Filter: CheckboxFilter,
           filter: 'includesValue',
           filterChoices: [{
-            name: 'orange tabby',
+            name: 'Orange Tabby',
             number: 1,
             value: 'orange tabby',
           },
           {
-            name: 'brown tabby',
+            name: 'Brown Tabby',
             number: 1,
             value: 'brown tabby',
           },
           {
-            name: 'siamese',
+            name: 'Siamese',
             number: 1,
             value: 'siamese',
           }],
@@ -503,17 +503,17 @@ See ``dataViewToggleOptions`` props documentation for all supported props.
           Filter: CheckboxFilter,
           filter: 'includesValue',
           filterChoices: [{
-            name: 'orange tabby',
+            name: 'Orange Tabby',
             number: 1,
             value: 'orange tabby',
           },
           {
-            name: 'brown tabby',
+            name: 'Brown Tabby',
             number: 1,
             value: 'brown tabby',
           },
           {
-            name: 'siamese',
+            name: 'Siamese',
             number: 1,
             value: 'siamese',
           }]
@@ -1306,17 +1306,17 @@ For a more desktop friendly view, you can move filters into a sidebar by providi
         Filter: CheckboxFilter,
         filter: 'includesValue',
         filterChoices: [{
-          name: 'orange tabby',
+          name: 'Orange Tabby',
           number: 2,
           value: 'orange tabby',
         },
         {
-          name: 'brown tabby',
+          name: 'Brown Tabby',
           number: 2,
           value: 'brown tabby',
         },
         {
-          name: 'siamese',
+          name: 'Siamese',
           number: 1,
           value: 'siamese',
         }]
@@ -1659,17 +1659,17 @@ After selecting the maximum possible number of rows, you can display an error me
           filter: 'includesValue',
           filterChoices: [
             {
-              name: 'russian white',
+              name: 'Russian white',
               number: 1,
               value: 'russian white',
             },
             {
-              name: 'orange tabby',
+              name: 'Orange Tabby',
               number: 2,
               value: 'orange tabby',
             },
             {
-              name: 'brown tabby',
+              name: 'Brown Tabby',
               number: 3,
               value: 'brown tabby',
             },

--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -31,7 +31,7 @@ function CheckboxFilter({
         {filterChoices.map(({ name, number, value }) => (
           <Form.Checkbox
             key={`${headerBasedId}${name}`}
-            value={name}
+            value={value}
             checked={checkedBoxes.includes(value)}
             onChange={() => changeCheckbox(value)}
             aria-label={name}

--- a/src/DataTable/filters/tests/CheckboxFilter.test.jsx
+++ b/src/DataTable/filters/tests/CheckboxFilter.test.jsx
@@ -83,4 +83,35 @@ describe('<CheckboxFilter />', () => {
       expect(checkbox).not.toBeChecked();
     });
   });
+
+  it('uses value for filtering when name and value differ', async () => {
+    const testChoice = { name: 'Test', value: 'test' };
+    const propsWithCaseDifference = {
+      column: {
+        ...props.column,
+        filterChoices: [testChoice],
+        filterValue: [],
+      },
+    };
+
+    const { rerender } = render(<CheckboxFilter {...propsWithCaseDifference} />);
+
+    const checkbox = screen.getByLabelText(testChoice.name);
+
+    await userEvent.click(checkbox);
+
+    expect(setFilterMock).toHaveBeenCalledWith([testChoice.value]);
+
+    rerender(<CheckboxFilter column={{
+      ...propsWithCaseDifference.column,
+      filterValue: [testChoice.value],
+    }}
+    />);
+
+    expect(checkbox).toBeChecked();
+
+    await userEvent.click(checkbox);
+
+    expect(setFilterMock).toHaveBeenCalledWith([]);
+  });
 });

--- a/src/DataTable/tablecontrolbar.mdx
+++ b/src/DataTable/tablecontrolbar.mdx
@@ -73,22 +73,22 @@ It always shows the `SmartStatus` component. If applicable, it displays the `Dro
       Filter: CheckboxFilter,
       filter: 'includesValue',
       filterChoices: [{
-        name: 'russian white',
+        name: 'Russian white',
         number: 1,
         value: 'russian white',
       },
       {
-        name: 'orange tabby',
+        name: 'Orange Tabby',
         number: 2,
         value: 'orange tabby',
       },
       {
-        name: 'brown tabby',
+        name: 'Brown Tabby',
         number: 3,
         value: 'brown tabby',
       },
       {
-        name: 'siamese',
+        name: 'Siamese',
         number: 1,
         value: 'siamese',
       }]

--- a/src/DataTable/tablefilters.mdx
+++ b/src/DataTable/tablefilters.mdx
@@ -104,22 +104,22 @@ all filters will be rendered in the dropdown.
       Filter: CheckboxFilter,
       filter: 'includesValue',
       filterChoices: [{
-        name: 'russian white',
+        name: 'Russian white',
         number: 1,
         value: 'russian white',
       },
       {
-        name: 'orange tabby',
+        name: 'Orange Tabby',
         number: 2,
         value: 'orange tabby',
       },
       {
-        name: 'brown tabby',
+        name: 'Brown Tabby',
         number: 3,
         value: 'brown tabby',
       },
       {
-        name: 'siamese',
+        name: 'Siamese',
         number: 1,
         value: 'siamese',
       }]
@@ -227,22 +227,22 @@ all filters will be rendered in the dropdown.
       Filter: CheckboxFilter,
       filter: 'includesValue',
       filterChoices: [{
-        name: 'russian white',
+        name: 'Russian white',
         number: 1,
         value: 'russian white',
       },
       {
-        name: 'orange tabby',
+        name: 'Orange Tabby',
         number: 2,
         value: 'orange tabby',
       },
       {
-        name: 'brown tabby',
+        name: 'Brown Tabby',
         number: 3,
         value: 'brown tabby',
       },
       {
-        name: 'siamese',
+        name: 'Siamese',
         number: 1,
         value: 'siamese',
       }]


### PR DESCRIPTION
## Description

Fixes an issue where `DataTable` filtering only worked if `filterChoices` had identical `name` and `value`.
`CheckboxFilter` now uses the `value` property for filtering, allowing `name` to be used solely as a display label.

**More context:** https://github.com/openedx/paragon/issues/3880

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
