### PR TITLE
fix(cli): ensure style dictionary verbose error stack is displayed

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -267,6 +267,10 @@ const COMMANDS = {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(chalk.red.bold('An error occurred:', error));
+    if (error instanceof Error) {
+      // eslint-disable-next-line no-console
+      console.error(chalk.red(error.stack));
+    }
     sendTrackInfo('openedx.paragon.cli-command.used', { command, status: 'error', errorMsg: error.message });
     process.exit(1);
   }


### PR DESCRIPTION
## Description

Using the example from https://discuss.openedx.org/t/friction-points-in-paragon/17442/4, I found the error displayed when running [the `build-other` script](https://github.com/obscherler/openedx-repros/blob/deab8c83da1345fa4eaf8ad801821d027282195a/paragon-actions/package.json#L5) in the reference minimal repro repo was

<img width="779" height="29" alt="image" src="https://github.com/user-attachments/assets/d7fe1541-18bb-4a1f-a5da-7b6c06bacc24" />

When changing the line to not use `chalk`
```diff
- console.error(chalk.red.bold('An error occurred:', error));
+ console.error(chalk.red.bold('An error occurred:'), error);
```

I instead saw

<img width="1480" height="209" alt="image" src="https://github.com/user-attachments/assets/023e79f8-6afd-4613-8200-97616eff4fa7" />

With the changes in this PR, the entire error stays red, and the message is repeated

<img width="1482" height="224" alt="image" src="https://github.com/user-attachments/assets/ca3b2893-078b-4bb0-9e46-5ce7add99117" />

_____

I think *how* (bold/color/etc) we present the stack is a matter of preference, and I'm very open to any thoughts/opinions there, but I'd like to ensure we aren't hiding the stack from CLI users. 

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
