### PR TITLE
fix: ensure gap between `SearchField` input and button is transparent

### DIFF
--- a/src/SearchField/index.scss
+++ b/src/SearchField/index.scss
@@ -91,6 +91,10 @@
   &.pgn__searchfield--external {
     border: none;
 
+    .pgn__searchfield-form {
+      background-color: transparent;
+    }
+
     &.has-focus {
       box-shadow: none;
 
@@ -112,6 +116,7 @@
     display: flex;
     align-items: center;
     width: 100%;
+    background-color: var(--pgn-color-search-field-form-bg);
     border: var(--pgn-size-search-field-border-width-base) solid var(--pgn-color-search-field-border-base);
 
     &:hover,


### PR DESCRIPTION
## Description

Resolves https://github.com/openedx/paragon/issues/2651

### Before

<img width="988" height="245" alt="image" src="https://github.com/user-attachments/assets/9fe5eae4-a728-4c29-8e1e-08e2dcef7b56" />

<img width="988" height="219" alt="image" src="https://github.com/user-attachments/assets/5e7a584b-eed4-4019-ba6e-014d5a34fa1a" />

<img width="988" height="219" alt="image" src="https://github.com/user-attachments/assets/55a9e1f4-8049-411a-82b7-36d45f694d66" />

### After

<img width="988" height="241" alt="image" src="https://github.com/user-attachments/assets/1306c05a-0465-47f0-a599-5501d3274741" />

<img width="988" height="219" alt="image" src="https://github.com/user-attachments/assets/e412e839-bb6b-45a6-99bf-b6548ee45ca7" />

<img width="988" height="219" alt="image" src="https://github.com/user-attachments/assets/ea747ca6-4bad-4106-aae4-60b9f6c88e8d" />

### Deploy Preview

https://deploy-preview-4006--paragon-openedx-v23.netlify.app/components/searchfield/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
