### PR TITLE
fix(deps): update axios

### DIFF
--- a/component-generator/package.json
+++ b/component-generator/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.28.0",
+    "axios": "^0.30.2",
     "commander": "^9.3.0",
     "dotenv": "^16.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.4",
         "@tokens-studio/sd-transforms": "^1.2.4",
-        "axios": "^0.27.2",
+        "axios": "^0.30.2",
         "bootstrap": "^4.6.2",
         "chalk": "^4.1.2",
         "child_process": "^1.0.2",
@@ -92,7 +92,6 @@
         "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
-        "axios": "^0.28.0",
         "axios-mock-adapter": "^1.21.1",
         "babel-jest": "^29.7.0",
         "babel-loader": "^8.2.4",
@@ -128,7 +127,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^0.28.0",
+        "axios": "^0.30.2",
         "commander": "^9.3.0",
         "dotenv": "^16.0.0"
       },
@@ -267,7 +266,6 @@
     "example/node_modules/@babel/core": {
       "version": "7.22.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -537,7 +535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -755,6 +752,7 @@
     "example/node_modules/@jest/console": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -770,6 +768,7 @@
     "example/node_modules/@jest/console/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -785,6 +784,7 @@
     "example/node_modules/@jest/console/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -792,6 +792,7 @@
     "example/node_modules/@jest/console/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -807,6 +808,7 @@
     "example/node_modules/@jest/console/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -814,6 +816,7 @@
     "example/node_modules/@jest/globals": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -827,6 +830,7 @@
     "example/node_modules/@jest/globals/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -842,6 +846,7 @@
     "example/node_modules/@jest/globals/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -849,6 +854,7 @@
     "example/node_modules/@jest/reporters": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^29.7.0",
@@ -890,6 +896,7 @@
     "example/node_modules/@jest/reporters/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -903,6 +910,7 @@
     "example/node_modules/@jest/reporters/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -927,6 +935,7 @@
     "example/node_modules/@jest/reporters/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -942,17 +951,20 @@
     "example/node_modules/@jest/reporters/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/@jest/reporters/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -971,6 +983,7 @@
     "example/node_modules/@jest/reporters/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -994,6 +1007,7 @@
     "example/node_modules/@jest/reporters/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1001,6 +1015,7 @@
     "example/node_modules/@jest/reporters/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -1016,6 +1031,7 @@
     "example/node_modules/@jest/reporters/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1023,6 +1039,7 @@
     "example/node_modules/@jest/reporters/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -1034,6 +1051,7 @@
     "example/node_modules/@jest/source-map": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
@@ -1046,6 +1064,7 @@
     "example/node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
@@ -1059,6 +1078,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1072,6 +1092,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1087,6 +1108,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1094,6 +1116,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -1117,6 +1140,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1124,6 +1148,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -1139,6 +1164,7 @@
     "example/node_modules/@jest/test-sequencer/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1191,6 +1217,7 @@
     "example/node_modules/@openedx/frontend-build": {
       "version": "14.2.2",
       "license": "AGPL-3.0",
+      "peer": true,
       "dependencies": {
         "@babel/cli": "7.24.8",
         "@babel/core": "7.24.9",
@@ -1271,6 +1298,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/cli": {
       "version": "7.24.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "commander": "^6.2.0",
@@ -1327,6 +1355,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/preset-env": {
       "version": "7.24.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.24.8",
         "@babel/helper-compilation-targets": "^7.24.8",
@@ -1420,6 +1449,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -1432,6 +1462,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/preset-react": {
       "version": "7.24.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/helper-validator-option": "^7.24.7",
@@ -1450,6 +1481,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@edx/eslint-config": {
       "version": "4.3.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
@@ -1465,6 +1497,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/reporters": "^29.7.0",
@@ -1510,6 +1543,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core/node_modules/babel-jest": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -1529,6 +1563,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core/node_modules/jest-config": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -1572,6 +1607,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1579,6 +1615,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1592,6 +1629,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -1616,6 +1654,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/transform/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1623,6 +1662,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1638,6 +1678,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.15",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
@@ -1684,6 +1725,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1705,6 +1747,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.3",
         "caniuse-lite": "^1.0.30001646",
@@ -1726,6 +1769,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-jest": {
       "version": "29.6.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
@@ -1745,6 +1789,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-jest/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1752,6 +1797,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.10.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2",
         "core-js-compat": "^3.38.0"
@@ -1763,6 +1809,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
@@ -1773,6 +1820,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-preset-jest": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
@@ -1787,17 +1835,20 @@
     "example/node_modules/@openedx/frontend-build/node_modules/commander": {
       "version": "6.2.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
     },
     "example/node_modules/@openedx/frontend-build/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/@openedx/frontend-build/node_modules/cssnano": {
       "version": "6.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^6.0.3",
         "lilconfig": "^3.0.0"
@@ -1816,6 +1867,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/debug": {
       "version": "4.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1831,6 +1883,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1849,6 +1902,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/html-webpack-plugin": {
       "version": "5.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -1904,6 +1958,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/test-result": "^29.7.0",
@@ -1935,6 +1990,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli/node_modules/babel-jest": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -1954,6 +2010,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli/node_modules/jest-config": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -1997,6 +2054,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2004,6 +2062,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -2027,6 +2086,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2034,6 +2094,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -2049,6 +2110,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-validate": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -2064,6 +2126,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/postcss-loader": {
       "version": "7.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cosmiconfig": "^8.3.5",
         "jiti": "^1.20.0",
@@ -2084,6 +2147,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/postcss-loader/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2102,6 +2166,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/sass-loader": {
       "version": "13.3.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "neo-async": "^2.6.2"
       },
@@ -2137,6 +2202,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/source-map": {
       "version": "0.7.4",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2144,6 +2210,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/source-map-loader": {
       "version": "4.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "source-map-js": "^1.0.2"
@@ -2162,6 +2229,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/style-loader": {
       "version": "3.3.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12.13.0"
       },
@@ -2176,6 +2244,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/ts-jest": {
       "version": "29.1.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
@@ -2221,6 +2290,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/ts-jest/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2231,6 +2301,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/webpack-merge": {
       "version": "5.10.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
         "flat": "^5.0.2",
@@ -2243,6 +2314,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -2254,6 +2326,7 @@
     "example/node_modules/@openedx/frontend-build/node_modules/yargs": {
       "version": "17.7.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2342,6 +2415,7 @@
     "example/node_modules/@types/jest": {
       "version": "29.5.12",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -2350,6 +2424,7 @@
     "example/node_modules/ansi-styles": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2360,7 +2435,6 @@
     "example/node_modules/axios": {
       "version": "1.6.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -2430,6 +2504,7 @@
     "example/node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -2483,17 +2558,20 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "example/node_modules/cjs-module-lexer": {
       "version": "1.4.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/cliui": {
       "version": "8.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2527,6 +2605,7 @@
     "example/node_modules/emittery": {
       "version": "0.13.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2537,7 +2616,6 @@
     "example/node_modules/eslint": {
       "version": "8.44.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -2594,7 +2672,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -2624,7 +2701,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
       "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "aria-query": "^5.1.3",
@@ -2653,7 +2729,6 @@
     "example/node_modules/eslint-plugin-react": {
       "version": "7.32.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flatmap": "^1.3.1",
@@ -2681,7 +2756,6 @@
     "example/node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2744,6 +2818,7 @@
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
       "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2775,6 +2850,7 @@
     "example/node_modules/iconv-lite": {
       "version": "0.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2785,6 +2861,7 @@
     "example/node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -2799,6 +2876,7 @@
     "example/node_modules/istanbul-lib-instrument/node_modules/@babel/core": {
       "version": "7.26.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2827,17 +2905,20 @@
     "example/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "example/node_modules/istanbul-lib-instrument/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/istanbul-lib-instrument/node_modules/debug": {
       "version": "4.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2853,6 +2934,7 @@
     "example/node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2878,6 +2960,7 @@
     "example/node_modules/jest-changed-files": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "execa": "^5.0.0",
         "jest-util": "^29.7.0",
@@ -2890,6 +2973,7 @@
     "example/node_modules/jest-changed-files/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2905,6 +2989,7 @@
     "example/node_modules/jest-changed-files/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -2912,6 +2997,7 @@
     "example/node_modules/jest-changed-files/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -2952,6 +3038,7 @@
     "example/node_modules/jest-docblock": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -2962,6 +3049,7 @@
     "example/node_modules/jest-environment-jsdom": {
       "version": "29.6.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.6.1",
         "@jest/fake-timers": "^29.6.1",
@@ -2987,6 +3075,7 @@
     "example/node_modules/jest-environment-jsdom/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3002,6 +3091,7 @@
     "example/node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3009,6 +3099,7 @@
     "example/node_modules/jest-environment-jsdom/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3024,6 +3115,7 @@
     "example/node_modules/jest-environment-node": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -3039,6 +3131,7 @@
     "example/node_modules/jest-environment-node/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3054,6 +3147,7 @@
     "example/node_modules/jest-environment-node/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3061,6 +3155,7 @@
     "example/node_modules/jest-environment-node/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3076,6 +3171,7 @@
     "example/node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.7.0"
@@ -3087,6 +3183,7 @@
     "example/node_modules/jest-message-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -3105,6 +3202,7 @@
     "example/node_modules/jest-message-util/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3120,6 +3218,7 @@
     "example/node_modules/jest-message-util/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3127,6 +3226,7 @@
     "example/node_modules/jest-message-util/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3134,6 +3234,7 @@
     "example/node_modules/jest-resolve": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -3152,6 +3253,7 @@
     "example/node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
         "jest-snapshot": "^29.7.0"
@@ -3163,6 +3265,7 @@
     "example/node_modules/jest-resolve-dependencies/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3170,6 +3273,7 @@
     "example/node_modules/jest-resolve/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3185,6 +3289,7 @@
     "example/node_modules/jest-resolve/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3192,6 +3297,7 @@
     "example/node_modules/jest-resolve/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3215,6 +3321,7 @@
     "example/node_modules/jest-resolve/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3222,6 +3329,7 @@
     "example/node_modules/jest-resolve/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3237,6 +3345,7 @@
     "example/node_modules/jest-resolve/node_modules/jest-validate": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -3252,6 +3361,7 @@
     "example/node_modules/jest-resolve/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3259,6 +3369,7 @@
     "example/node_modules/jest-runner": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -3289,6 +3400,7 @@
     "example/node_modules/jest-runner/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3302,6 +3414,7 @@
     "example/node_modules/jest-runner/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3326,6 +3439,7 @@
     "example/node_modules/jest-runner/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3341,17 +3455,20 @@
     "example/node_modules/jest-runner/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/jest-runner/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/jest-runner/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3375,6 +3492,7 @@
     "example/node_modules/jest-runner/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3382,6 +3500,7 @@
     "example/node_modules/jest-runner/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3397,6 +3516,7 @@
     "example/node_modules/jest-runner/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3404,6 +3524,7 @@
     "example/node_modules/jest-runner/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -3415,6 +3536,7 @@
     "example/node_modules/jest-runtime": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -3446,6 +3568,7 @@
     "example/node_modules/jest-runtime/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3459,6 +3582,7 @@
     "example/node_modules/jest-runtime/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3483,6 +3607,7 @@
     "example/node_modules/jest-runtime/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3498,17 +3623,20 @@
     "example/node_modules/jest-runtime/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/jest-runtime/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3527,6 +3655,7 @@
     "example/node_modules/jest-runtime/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3550,6 +3679,7 @@
     "example/node_modules/jest-runtime/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3557,6 +3687,7 @@
     "example/node_modules/jest-runtime/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3572,6 +3703,7 @@
     "example/node_modules/jest-runtime/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3579,6 +3711,7 @@
     "example/node_modules/jest-runtime/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -3590,6 +3723,7 @@
     "example/node_modules/jest-snapshot": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
@@ -3619,6 +3753,7 @@
     "example/node_modules/jest-snapshot/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3643,6 +3778,7 @@
     "example/node_modules/jest-snapshot/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3658,17 +3794,20 @@
     "example/node_modules/jest-snapshot/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/jest-snapshot/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/jest-snapshot/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3692,6 +3831,7 @@
     "example/node_modules/jest-snapshot/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3699,6 +3839,7 @@
     "example/node_modules/jest-snapshot/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3714,6 +3855,7 @@
     "example/node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3724,6 +3866,7 @@
     "example/node_modules/jest-snapshot/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3731,6 +3874,7 @@
     "example/node_modules/jest-snapshot/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -3742,6 +3886,7 @@
     "example/node_modules/jest-watcher": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3759,6 +3904,7 @@
     "example/node_modules/jest-watcher/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3772,6 +3918,7 @@
     "example/node_modules/jest-watcher/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3787,6 +3934,7 @@
     "example/node_modules/jest-watcher/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3794,6 +3942,7 @@
     "example/node_modules/jest-watcher/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3809,6 +3958,7 @@
     "example/node_modules/jest-worker": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-util": "^29.7.0",
@@ -3822,6 +3972,7 @@
     "example/node_modules/jest-worker/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3837,6 +3988,7 @@
     "example/node_modules/jest-worker/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3844,6 +3996,7 @@
     "example/node_modules/jest-worker/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3859,6 +4012,7 @@
     "example/node_modules/lilconfig": {
       "version": "3.1.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3869,6 +4023,7 @@
     "example/node_modules/parse5": {
       "version": "7.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -3891,6 +4046,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/cascade-layer-name-parser": "^1.0.13",
         "@csstools/css-parser-algorithms": "^2.7.1",
@@ -3915,6 +4071,7 @@
     "example/node_modules/pretty-format": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -3927,7 +4084,6 @@
     "example/node_modules/react": {
       "version": "17.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -3939,7 +4095,6 @@
     "example/node_modules/react-dom": {
       "version": "17.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -3951,7 +4106,8 @@
     },
     "example/node_modules/react-is": {
       "version": "18.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/renderkid": {
       "version": "3.0.0",
@@ -4018,6 +4174,7 @@
     "example/node_modules/source-map-support": {
       "version": "0.5.13",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4026,6 +4183,7 @@
     "example/node_modules/supports-color": {
       "version": "8.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4039,6 +4197,7 @@
     "example/node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -4050,12 +4209,12 @@
     },
     "example/node_modules/v8-to-istanbul/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "example/node_modules/webpack": {
       "version": "5.89.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -4135,6 +4294,7 @@
     "example/node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4142,6 +4302,7 @@
     "example/node_modules/yargs-parser": {
       "version": "21.1.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4309,7 +4470,6 @@
     "node_modules/@algolia/client-search": {
       "version": "5.17.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.17.0",
         "@algolia/requester-browser-xhr": "5.17.0",
@@ -4574,7 +4734,6 @@
     "node_modules/@babel/core": {
       "version": "7.26.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -6764,7 +6923,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -6785,7 +6943,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -7679,6 +7836,7 @@
     "node_modules/@fortawesome/react-fontawesome": {
       "version": "0.1.19",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prop-types": "^15.8.1"
       },
@@ -7714,7 +7872,6 @@
     "node_modules/@gatsbyjs/reach-router": {
       "version": "2.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1"
@@ -9504,7 +9661,6 @@
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0",
         "@types/react": ">=16"
@@ -9656,7 +9812,6 @@
       "version": "4.2.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -9899,7 +10054,6 @@
     "node_modules/@parcel/core": {
       "version": "2.8.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.8.3",
@@ -10813,7 +10967,6 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -10822,6 +10975,7 @@
     "node_modules/@remix-run/router": {
       "version": "1.21.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -11529,7 +11683,6 @@
       "version": "6.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@svgr/babel-preset": "^6.5.1",
@@ -11667,7 +11820,6 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -11897,7 +12049,6 @@
       "version": "6.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@svgr/babel-preset": "^6.5.1",
@@ -12207,7 +12358,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -12605,7 +12757,8 @@
     },
     "node_modules/@types/picomatch": {
       "version": "2.3.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
@@ -12633,7 +12786,6 @@
     "node_modules/@types/react": {
       "version": "18.3.16",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -12658,6 +12810,7 @@
     "node_modules/@types/react-redux": {
       "version": "7.1.34",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -12808,7 +12961,6 @@
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -12866,7 +13018,6 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -13117,7 +13268,6 @@
       "integrity": "sha512-m3g9nQDWPtL+sTFdtCGRMI1Vrp86Ay4PBYq1Bo7Bnchj5ElNtAJpOqD+zg+apthVA4fB7oVpMWNjwpa6ElDWFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -13429,7 +13579,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13537,7 +13686,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13592,7 +13740,6 @@
     "node_modules/algoliasearch": {
       "version": "5.17.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.17.0",
         "@algolia/client-analytics": "5.17.0",
@@ -13681,6 +13828,7 @@
         "node >= 0.8.0"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "ansi-html": "bin/ansi-html"
       }
@@ -13723,6 +13871,7 @@
     "node_modules/ansis": {
       "version": "1.5.2",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12.13"
       },
@@ -14308,12 +14457,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.28.1",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
+      "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -14350,6 +14500,7 @@
     "node_modules/babel-eslint": {
       "version": "10.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",
@@ -14368,6 +14519,7 @@
     "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -15230,7 +15382,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -16842,7 +16993,6 @@
       "version": "3.39.0",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -18969,7 +19119,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -20207,7 +20358,6 @@
     "node_modules/eslint-config-airbnb": {
       "version": "19.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
@@ -20244,7 +20394,6 @@
     "node_modules/eslint-config-airbnb-typescript": {
       "version": "17.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
       },
@@ -20374,6 +20523,7 @@
     "node_modules/eslint-plugin-formatjs": {
       "version": "4.13.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "2.7.8",
         "@formatjs/ts-transformer": "3.13.14",
@@ -20394,6 +20544,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
       "version": "2.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -20402,6 +20553,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
       "version": "2.7.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.0.0",
         "@formatjs/icu-skeleton-parser": "1.8.2",
@@ -20411,6 +20563,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.8.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.0.0",
         "tslib": "^2.4.0"
@@ -20419,6 +20572,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/intl-localematcher": {
       "version": "0.5.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -20426,6 +20580,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
       "version": "3.13.14",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "2.7.8",
         "@types/json-stable-stringify": "^1.0.32",
@@ -20447,6 +20602,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@types/eslint": {
       "version": "8.56.12",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -20454,11 +20610,13 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@types/node": {
       "version": "17.0.45",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/scope-manager": {
       "version": "6.21.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "@typescript-eslint/visitor-keys": "6.21.0"
@@ -20474,6 +20632,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/types": {
       "version": "6.21.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -20485,6 +20644,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/typescript-estree": {
       "version": "6.21.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "@typescript-eslint/visitor-keys": "6.21.0",
@@ -20511,6 +20671,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/utils": {
       "version": "6.21.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
@@ -20534,6 +20695,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/visitor-keys": {
       "version": "6.21.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -20549,6 +20711,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/brace-expansion": {
       "version": "2.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -20556,6 +20719,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/debug": {
       "version": "4.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -20570,11 +20734,13 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/emoji-regex": {
       "version": "10.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eslint-plugin-formatjs/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -20585,6 +20751,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/magic-string": {
       "version": "0.30.17",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -20592,6 +20759,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/minimatch": {
       "version": "9.0.3",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -20605,6 +20773,7 @@
     "node_modules/eslint-plugin-formatjs/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -20614,11 +20783,13 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/eslint-plugin-formatjs/node_modules/typescript": {
       "version": "5.7.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21856,6 +22027,7 @@
     "node_modules/flat": {
       "version": "5.0.2",
       "license": "BSD-3-Clause",
+      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -21907,6 +22079,7 @@
     "node_modules/font-awesome": {
       "version": "4.7.0",
       "license": "(OFL-1.1 AND MIT)",
+      "peer": true,
       "engines": {
         "node": ">=0.10.3"
       }
@@ -22093,11 +22266,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -22266,7 +22443,6 @@
       "version": "5.14.0",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/core": "^7.20.12",
@@ -23136,7 +23312,6 @@
     "node_modules/gatsby-source-filesystem": {
       "version": "5.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "chokidar": "^3.5.3",
@@ -23385,7 +23560,6 @@
     "node_modules/gatsby/node_modules/eslint": {
       "version": "7.32.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -23472,7 +23646,6 @@
     "node_modules/gatsby/node_modules/eslint-plugin-flowtype": {
       "version": "5.10.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
@@ -24166,7 +24339,6 @@
     "node_modules/graphql": {
       "version": "16.9.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -31466,7 +31638,6 @@
       "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -39137,7 +39308,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -39746,6 +39916,7 @@
     "node_modules/postcss-rtlcss": {
       "version": "5.1.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "rtlcss": "4.1.1"
       },
@@ -39799,7 +39970,6 @@
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -39949,6 +40119,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -39962,6 +40133,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -39972,7 +40144,8 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prism-react-renderer": {
       "version": "1.3.5",
@@ -40030,7 +40203,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -40302,7 +40474,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -40495,7 +40666,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -40605,7 +40775,6 @@
     "node_modules/react-helmet": {
       "version": "6.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.7.2",
@@ -40648,7 +40817,6 @@
     "node_modules/react-intl": {
       "version": "6.8.9",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.2.4",
         "@formatjs/icu-messageformat-parser": "2.9.4",
@@ -41485,6 +41653,7 @@
     "node_modules/react-redux": {
       "version": "7.2.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -41507,12 +41676,12 @@
     },
     "node_modules/react-redux/node_modules/react-is": {
       "version": "17.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -41579,6 +41748,7 @@
     "node_modules/react-router": {
       "version": "6.28.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.21.0"
       },
@@ -42004,7 +42174,6 @@
     "node_modules/redux": {
       "version": "4.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -44029,7 +44198,6 @@
     "node_modules/sass": {
       "version": "1.82.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -44123,7 +44291,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -44189,7 +44356,6 @@
       "version": "20.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
@@ -44448,7 +44614,6 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -46343,7 +46508,6 @@
       "integrity": "sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
@@ -46482,7 +46646,6 @@
       "version": "15.11.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.3.1",
         "@csstools/css-tokenizer": "^2.2.0",
@@ -47642,7 +47805,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -47868,6 +48030,7 @@
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -47886,7 +48049,6 @@
       "version": "29.2.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
@@ -48008,8 +48170,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -48062,7 +48223,6 @@
     "node_modules/type-fest": {
       "version": "0.21.3",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -48171,7 +48331,6 @@
     "node_modules/typescript": {
       "version": "4.9.5",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -48420,13 +48579,15 @@
     "node_modules/unicode-emoji-utils": {
       "version": "1.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "10.3.0"
       }
     },
     "node_modules/unicode-emoji-utils/node_modules/emoji-regex": {
       "version": "10.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
@@ -49135,7 +49296,6 @@
     "node_modules/webpack": {
       "version": "5.97.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -49231,7 +49391,6 @@
     "node_modules/webpack-cli": {
       "version": "5.1.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -49457,6 +49616,7 @@
     "node_modules/webpack-remove-empty-scripts": {
       "version": "1.0.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansis": "1.5.2"
       },
@@ -50235,7 +50395,7 @@
         "@mdx-js/react": "^2",
         "@openedx/brand-openedx": "^1.2.2",
         "analytics-node": "^6.0.0",
-        "axios": "^0.28.0",
+        "axios": "^0.30.2",
         "classnames": "^2.3.1",
         "gatsby": "^5.14",
         "gatsby-plugin-manifest": "^5.14",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.4",
     "@tokens-studio/sd-transforms": "^1.2.4",
-    "axios": "^0.27.2",
+    "axios": "^0.30.2",
     "bootstrap": "^4.6.2",
     "chalk": "^4.1.2",
     "child_process": "^1.0.2",
@@ -139,7 +139,6 @@
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
-    "axios": "^0.28.0",
     "axios-mock-adapter": "^1.21.1",
     "babel-jest": "^29.7.0",
     "babel-loader": "^8.2.4",

--- a/www/package.json
+++ b/www/package.json
@@ -9,7 +9,7 @@
     "@mdx-js/react": "^2",
     "@openedx/brand-openedx": "^1.2.2",
     "analytics-node": "^6.0.0",
-    "axios": "^0.28.0",
+    "axios": "^0.30.2",
     "classnames": "^2.3.1",
     "gatsby": "^5.14",
     "gatsby-plugin-manifest": "^5.14",


### PR DESCRIPTION
## Description

https://github.com/openedx/paragon/pull/3884 but only updating to `0.30.2` instead of the major bump to `1.x`

Also removed the duplicate inclusion of `axios` in the top-level `package.json` (it was listed as both a direct dep and a dev dep - kept only the direct dep)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
