### PR TITLE
fix: <MenuItem> type wasn't accepting extra HTML props

### DIFF
--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -1,10 +1,15 @@
 import React, {
-  ReactElement, ReactNode, ElementType, createElement, ComponentType,
+  type ReactElement,
+  type ReactNode,
+  type ElementType,
+  createElement,
+  type ComponentType,
+  type ComponentPropsWithoutRef,
 } from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-interface MenuItemProps {
+interface MenuItemProps<As extends ElementType> {
   /** Specifies that this `MenuItem` is selected inside the `SelectMenu` */
   defaultSelected?: boolean;
   /** Specifies class name to append to the base element */
@@ -12,21 +17,22 @@ interface MenuItemProps {
   /** Specifies the content of the `MenuItem` */
   children: ReactNode;
   /** Specifies the base element */
-  as?: ElementType;
+  as?: As;
   /** Specifies the jsx before the content of the `MenuItem` */
   iconBefore?: ReactElement | ElementType;
   /** Specifies the jsx after the content of the `MenuItem` */
   iconAfter?: ReactElement | ElementType;
 }
-function MenuItem({
-  as = 'button',
+
+function MenuItem<As extends ElementType = 'button'>({
+  as = 'button' as As,
   children,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   defaultSelected = false,
   iconAfter,
   iconBefore,
   ...props
-}: MenuItemProps) {
+}: MenuItemProps<As> & ComponentPropsWithoutRef<As>) {
   const className = classNames(props.className, 'pgn__menu-item');
 
   return createElement(

--- a/src/Menu/index.tsx
+++ b/src/Menu/index.tsx
@@ -1,8 +1,13 @@
-import React, { ElementType, ReactNode, createElement } from 'react';
+import React, {
+  createElement,
+  type ElementType,
+  type ReactNode,
+  type ComponentPropsWithoutRef,
+} from 'react';
 import classNames from 'classnames';
 import useArrowKeyNavigation from '../hooks/useArrowKeyNavigationHook';
 
-interface MenuProps {
+interface MenuProps<As extends ElementType> {
   /** Specifies class name to append to the base element */
   className?: string;
   /**
@@ -11,16 +16,17 @@ interface MenuProps {
    */
   arrowKeyNavigationSelector?: string;
   /** Specifies the base element */
-  as?: ElementType;
+  as?: As;
   /** Specifies the content of the menu */
   children?: ReactNode;
 }
-function Menu({
-  as = 'div',
+
+function Menu<As extends ElementType = 'div'>({
+  as = 'div' as As,
   arrowKeyNavigationSelector = 'a:not(:disabled),button:not(:disabled),input:not(:disabled)',
   children,
   ...props
-}: MenuProps) {
+}: MenuProps<As> & ComponentPropsWithoutRef<As>) {
   const parentRef = useArrowKeyNavigation({ selectors: arrowKeyNavigationSelector });
   const className = classNames(props.className, 'pgn__menu');
 

--- a/src/Stack/index.tsx
+++ b/src/Stack/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ForwardedRef } from 'react';
+import React, { forwardRef, ForwardedRef, HTMLProps } from 'react';
 import classNames from 'classnames';
 
 interface StackProps {
@@ -26,7 +26,7 @@ const Stack = forwardRef(({
   children,
   className,
   ...rest
-}: StackProps, ref: ForwardedRef<HTMLDivElement>) => (
+}: StackProps & HTMLProps<HTMLDivElement>, ref: ForwardedRef<HTMLDivElement>) => (
   <div
     ref={ref}
     className={classNames(


### PR DESCRIPTION
## Description

When I pulled in the latest version of Paragon with the type improvements from https://github.com/openedx/paragon/pull/3831 there were some invalid type errors appearing in the Authoring MFE, like this:

```
src/taxonomy/TaxonomyListPage.tsx:130:11 - error TS2322: Type '{ children: string; key: string; className: string; iconAfter: () => Element | null; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & MenuItemProps'.
  Property 'onClick' does not exist on type 'IntrinsicAttributes & MenuItemProps'.

130 <MenuItem onClick={() => setSelectedOrgFilter(org)}
              ~~~~~~~
```

This fix updates the types to accept any valid HTML props, based on the `as` attribute.

### Deploy Preview

https://deploy-preview-3955--paragon-openedx-v23.netlify.app/components/menu/ - `Menu` and `MenuItem`

https://deploy-preview-3955--paragon-openedx-v23.netlify.app/components/stack/ - `Stack`

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
