### PR TITLE
fix: change `IconButton` base Props type to `ButtonHTMLAttributes`

### DIFF
--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -5,7 +5,7 @@ import { OverlayTrigger } from '../Overlay';
 import Tooltip from '../Tooltip';
 import Icon from '../Icon';
 
-interface Props extends React.HTMLAttributes<HTMLButtonElement> {
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Component that renders the icon, currently defaults to `Icon` */
   iconAs?: React.ComponentType<any>,
   /** Additional CSS class[es] to apply to this button */

--- a/src/IconButtonToggle/index.jsx
+++ b/src/IconButtonToggle/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 /**
  *
  * @param {object} args arguments
- * @param {boolean} args.activeValue the current value of the active/selected iconButton.
+ * @param {string} args.activeValue the current value of the active/selected iconButton.
  *                                   if not provided, none of the iconButtons will initially be active
  * @param {Function} args.onChange callback to call when toggle value changes.
  *                                 Receives value of the selected toggle button.


### PR DESCRIPTION
## Description

This PR changes the `IconButton` base type props from `HTMLAttributes` to `ButtonHTMLAttributes`. This fixes a typescript error while passing `value` to `IconButton`, as in the snippet below (from [here](https://paragon-openedx.netlify.app/components/iconbuttontoggle/)):

```jsx
 () => {
      const [activeValue, setActiveValue] = React.useState('card');
      return (
        <>
        <div className="mr-2 mt-2 mb-2">Current value is: <strong>{activeValue}</strong></div>
        <IconButtonToggle activeValue={activeValue} onChange={ value => setActiveValue(value) }>
          <IconButton value="card" src={GridView} iconAs={Icon} alt="Card" />
          <IconButton value="list" src={ListView} iconAs={Icon} alt="List" />
        </IconButtonToggle>
        </>
      );
    }
```

### Deploy Preview

No design changes made.

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [x] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
