### PR TITLE
feat!: better support header-only card use

### DIFF
--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -27,7 +27,7 @@ const CardImageCap = React.forwardRef(({
   const [showImageCap, setShowImageCap] = useState(false);
   const [showLogoCap, setShowLogoCap] = useState(false);
 
-  const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
+  const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}${showLogoCap ? ' with-logo' : ''}`;
 
   if (isLoading) {
     return (

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -157,12 +157,14 @@ This header displays a title, subtitle, and may contain actions.
 <div>
   <Card className="mb-2">
     <Card.Header title="Title" />
+    <Card.Footer />
   </Card>
   <Card>
     <Card.Header 
       title="Title"
       subtitle="Subtitle"
     />
+    <Card.Footer />
   </Card>
 </div>
 ```
@@ -191,6 +193,7 @@ The `Card.Header` supports custom actions via the actions prop and renders them 
             </ActionRow>
           } 
         />
+        <Card.Footer />
       </Card>
       <Card>
         <Card.Header
@@ -214,6 +217,7 @@ The `Card.Header` supports custom actions via the actions prop and renders them 
             </Dropdown>
           }
         />
+        <Card.Footer />
       </Card>
     </div>
 )}
@@ -235,6 +239,7 @@ Add ``size="sm"`` for smaller header content and actions.
     }
     size="sm"
   />
+  <Card.Footer />
 </Card>
 ```
 

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -118,7 +118,7 @@ a.pgn__card {
     .pgn__card-header-content {
       display: flex;
       flex-direction: column;
-      margin-top: map.get($spacers, 4\.5);
+      margin-top: var(--pgn-spacing-spacer-base);
       overflow: auto;
       text-align: start;
       width: 100%;
@@ -164,6 +164,8 @@ a.pgn__card {
     }
 
     .pgn__card-header-actions {
+      display: flex;
+      align-items: center;
       margin-top: var(--pgn-spacing-spacer-base);
       margin-inline-start: var(--pgn-spacing-spacer-base);
       flex-shrink: 0;
@@ -334,7 +336,12 @@ a.pgn__card {
 
     &.vertical {
       max-height: var(--pgn-size-card-image-vertical-max-height);
+
+      &.with-logo {
+        margin-bottom: var(--pgn-spacing-spacer-base);
+      }
     }
+
 
     .pgn__card-image-cap-loader {
       .react-loading-skeleton {


### PR DESCRIPTION
## :warning: BREAKING CHANGES :warning: 

**BREAKING CHANGE:**
* Modified `pgn__card-header-content` styles
  * `margin-top` changed:
    * Before: 2x `var(--pgn-spacing-spacer-base)`
    * After: 1x `var(--pgn-spacing-spacer-base)`

**BREAKING CHANGE:**
* Modified `pgn__card-header-actions` styles
  * Children now centered
    * `display: flex` added
    * `align-items: center` added

**BREAKING CHANGE:**
* `pgn__card-wrapper-image-cap.vertical` modified
  * Bottom margin conditionally added when logo image is used. This replicates the spacing previously baked into `pgn__card-header-content`
    * `margin-bottom: var(--pgn-spacing-spacer-base)` added when logo image used

## Description

<details>

<summary>  <h3><code>frontend-app-authoring</code> uses cards in a header-only manner</h3> </summary>

<img width="1085" height="635" alt="image" src="https://github.com/user-attachments/assets/9786b956-6f8e-417f-b341-c31fc38afd55" />

The current styling for that MFE is accomplished via [custom style overrides](https://github.com/openedx/frontend-app-authoring/blob/36c9eba66da4d9fe2e3a841953d2e05f5386b29b/src/studio-home/scss/StudioHome.scss#L61-L75)

```scss
  .pgn__card-header {
    padding: .9375rem 1.25rem;

    .pgn__card-header-content {
      margin: 0;
      overflow: hidden;
    }

    .pgn__card-header-actions {
      display: flex;
      align-items: center;
      justify-content: center;
      margin: 0;
    }
  }
```

This is definitely not an ideal way to accomplish this, however, removing this custom styling leads to less-than-ideal styles in the MFE

<img width="1085" height="635" alt="image" src="https://github.com/user-attachments/assets/428af270-d36e-443a-a030-28621f4b0411" />

This can be made slightly better by adding an empty `Card.Footer`

```diff
bsmith@aximdev:~/code/frontend-app-authoring$ git diff
diff --git a/src/studio-home/card-item/index.tsx b/src/studio-home/card-item/index.tsx
index 699d9164..9e4862a0 100644
--- a/src/studio-home/card-item/index.tsx
+++ b/src/studio-home/card-item/index.tsx
@@ -293,6 +293,7 @@ const CardItem: React.FC<Props> = ({
             </Stack>
           </Card.Status>
           )}
+        <Card.Footer />
       </Card>
     </div>
   );
```

<img width="1100" height="627" alt="image" src="https://github.com/user-attachments/assets/5613f7dd-3f85-462c-9c74-13a65c5def2d" />

But it still looks "off."

</details>

_____

<details>

<summary> <h3>Replicating the "off" styling on the Paragon docs site</h3> </summary>

It already looks kind of "off" [here](https://paragon-openedx.netlify.app/components/card/#header)

<img width="982" height="813" alt="image" src="https://github.com/user-attachments/assets/63f8dda6-e9c5-4887-bd17-3b9786d7d4d6" />

This can also be addressed somewhat by adding `Card.Footer` to the examples, but again, still looks "off"

<img width="982" height="890" alt="image" src="https://github.com/user-attachments/assets/6adcdfd5-327e-4766-98be-3ee45b146ab0" />

</details>

_____

### What this PR does:
 * Adds empty `Card.Footer`s to [the `Header` examples on the docs site](https://deploy-preview-3966--paragon-openedx-v23.netlify.app/components/card/#header)
 * Updates the top margin on `card-header-content` to match the top margin on `card-header-actions`
 * Updates `card-header-actions` to use `display: flex` and  `align-items: center`
<li><details>

<summary>Conditionally adds a new <code>with-logo</code> class when a <code>Card.ImageCap</code> has a logo to ensure the header maintains the current spacing</summary>

#### With `with-logo`

<img width="982" height="763" alt="image" src="https://github.com/user-attachments/assets/7d4fb85b-57d8-4cbe-bc81-5250eacccb9f" />

#### Without `with-logo`

<img width="982" height="748" alt="image" src="https://github.com/user-attachments/assets/431511d2-5da1-407f-9c17-81238454f531" />

</details></li>

* Makes header-only cards (with empty footers added) look like this

<img width="984" height="822" alt="image" src="https://github.com/user-attachments/assets/3477efc1-9d9d-4898-8a4b-8e2354d52f5e" />


### Deploy Preview

https://deploy-preview-3966--paragon-openedx-v23.netlify.app/components/card/#header

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
