### PR TITLE
fix: allow DataTable breakout filters count to be zero

### DIFF
--- a/src/DataTable/DropdownFilters.jsx
+++ b/src/DataTable/DropdownFilters.jsx
@@ -23,7 +23,7 @@ function DropdownFilters() {
       return [[], availableFilters];
     }
 
-    const numberOfBreakoutFilters = numBreakoutFilters || 1;
+    const numberOfBreakoutFilters = numBreakoutFilters ?? 1;
     const boFilters = availableFilters.slice(0, numberOfBreakoutFilters);
     const dropdownFilters = availableFilters.slice(numberOfBreakoutFilters);
 

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -416,8 +416,8 @@ DataTable.propTypes = {
     /** A custom component representing an action */
     PropTypes.element,
   ]),
-  /** Number between one and four filters that can be shown on the top row. */
-  numBreakoutFilters: PropTypes.oneOf([1, 2, 3, 4]),
+  /** Number between zero and four filters that can be shown on the top row. */
+  numBreakoutFilters: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Component to be displayed when the table is empty */
   EmptyTableComponent: PropTypes.elementType,
   /** Component to be displayed for row status, ie, 10 of 20 rows. Displayed by default in the TableControlBar */

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -162,6 +162,44 @@ describe('<DataTable />', () => {
     expect(screen.getByText('More')).toBeInTheDocument();
   });
 
+  it('places all filters in the dropdown if numBreakoutFilters is 0', async () => {
+    render(
+      <DataTableWrapper
+        {...props}
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
+        numBreakoutFilters={0}
+      />,
+    );
+
+    expect(screen.queryByPlaceholderText('Search name')).toBeNull();
+
+    const filtersButton = screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage });
+    await userEvent.click(filtersButton);
+
+    expect(screen.getByPlaceholderText('Search name')).toBeInTheDocument();
+  });
+
+  it('displays two breakout filters if numBreakoutFilters is 2', async () => {
+    render(
+      <DataTableWrapper
+        {...props}
+        isFilterable
+        defaultColumnValues={{ Filter: TextFilter }}
+        numBreakoutFilters={2}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText('Search name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search famous for')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Search coat color')).toBeNull();
+
+    const filtersButton = screen.getByRole('button', { name: messages.filtersDropdownTitle.defaultMessage });
+    await userEvent.click(filtersButton);
+
+    expect(screen.getByPlaceholderText('Search coat color')).toBeInTheDocument();
+  });
+
   it('displays the custom filters title in the sidebar', () => {
     render(
       <DataTableWrapper


### PR DESCRIPTION
## Description

Allow `numBreakoutFilters` to be set to `0` so all filters can stay in the dropdown.

### Issue
https://github.com/openedx/paragon/issues/3940

### Deploy Preview

https://deploy-preview-3986--paragon-openedx-v23.netlify.app/components/datatable/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
