### PR TITLE
feat: add `skeletonDuringImageLoad` prop to `CardImageCap`

### DIFF
--- a/src/Card/CardImageCap.jsx
+++ b/src/Card/CardImageCap.jsx
@@ -22,6 +22,7 @@ const CardImageCap = React.forwardRef(({
   logoSkeletonWidth,
   className,
   imageLoadingType,
+  skeletonDuringImageLoad,
 }, ref) => {
   const { orientation, isLoading } = useContext(CardContext);
   const [showImageCap, setShowImageCap] = useState(false);
@@ -29,24 +30,30 @@ const CardImageCap = React.forwardRef(({
 
   const wrapperClassName = `pgn__card-wrapper-image-cap ${orientation}`;
 
+  const loadingSkeleton = () => (
+    <Skeleton
+      containerClassName="pgn__card-image-cap-loader"
+      height={orientation === 'horizontal' ? '100%' : skeletonHeight}
+      width={skeletonWidth}
+    />
+  );
+
+  const loadingLogoSkeleton = () => (
+    <Skeleton
+      containerClassName="pgn__card-logo-cap"
+      height={logoSkeletonHeight}
+      width={logoSkeletonWidth}
+    />
+  );
+
   if (isLoading) {
     return (
       <div
         className={classNames(wrapperClassName, className)}
         data-testid="image-loader-wrapper"
       >
-        <Skeleton
-          containerClassName="pgn__card-image-cap-loader"
-          height={orientation === 'horizontal' ? '100%' : skeletonHeight}
-          width={skeletonWidth}
-        />
-        {logoSkeleton && (
-          <Skeleton
-            containerClassName="pgn__card-logo-cap"
-            height={logoSkeletonHeight}
-            width={logoSkeletonWidth}
-          />
-        )}
+        {loadingSkeleton()}
+        {logoSkeleton && loadingLogoSkeleton()}
       </div>
     );
   }
@@ -70,24 +77,30 @@ const CardImageCap = React.forwardRef(({
   return (
     <div className={classNames(className, wrapperClassName)} ref={ref}>
       {!!src && (
-        <img
-          className={classNames('pgn__card-image-cap', { show: showImageCap })}
-          src={src}
-          onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
-          onLoad={() => setShowImageCap(true)}
-          alt={srcAlt}
-          loading={imageLoadingType}
-        />
+        <>
+          {skeletonDuringImageLoad && !showImageCap && loadingSkeleton()}
+          <img
+            className={classNames('pgn__card-image-cap', { show: showImageCap })}
+            src={src}
+            onError={(event) => handleSrcFallback(event, fallbackSrc, 'imageCap')}
+            onLoad={() => setShowImageCap(true)}
+            alt={srcAlt}
+            loading={imageLoadingType}
+          />
+        </>
       )}
       {!!logoSrc && (
-        <img
-          className={classNames('pgn__card-logo-cap', { show: showLogoCap })}
-          src={logoSrc}
-          onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
-          onLoad={() => setShowLogoCap(true)}
-          alt={logoAlt}
-          loading={imageLoadingType}
-        />
+        <>
+          {skeletonDuringImageLoad && !showLogoCap && loadingLogoSkeleton()}
+          <img
+            className={classNames('pgn__card-logo-cap', { show: showLogoCap })}
+            src={logoSrc}
+            onError={(event) => handleSrcFallback(event, fallbackLogoSrc, 'logoCap')}
+            onLoad={() => setShowLogoCap(true)}
+            alt={logoAlt}
+            loading={imageLoadingType}
+          />
+        </>
       )}
     </div>
   );
@@ -120,6 +133,9 @@ CardImageCap.propTypes = {
   logoSkeletonWidth: PropTypes.number,
   /** Specifies loading type for images */
   imageLoadingType: PropTypes.oneOf(['eager', 'lazy']),
+  /** Render the loading skeleton when the image is loading in
+   *  addition to when the whole card is in `isLoading` state */
+  skeletonDuringImageLoad: PropTypes.bool,
 };
 
 CardImageCap.defaultProps = {
@@ -136,6 +152,7 @@ CardImageCap.defaultProps = {
   skeletonWidth: undefined,
   logoSkeletonWidth: undefined,
   imageLoadingType: 'eager',
+  skeletonDuringImageLoad: false,
 };
 
 export default CardImageCap;


### PR DESCRIPTION
## Description

The current behavior of `CardImageCap` is to show the loading skeleton when the Card context's `isLoading` is true, but not when the image itself is loading. This leads to resizing on load. This PR adds a new `skeletonDuringImageLoad` prop so consumers can choose to instead continue to display the skeleton loader until the images load.

### `skeletonDuringImageLoad={false}`
##### Slow network simulated

https://github.com/user-attachments/assets/d114bdb3-cead-4d0f-8b97-1cf0b1c66fda

### `skeletonDuringImageLoad={true}`
##### Slow network simulated

https://github.com/user-attachments/assets/d32b5f2a-b954-4776-859a-690a2f913859

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
