### PR TITLE
feat: add icon to `Toast` component

### DIFF
--- a/src/Toast/README.md
+++ b/src/Toast/README.md
@@ -45,6 +45,28 @@ notes: ''
 }
 ```
 
+## With Icon
+
+```jsx live
+() => {
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <Toast
+        icon={Settings}
+        onClose={() => setShow(false)}
+        show={show}
+      >
+        Processing.. Example of a Toast with an icon.
+      </Toast>
+
+      <Button onClick={() => setShow(true)}>Show Toast</Button>
+    </>
+  );
+}
+```
+
 ## With Button
 
 ```jsx live

--- a/src/Toast/Toast.test.tsx
+++ b/src/Toast/Toast.test.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 
+import { Info } from '../../icons';
 import Toast from '.';
 
 function ToastWrapper({ children, ...props }: React.ComponentProps<typeof Toast>) {
@@ -50,6 +52,20 @@ describe('<Toast />', () => {
     );
     const toastButton = screen.getByRole('button', { name: 'Optional action' });
     expect(toastButton.className).toContain('btn');
+  });
+  it('renders optional icon', () => {
+    const { container } = render(
+      <ToastWrapper
+        {...props}
+        icon={Info}
+        iconClassName="icon-class"
+      >
+        Success message.
+      </ToastWrapper>,
+    );
+
+    const toastIcon = container.querySelector('.__pgn__icon');
+    expect(toastIcon).toBeInTheDocument();
   });
   it('autohide is set to false on onMouseOver and true on onMouseLeave', async () => {
     render(

--- a/src/Toast/index.scss
+++ b/src/Toast/index.scss
@@ -39,12 +39,16 @@
   .toast-header {
     align-items: center;
     border-bottom: 0;
-    justify-content: space-between;
     padding: 0;
+
+    .toast-header-icon {
+      margin-right: .75rem;
+    }
 
     p {
       font-size: var(--pgn-typography-font-size-sm);
-      margin: 0;
+      font-weight: var(--pgn-typography-weight-normal);
+      margin: 0 auto 0 0;
       padding-right: .75rem;
     }
 

--- a/src/Toast/index.tsx
+++ b/src/Toast/index.tsx
@@ -7,7 +7,7 @@ import { useIntl } from 'react-intl';
 import { Close } from '../../icons';
 import ToastContainer from './ToastContainer';
 import Button from '../Button';
-import Icon from '../Icon';
+import Icon, { type IconProps } from '../Icon';
 import IconButton from '../IconButton';
 
 export const TOAST_CLOSE_LABEL_TEXT = 'Close';
@@ -21,6 +21,8 @@ interface ToastAction {
 
 interface ToastProps {
   children: string;
+  icon?: React.ComponentType<IconProps>;
+  iconClassName?: string;
   onClose: () => void;
   show: boolean;
   action?: ToastAction;
@@ -36,6 +38,9 @@ function Toast({
   closeLabel,
   onClose,
   show,
+  icon,
+  iconClassName,
+  delay = TOAST_DELAY,
   ...rest
 }: ToastProps) {
   const intl = useIntl();
@@ -58,10 +63,12 @@ function Toast({
         onMouseOut={() => setAutoHide(true)}
         onMouseOver={() => setAutoHide(false)}
         show={show}
+        delay={delay}
         {...rest}
       >
         <div className="toast-header">
-          <p className="small">{children}</p>
+          {icon && <Icon className={classNames('toast-header-icon', iconClassName)} src={icon} />}
+          <p>{children}</p>
           <div className="toast-header-btn-container">
             <IconButton
               iconAs={Icon}
@@ -89,13 +96,6 @@ function Toast({
     </ToastContainer>
   );
 }
-
-Toast.defaultProps = {
-  action: null,
-  closeLabel: undefined,
-  delay: TOAST_DELAY,
-  className: undefined,
-};
 
 Toast.propTypes = {
   /** A string or an element that is rendered inside the main body of the `Toast`. */
@@ -127,6 +127,10 @@ Toast.propTypes = {
   delay: PropTypes.number,
   /** Class names for the `BaseToast` component */
   className: PropTypes.string,
+  /** Icon that will be shown in the  toast */
+  icon: PropTypes.func,
+  /** Class names for the `Icon` component */
+  iconClassName: PropTypes.string,
 };
 
 export default Toast;


### PR DESCRIPTION
## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
