### PR TITLE
refactor: run tests with node:test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,10 +80,8 @@
         "@formatjs/cli": "^5.0.2",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
-        "@testing-library/jest-dom": "^6.6",
         "@testing-library/react": "^16.1",
         "@testing-library/user-event": "^14.5",
-        "@types/jest": "^29.5.10",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/react-responsive": "^9.0.0",
@@ -93,7 +91,6 @@
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
         "axios-mock-adapter": "^2.0.0",
-        "babel-jest": "^29.7.0",
         "babel-loader": "^8.2.4",
         "commander": "^9.3.0",
         "eslint": "8.57.1",
@@ -102,19 +99,17 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-jsonc": "^2.18.1",
         "eslint-plugin-jsx-a11y": "6.10.2",
+        "global-jsdom": "^27.0.0",
         "husky": "^9.0.11",
         "identity-obj-proxy": "^3.0.0",
-        "jest": "^29.7.0",
-        "jest-cli": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^15.2.0",
-        "markdown-loader-jest": "^0.1.1",
+        "pretty-format": "^30.2.0",
         "react": "^18",
         "react-test-renderer": "^18",
         "regenerator-runtime": "^0.14.0",
         "semantic-release": "^20.1.3",
         "stylelint": "^15.11.0",
-        "ts-jest": "^29.1.2",
+        "tsx": "^4.21.0",
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
@@ -266,6 +261,7 @@
     "example/node_modules/@babel/core": {
       "version": "7.22.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -535,6 +531,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -752,7 +749,6 @@
     "example/node_modules/@jest/console": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -768,7 +764,6 @@
     "example/node_modules/@jest/console/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -784,7 +779,6 @@
     "example/node_modules/@jest/console/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -792,7 +786,6 @@
     "example/node_modules/@jest/console/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -808,7 +801,6 @@
     "example/node_modules/@jest/console/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -816,7 +808,6 @@
     "example/node_modules/@jest/globals": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -830,7 +821,6 @@
     "example/node_modules/@jest/globals/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -846,7 +836,6 @@
     "example/node_modules/@jest/globals/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -854,7 +843,6 @@
     "example/node_modules/@jest/reporters": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^29.7.0",
@@ -896,7 +884,6 @@
     "example/node_modules/@jest/reporters/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -910,7 +897,6 @@
     "example/node_modules/@jest/reporters/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -935,7 +921,6 @@
     "example/node_modules/@jest/reporters/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -951,20 +936,17 @@
     "example/node_modules/@jest/reporters/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/@jest/reporters/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -983,7 +965,6 @@
     "example/node_modules/@jest/reporters/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -1007,7 +988,6 @@
     "example/node_modules/@jest/reporters/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1015,7 +995,6 @@
     "example/node_modules/@jest/reporters/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -1031,7 +1010,6 @@
     "example/node_modules/@jest/reporters/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1039,7 +1017,6 @@
     "example/node_modules/@jest/reporters/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -1051,7 +1028,6 @@
     "example/node_modules/@jest/source-map": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
@@ -1064,7 +1040,6 @@
     "example/node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
@@ -1078,7 +1053,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1092,7 +1066,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1108,7 +1081,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1116,7 +1088,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -1140,7 +1111,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1148,7 +1118,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -1164,7 +1133,6 @@
     "example/node_modules/@jest/test-sequencer/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1217,7 +1185,6 @@
     "example/node_modules/@openedx/frontend-build": {
       "version": "14.2.2",
       "license": "AGPL-3.0",
-      "peer": true,
       "dependencies": {
         "@babel/cli": "7.24.8",
         "@babel/core": "7.24.9",
@@ -1298,7 +1265,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/cli": {
       "version": "7.24.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "commander": "^6.2.0",
@@ -1355,7 +1321,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/preset-env": {
       "version": "7.24.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.24.8",
         "@babel/helper-compilation-targets": "^7.24.8",
@@ -1449,7 +1414,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -1462,7 +1426,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@babel/preset-react": {
       "version": "7.24.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/helper-validator-option": "^7.24.7",
@@ -1481,7 +1444,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@edx/eslint-config": {
       "version": "4.3.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
@@ -1497,7 +1459,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/reporters": "^29.7.0",
@@ -1543,7 +1504,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core/node_modules/babel-jest": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -1563,7 +1523,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core/node_modules/jest-config": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -1607,7 +1566,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/core/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1615,7 +1573,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1629,7 +1586,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -1654,7 +1610,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/transform/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1662,7 +1617,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1678,7 +1632,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.15",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
@@ -1725,7 +1678,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1747,7 +1699,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.23.3",
         "caniuse-lite": "^1.0.30001646",
@@ -1769,7 +1720,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-jest": {
       "version": "29.6.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
@@ -1789,7 +1739,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-jest/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1797,7 +1746,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.10.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2",
         "core-js-compat": "^3.38.0"
@@ -1809,7 +1757,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
@@ -1820,7 +1767,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/babel-preset-jest": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
@@ -1835,20 +1781,17 @@
     "example/node_modules/@openedx/frontend-build/node_modules/commander": {
       "version": "6.2.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
     },
     "example/node_modules/@openedx/frontend-build/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/@openedx/frontend-build/node_modules/cssnano": {
       "version": "6.0.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^6.0.3",
         "lilconfig": "^3.0.0"
@@ -1867,7 +1810,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/debug": {
       "version": "4.4.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1883,7 +1825,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1902,7 +1843,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/html-webpack-plugin": {
       "version": "5.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -1958,7 +1898,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/test-result": "^29.7.0",
@@ -1990,7 +1929,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli/node_modules/babel-jest": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -2010,7 +1948,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli/node_modules/jest-config": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -2054,7 +1991,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-cli/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2062,7 +1998,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -2086,7 +2021,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2094,7 +2028,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -2110,7 +2043,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/jest-validate": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -2126,7 +2058,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/postcss-loader": {
       "version": "7.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cosmiconfig": "^8.3.5",
         "jiti": "^1.20.0",
@@ -2147,7 +2078,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/postcss-loader/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2166,7 +2096,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/sass-loader": {
       "version": "13.3.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "neo-async": "^2.6.2"
       },
@@ -2202,7 +2131,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/source-map": {
       "version": "0.7.4",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2210,7 +2138,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/source-map-loader": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "source-map-js": "^1.0.2"
@@ -2229,7 +2156,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/style-loader": {
       "version": "3.3.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12.13.0"
       },
@@ -2244,7 +2170,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/ts-jest": {
       "version": "29.1.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
@@ -2290,7 +2215,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/ts-jest/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2301,7 +2225,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/webpack-merge": {
       "version": "5.10.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
         "flat": "^5.0.2",
@@ -2314,7 +2237,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -2326,7 +2248,6 @@
     "example/node_modules/@openedx/frontend-build/node_modules/yargs": {
       "version": "17.7.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2394,7 +2315,6 @@
     "example/node_modules/@types/jest": {
       "version": "29.5.12",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -2403,7 +2323,6 @@
     "example/node_modules/ansi-styles": {
       "version": "5.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2414,6 +2333,7 @@
     "example/node_modules/axios": {
       "version": "1.6.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -2483,7 +2403,6 @@
     "example/node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -2537,20 +2456,17 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "example/node_modules/cjs-module-lexer": {
       "version": "1.4.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/cliui": {
       "version": "8.0.1",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2584,7 +2500,6 @@
     "example/node_modules/emittery": {
       "version": "0.13.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2595,6 +2510,7 @@
     "example/node_modules/eslint": {
       "version": "8.44.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -2651,6 +2567,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -2680,6 +2597,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
       "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "aria-query": "^5.1.3",
@@ -2708,6 +2626,7 @@
     "example/node_modules/eslint-plugin-react": {
       "version": "7.32.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flatmap": "^1.3.1",
@@ -2735,6 +2654,7 @@
     "example/node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2797,7 +2717,6 @@
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
       "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2829,7 +2748,6 @@
     "example/node_modules/iconv-lite": {
       "version": "0.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2840,7 +2758,6 @@
     "example/node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -2855,7 +2772,6 @@
     "example/node_modules/istanbul-lib-instrument/node_modules/@babel/core": {
       "version": "7.26.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2884,20 +2800,17 @@
     "example/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "example/node_modules/istanbul-lib-instrument/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/istanbul-lib-instrument/node_modules/debug": {
       "version": "4.4.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2913,7 +2826,6 @@
     "example/node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2939,7 +2851,6 @@
     "example/node_modules/jest-changed-files": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "execa": "^5.0.0",
         "jest-util": "^29.7.0",
@@ -2952,7 +2863,6 @@
     "example/node_modules/jest-changed-files/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2968,7 +2878,6 @@
     "example/node_modules/jest-changed-files/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -2976,7 +2885,6 @@
     "example/node_modules/jest-changed-files/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3017,7 +2925,6 @@
     "example/node_modules/jest-docblock": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -3028,7 +2935,6 @@
     "example/node_modules/jest-environment-jsdom": {
       "version": "29.6.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.6.1",
         "@jest/fake-timers": "^29.6.1",
@@ -3054,7 +2960,6 @@
     "example/node_modules/jest-environment-jsdom/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3070,7 +2975,6 @@
     "example/node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3078,7 +2982,6 @@
     "example/node_modules/jest-environment-jsdom/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3094,7 +2997,6 @@
     "example/node_modules/jest-environment-node": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -3110,7 +3012,6 @@
     "example/node_modules/jest-environment-node/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3126,7 +3027,6 @@
     "example/node_modules/jest-environment-node/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3134,7 +3034,6 @@
     "example/node_modules/jest-environment-node/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3150,7 +3049,6 @@
     "example/node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.7.0"
@@ -3162,7 +3060,6 @@
     "example/node_modules/jest-message-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -3181,7 +3078,6 @@
     "example/node_modules/jest-message-util/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3197,7 +3093,6 @@
     "example/node_modules/jest-message-util/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3205,7 +3100,6 @@
     "example/node_modules/jest-message-util/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3213,7 +3107,6 @@
     "example/node_modules/jest-resolve": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -3232,7 +3125,6 @@
     "example/node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
         "jest-snapshot": "^29.7.0"
@@ -3244,7 +3136,6 @@
     "example/node_modules/jest-resolve-dependencies/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3252,7 +3143,6 @@
     "example/node_modules/jest-resolve/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3268,7 +3158,6 @@
     "example/node_modules/jest-resolve/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3276,7 +3165,6 @@
     "example/node_modules/jest-resolve/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3300,7 +3188,6 @@
     "example/node_modules/jest-resolve/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3308,7 +3195,6 @@
     "example/node_modules/jest-resolve/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3324,7 +3210,6 @@
     "example/node_modules/jest-resolve/node_modules/jest-validate": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -3340,7 +3225,6 @@
     "example/node_modules/jest-resolve/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3348,7 +3232,6 @@
     "example/node_modules/jest-runner": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -3379,7 +3262,6 @@
     "example/node_modules/jest-runner/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3393,7 +3275,6 @@
     "example/node_modules/jest-runner/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3418,7 +3299,6 @@
     "example/node_modules/jest-runner/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3434,20 +3314,17 @@
     "example/node_modules/jest-runner/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/jest-runner/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/jest-runner/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3471,7 +3348,6 @@
     "example/node_modules/jest-runner/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3479,7 +3355,6 @@
     "example/node_modules/jest-runner/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3495,7 +3370,6 @@
     "example/node_modules/jest-runner/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3503,7 +3377,6 @@
     "example/node_modules/jest-runner/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -3515,7 +3388,6 @@
     "example/node_modules/jest-runtime": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -3547,7 +3419,6 @@
     "example/node_modules/jest-runtime/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3561,7 +3432,6 @@
     "example/node_modules/jest-runtime/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3586,7 +3456,6 @@
     "example/node_modules/jest-runtime/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3602,20 +3471,17 @@
     "example/node_modules/jest-runtime/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/jest-runtime/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3634,7 +3500,6 @@
     "example/node_modules/jest-runtime/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3658,7 +3523,6 @@
     "example/node_modules/jest-runtime/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3666,7 +3530,6 @@
     "example/node_modules/jest-runtime/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3682,7 +3545,6 @@
     "example/node_modules/jest-runtime/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3690,7 +3552,6 @@
     "example/node_modules/jest-runtime/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -3702,7 +3563,6 @@
     "example/node_modules/jest-snapshot": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
@@ -3732,7 +3592,6 @@
     "example/node_modules/jest-snapshot/node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3757,7 +3616,6 @@
     "example/node_modules/jest-snapshot/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3773,20 +3631,17 @@
     "example/node_modules/jest-snapshot/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "example/node_modules/jest-snapshot/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/jest-snapshot/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3810,7 +3665,6 @@
     "example/node_modules/jest-snapshot/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3818,7 +3672,6 @@
     "example/node_modules/jest-snapshot/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3834,7 +3687,6 @@
     "example/node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3845,7 +3697,6 @@
     "example/node_modules/jest-snapshot/node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3853,7 +3704,6 @@
     "example/node_modules/jest-snapshot/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -3865,7 +3715,6 @@
     "example/node_modules/jest-watcher": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3883,7 +3732,6 @@
     "example/node_modules/jest-watcher/node_modules/@jest/test-result": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3897,7 +3745,6 @@
     "example/node_modules/jest-watcher/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3913,7 +3760,6 @@
     "example/node_modules/jest-watcher/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3921,7 +3767,6 @@
     "example/node_modules/jest-watcher/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3937,7 +3782,6 @@
     "example/node_modules/jest-worker": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-util": "^29.7.0",
@@ -3951,7 +3795,6 @@
     "example/node_modules/jest-worker/node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3967,7 +3810,6 @@
     "example/node_modules/jest-worker/node_modules/@types/yargs": {
       "version": "17.0.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3975,7 +3817,6 @@
     "example/node_modules/jest-worker/node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3988,10 +3829,54 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "example/node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "example/node_modules/lilconfig": {
       "version": "3.1.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -4002,7 +3887,6 @@
     "example/node_modules/parse5": {
       "version": "7.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -4025,7 +3909,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/cascade-layer-name-parser": "^1.0.13",
         "@csstools/css-parser-algorithms": "^2.7.1",
@@ -4050,7 +3933,6 @@
     "example/node_modules/pretty-format": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -4063,6 +3945,7 @@
     "example/node_modules/react": {
       "version": "17.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -4074,6 +3957,7 @@
     "example/node_modules/react-dom": {
       "version": "17.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -4085,15 +3969,13 @@
     },
     "example/node_modules/react-is": {
       "version": "18.3.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/react-responsive": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
       "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
@@ -4172,7 +4054,6 @@
     "example/node_modules/source-map-support": {
       "version": "0.5.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4181,7 +4062,6 @@
     "example/node_modules/supports-color": {
       "version": "8.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4195,7 +4075,6 @@
     "example/node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -4207,12 +4086,12 @@
     },
     "example/node_modules/v8-to-istanbul/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "example/node_modules/webpack": {
       "version": "5.89.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -4292,7 +4171,6 @@
     "example/node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4300,7 +4178,6 @@
     "example/node_modules/yargs-parser": {
       "version": "21.1.1",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4336,8 +4213,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.1",
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.29",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.29.tgz",
+      "integrity": "sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4453,6 +4332,7 @@
     "node_modules/@algolia/client-search": {
       "version": "5.17.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.17.0",
         "@algolia/requester-browser-xhr": "5.17.0",
@@ -4597,6 +4477,179 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.0.tgz",
+      "integrity": "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.2"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/cli": {
       "version": "7.26.4",
       "dev": true,
@@ -4717,6 +4770,7 @@
     "node_modules/@babel/core": {
       "version": "7.26.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -6893,6 +6947,26 @@
         "@csstools/css-tokenizer": "^2.4.1"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "2.7.1",
       "funding": [
@@ -6906,11 +6980,35 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -6926,6 +7024,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -7819,7 +7918,6 @@
     "node_modules/@fortawesome/react-fontawesome": {
       "version": "0.1.19",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prop-types": "^15.8.1"
       },
@@ -7855,6 +7953,7 @@
     "node_modules/@gatsbyjs/reach-router": {
       "version": "2.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1"
@@ -9644,6 +9743,7 @@
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0",
         "@types/react": ">=16"
@@ -9795,6 +9895,7 @@
       "version": "4.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -10037,6 +10138,7 @@
     "node_modules/@parcel/core": {
       "version": "2.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.8.3",
@@ -10950,6 +11052,7 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -10958,7 +11061,6 @@
     "node_modules/@remix-run/router": {
       "version": "1.21.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -11668,6 +11770,7 @@
       "version": "6.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@svgr/babel-preset": "^6.5.1",
@@ -11805,6 +11908,7 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -11963,39 +12067,38 @@
         "node": ">=14"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
-        "redent": "^3.0.0"
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12069,6 +12172,8 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -12091,8 +12196,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -12353,44 +12457,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "18.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "license": "MIT",
@@ -12490,8 +12556,7 @@
     },
     "node_modules/@types/picomatch": {
       "version": "2.3.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
@@ -12519,6 +12584,7 @@
     "node_modules/@types/react": {
       "version": "18.3.16",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -12543,7 +12609,6 @@
     "node_modules/@types/react-redux": {
       "version": "7.1.34",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -12697,6 +12762,7 @@
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -12754,6 +12820,7 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -13004,6 +13071,7 @@
       "integrity": "sha512-m3g9nQDWPtL+sTFdtCGRMI1Vrp86Ay4PBYq1Bo7Bnchj5ElNtAJpOqD+zg+apthVA4fB7oVpMWNjwpa6ElDWFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -13315,6 +13383,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13324,6 +13393,8 @@
     },
     "node_modules/acorn-globals": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.1.0",
@@ -13422,6 +13493,7 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13476,6 +13548,7 @@
     "node_modules/algoliasearch": {
       "version": "5.17.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.17.0",
         "@algolia/client-analytics": "5.17.0",
@@ -13564,7 +13637,6 @@
         "node >= 0.8.0"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "ansi-html": "bin/ansi-html"
       }
@@ -13607,7 +13679,6 @@
     "node_modules/ansis": {
       "version": "1.5.2",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12.13"
       },
@@ -14197,6 +14268,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
       "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.4",
@@ -14238,7 +14310,6 @@
     "node_modules/babel-eslint": {
       "version": "10.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",
@@ -14257,7 +14328,6 @@
     "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14940,6 +15010,16 @@
         "node": ">8.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "license": "MIT",
@@ -15120,6 +15200,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -16731,6 +16812,7 @@
       "version": "3.39.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -18098,6 +18180,8 @@
     },
     "node_modules/cssom": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "license": "MIT"
     },
     "node_modules/cssstyle": {
@@ -18143,6 +18227,8 @@
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "license": "MIT",
       "dependencies": {
         "abab": "^2.0.6",
@@ -18268,7 +18354,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.3",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -18856,8 +18944,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -18913,6 +19000,9 @@
     },
     "node_modules/domexception": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
       "license": "MIT",
       "dependencies": {
         "webidl-conversions": "^7.0.0"
@@ -19038,20 +19128,6 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT"
-    },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.73",
@@ -19906,15 +19982,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/es6-templates": {
-      "version": "0.2.3",
-      "dev": true,
-      "license": "Apache 2",
-      "dependencies": {
-        "recast": "~0.11.12",
-        "through": "~2.3.6"
-      }
-    },
     "node_modules/es6-weak-map": {
       "version": "2.0.3",
       "license": "ISC",
@@ -20095,6 +20162,7 @@
     "node_modules/eslint-config-airbnb": {
       "version": "19.0.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
@@ -20131,6 +20199,7 @@
     "node_modules/eslint-config-airbnb-typescript": {
       "version": "17.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
       },
@@ -20260,7 +20329,6 @@
     "node_modules/eslint-plugin-formatjs": {
       "version": "4.13.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "2.7.8",
         "@formatjs/ts-transformer": "3.13.14",
@@ -20281,7 +20349,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
       "version": "2.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -20290,7 +20357,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
       "version": "2.7.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.0.0",
         "@formatjs/icu-skeleton-parser": "1.8.2",
@@ -20300,7 +20366,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.8.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.0.0",
         "tslib": "^2.4.0"
@@ -20309,7 +20374,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/intl-localematcher": {
       "version": "0.5.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -20317,7 +20381,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
       "version": "3.13.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "2.7.8",
         "@types/json-stable-stringify": "^1.0.32",
@@ -20339,7 +20402,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@types/eslint": {
       "version": "8.56.12",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -20347,13 +20409,11 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@types/node": {
       "version": "17.0.45",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/scope-manager": {
       "version": "6.21.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "@typescript-eslint/visitor-keys": "6.21.0"
@@ -20369,7 +20429,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/types": {
       "version": "6.21.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -20381,7 +20440,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/typescript-estree": {
       "version": "6.21.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "@typescript-eslint/visitor-keys": "6.21.0",
@@ -20408,7 +20466,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/utils": {
       "version": "6.21.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
@@ -20432,7 +20489,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/visitor-keys": {
       "version": "6.21.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -20448,7 +20504,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/brace-expansion": {
       "version": "2.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -20456,7 +20511,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/debug": {
       "version": "4.4.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -20471,13 +20525,11 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/emoji-regex": {
       "version": "10.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-formatjs/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -20488,7 +20540,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/magic-string": {
       "version": "0.30.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -20496,7 +20547,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/minimatch": {
       "version": "9.0.3",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -20510,7 +20560,6 @@
     "node_modules/eslint-plugin-formatjs/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -20520,13 +20569,11 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/eslint-plugin-formatjs/node_modules/typescript": {
       "version": "5.7.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21479,11 +21526,6 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "license": "ISC",
@@ -21616,33 +21658,6 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/filesize": {
       "version": "8.0.7",
       "license": "BSD-3-Clause",
@@ -21764,7 +21779,6 @@
     "node_modules/flat": {
       "version": "5.0.2",
       "license": "BSD-3-Clause",
-      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -21816,7 +21830,6 @@
     "node_modules/font-awesome": {
       "version": "4.7.0",
       "license": "(OFL-1.1 AND MIT)",
-      "peer": true,
       "engines": {
         "node": ">=0.10.3"
       }
@@ -22180,6 +22193,7 @@
       "version": "5.14.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/core": "^7.20.12",
@@ -23049,6 +23063,7 @@
     "node_modules/gatsby-source-filesystem": {
       "version": "5.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "chokidar": "^3.5.3",
@@ -23297,6 +23312,7 @@
     "node_modules/gatsby/node_modules/eslint": {
       "version": "7.32.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -23383,6 +23399,7 @@
     "node_modules/gatsby/node_modules/eslint-plugin-flowtype": {
       "version": "5.10.0",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
@@ -23823,6 +23840,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/get-value": {
       "version": "2.0.6",
       "license": "MIT",
@@ -23931,6 +23961,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/global-jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-27.0.0.tgz",
+      "integrity": "sha512-0lIJfZACEKdBZ1VKSY2L4T2sYhnQ4VfzbULUiEMPcUa3ZWv4ywOCNZAibZyKIDwysIr+WjRyM4U9L9vM6oQQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "jsdom": ">=27 <28"
       }
     },
     "node_modules/global-modules": {
@@ -24076,6 +24119,7 @@
     "node_modules/graphql": {
       "version": "16.9.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -25880,6 +25924,8 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
@@ -25906,62 +25952,6 @@
       "version": "2.0.2",
       "license": "MIT"
     },
-    "node_modules/html-loader": {
-      "version": "0.5.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es6-templates": "^0.2.3",
-        "fastparse": "^1.1.1",
-        "html-minifier": "^3.5.8",
-        "loader-utils": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/html-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/html-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/html-minifier": {
-      "version": "3.5.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.2.x",
-        "commander": "2.17.x",
-        "he": "1.2.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
-      },
-      "bin": {
-        "html-minifier": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
       "license": "MIT",
@@ -25987,57 +25977,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/html-minifier/node_modules/camel-case": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
-    "node_modules/html-minifier/node_modules/clean-css": {
-      "version": "4.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/html-minifier/node_modules/commander": {
-      "version": "2.17.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/html-minifier/node_modules/lower-case": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/html-minifier/node_modules/no-case": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^1.1.1"
-      }
-    },
-    "node_modules/html-minifier/node_modules/param-case": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^2.2.0"
-      }
-    },
-    "node_modules/html-minifier/node_modules/upper-case": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/html-tags": {
       "version": "3.3.1",
@@ -26165,6 +26104,8 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -26176,7 +26117,9 @@
       }
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -27658,28 +27601,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.6",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/java-properties": {
       "version": "1.0.2",
       "dev": true,
@@ -27691,31 +27612,6 @@
     "node_modules/javascript-stringify": {
       "version": "2.1.0",
       "license": "MIT"
-    },
-    "node_modules/jest": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "import-local": "^3.0.2",
-        "jest-cli": "^29.7.0"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
     },
     "node_modules/jest-changed-files": {
       "version": "26.6.2",
@@ -28138,731 +28034,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "create-jest": "^29.7.0",
-        "exit": "^0.1.2",
-        "import-local": "^3.0.2",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/console": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/core": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/reporters": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.7.0",
-        "jest-config": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-resolve-dependencies": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/globals": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/reporters": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/source-map": {
-      "version": "29.6.3",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/test-result": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/test-sequencer": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/ci-info": {
-      "version": "3.9.0",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-cli/node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-cli/node_modules/cliui": {
-      "version": "8.0.1",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jest-cli/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-cli/node_modules/emittery": {
-      "version": "0.13.1",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/glob": {
-      "version": "7.2.3",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-cli/node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "devOptional": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-changed-files": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.0.0",
-        "jest-util": "^29.7.0",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-config": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-jest": "^29.7.0",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-docblock": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-environment-node": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-leak-detector": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-resolve": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^2.0.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-resolve-dependencies": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-runner": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/environment": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-leak-detector": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-resolve": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-runtime": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/globals": "^29.7.0",
-        "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-snapshot": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-jsx": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^29.7.0",
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-util": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-validate": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "leven": "^3.1.0",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-watcher": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "jest-util": "^29.7.0",
-        "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/react-is": {
-      "version": "18.3.1",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-cli/node_modules/semver": {
-      "version": "7.6.3",
-      "devOptional": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-cli/node_modules/slash": {
-      "version": "3.0.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-cli/node_modules/source-map-support": {
-      "version": "0.5.13",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/supports-color": {
-      "version": "8.1.1",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/y18n": {
-      "version": "5.0.8",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-cli/node_modules/yargs": {
-      "version": "17.7.2",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jest-cli/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/jest-config": {
@@ -29421,62 +28592,6 @@
     "node_modules/jest-each/node_modules/react-is": {
       "version": "17.0.2",
       "license": "MIT"
-    },
-    "node_modules/jest-environment-jsdom": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/jsdom": "^20.0.0",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jsdom": "^20.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/ci-info": {
-      "version": "3.9.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/jest-util": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
     },
     "node_modules/jest-environment-node": {
       "version": "26.6.2",
@@ -30549,653 +29664,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/jest/node_modules/@jest/console": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/core": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/reporters": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.7.0",
-        "jest-config": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-resolve-dependencies": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest/node_modules/@jest/globals": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/reporters": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest/node_modules/@jest/source-map": {
-      "version": "29.6.3",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/test-result": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/test-sequencer": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest/node_modules/ci-info": {
-      "version": "3.9.0",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest/node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/jest/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/jest/node_modules/emittery": {
-      "version": "0.13.1",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
-    "node_modules/jest/node_modules/glob": {
-      "version": "7.2.3",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest/node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "devOptional": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest/node_modules/jest-changed-files": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.0.0",
-        "jest-util": "^29.7.0",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-config": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-jest": "^29.7.0",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest/node_modules/jest-docblock": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-environment-node": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest/node_modules/jest-leak-detector": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-resolve": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^2.0.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-resolve-dependencies": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-runner": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/environment": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-leak-detector": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-resolve": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-runtime": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/globals": "^29.7.0",
-        "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-snapshot": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-jsx": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^29.7.0",
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-util": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-validate": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "leven": "^3.1.0",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-watcher": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "jest-util": "^29.7.0",
-        "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/react-is": {
-      "version": "18.3.1",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/jest/node_modules/semver": {
-      "version": "7.6.3",
-      "devOptional": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest/node_modules/slash": {
-      "version": "3.0.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest/node_modules/source-map-support": {
-      "version": "0.5.13",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/jest/node_modules/supports-color": {
-      "version": "8.1.1",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest/node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/jiti": {
       "version": "1.21.6",
       "license": "MIT",
@@ -31248,46 +29716,297 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "20.0.3",
+      "version": "27.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.3.0.tgz",
+      "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/cssstyle": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.4.tgz",
+      "integrity": "sha512-KyOS/kJMEq5O9GdPnaf82noigg5X5DYn0kZPJTaAsCUaBizp6Xa1y9D4Qoqf/JazEXWuruErHgVXwjN5391ZJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.0",
+        "@csstools/css-syntax-patches-for-csstree": "1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -31363,6 +30082,7 @@
       "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -32429,63 +31149,9 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/markdown-loader": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "marked": "^0.3.9"
-      }
-    },
-    "node_modules/markdown-loader-jest": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "html-loader": "^0.5.1",
-        "markdown-loader": "^2.0.1"
-      }
-    },
-    "node_modules/markdown-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/markdown-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "0.3.19",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/matchmediaquery": {
       "version": "0.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-mediaquery": "^0.1.2"
       }
@@ -39034,6 +37700,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -39642,7 +38309,6 @@
     "node_modules/postcss-rtlcss": {
       "version": "5.1.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "rtlcss": "4.1.1"
       },
@@ -39696,6 +38362,7 @@
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -39842,24 +38509,44 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.5.1",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/pretty-format/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -39868,24 +38555,17 @@
       }
     },
     "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prism-react-renderer": {
       "version": "1.3.5",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=0.14.9"
-      }
-    },
-    "node_modules/private": {
-      "version": "0.1.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/process": {
@@ -39929,6 +38609,7 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -40200,6 +38881,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -40392,6 +39074,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -40501,6 +39184,7 @@
     "node_modules/react-helmet": {
       "version": "6.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.7.2",
@@ -40543,6 +39227,7 @@
     "node_modules/react-intl": {
       "version": "6.8.9",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.2.4",
         "@formatjs/icu-messageformat-parser": "2.9.4",
@@ -41379,7 +40064,6 @@
     "node_modules/react-redux": {
       "version": "7.2.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -41402,12 +40086,12 @@
     },
     "node_modules/react-redux/node_modules/react-is": {
       "version": "17.0.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -41491,7 +40175,6 @@
     "node_modules/react-router": {
       "version": "6.28.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.21.0"
       },
@@ -41815,48 +40498,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/recast": {
-      "version": "0.11.23",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/recast/node_modules/ast-types": {
-      "version": "0.9.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/recast/node_modules/esprima": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "license": "MIT",
@@ -41917,6 +40558,7 @@
     "node_modules/redux": {
       "version": "4.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -43381,6 +42023,16 @@
       "version": "3.0.0",
       "license": "MIT"
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "license": "MIT"
@@ -43941,6 +42593,7 @@
     "node_modules/sass": {
       "version": "1.82.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -44034,6 +42687,7 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -44099,6 +42753,7 @@
       "version": "20.1.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
@@ -44357,6 +43012,7 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -44926,8 +43582,7 @@
     },
     "node_modules/shallow-equal": {
       "version": "1.2.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -46252,6 +44907,7 @@
       "integrity": "sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
@@ -46390,6 +45046,7 @@
       "version": "15.11.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.3.1",
         "@csstools/css-tokenizer": "^2.2.0",
@@ -47549,6 +46206,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -47562,6 +46220,26 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -47708,6 +46386,8 @@
     },
     "node_modules/tr46": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.1"
@@ -47774,7 +46454,6 @@
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -47788,102 +46467,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/ts-jest": {
-      "version": "29.2.5",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
-        "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.6.3",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/transform": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/ci-info": {
-      "version": "3.9.0",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-jest/node_modules/jest-util": {
-      "version": "29.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "devOptional": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ts-jest/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -47914,7 +46497,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -47932,6 +46516,510 @@
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+      "integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+      "integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+      "integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+      "integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+      "integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+      "integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+      "integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+      "integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+      "integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+      "integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+      "integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+      "integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+      "integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+      "integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+      "integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+      "integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+      "integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+      "integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+      "integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+      "integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+      "integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+      "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.1",
+        "@esbuild/android-arm": "0.27.1",
+        "@esbuild/android-arm64": "0.27.1",
+        "@esbuild/android-x64": "0.27.1",
+        "@esbuild/darwin-arm64": "0.27.1",
+        "@esbuild/darwin-x64": "0.27.1",
+        "@esbuild/freebsd-arm64": "0.27.1",
+        "@esbuild/freebsd-x64": "0.27.1",
+        "@esbuild/linux-arm": "0.27.1",
+        "@esbuild/linux-arm64": "0.27.1",
+        "@esbuild/linux-ia32": "0.27.1",
+        "@esbuild/linux-loong64": "0.27.1",
+        "@esbuild/linux-mips64el": "0.27.1",
+        "@esbuild/linux-ppc64": "0.27.1",
+        "@esbuild/linux-riscv64": "0.27.1",
+        "@esbuild/linux-s390x": "0.27.1",
+        "@esbuild/linux-x64": "0.27.1",
+        "@esbuild/netbsd-arm64": "0.27.1",
+        "@esbuild/netbsd-x64": "0.27.1",
+        "@esbuild/openbsd-arm64": "0.27.1",
+        "@esbuild/openbsd-x64": "0.27.1",
+        "@esbuild/openharmony-arm64": "0.27.1",
+        "@esbuild/sunos-x64": "0.27.1",
+        "@esbuild/win32-arm64": "0.27.1",
+        "@esbuild/win32-ia32": "0.27.1",
+        "@esbuild/win32-x64": "0.27.1"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -47967,6 +47055,7 @@
     "node_modules/type-fest": {
       "version": "0.21.3",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -48075,6 +47164,7 @@
     "node_modules/typescript": {
       "version": "4.9.5",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -48126,6 +47216,7 @@
       "version": "3.4.10",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "commander": "~2.19.0",
         "source-map": "~0.6.1"
@@ -48140,7 +47231,8 @@
     "node_modules/uglify-js/node_modules/commander": {
       "version": "2.19.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -48323,15 +47415,13 @@
     "node_modules/unicode-emoji-utils": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "10.3.0"
       }
     },
     "node_modules/unicode-emoji-utils/node_modules/emoji-regex": {
       "version": "10.3.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
@@ -48979,6 +48069,8 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^4.0.0"
@@ -49032,6 +48124,8 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -49040,6 +48134,7 @@
     "node_modules/webpack": {
       "version": "5.97.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -49135,6 +48230,7 @@
     "node_modules/webpack-cli": {
       "version": "5.1.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -49360,7 +48456,6 @@
     "node_modules/webpack-remove-empty-scripts": {
       "version": "1.0.4",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "ansis": "1.5.2"
       },
@@ -49445,6 +48540,8 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -49455,6 +48552,8 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -49465,6 +48564,8 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -49472,6 +48573,8 @@
     },
     "node_modules/whatwg-url": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "license": "MIT",
       "dependencies": {
         "tr46": "^3.0.0",
@@ -49703,7 +48806,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -49746,6 +48851,8 @@
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -36,11 +36,12 @@
     "lint:fix": "npm run stylelint && eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx --ext .json . && npm run lint --workspaces --if-present",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release",
-    "snapshot": "jest --updateSnapshot",
+    "snapshot": "npm run test:no-coverage -- --test-update-snapshots",
     "start": "npm start --workspace=www",
-    "test": "jest --coverage",
+    "test": "npm run test:no-coverage -- --experimental-test-coverage --test-coverage-exclude='**/*.test.*'  --test-coverage-exclude='icons/**'",
+    "test:no-coverage": "node --experimental-test-module-mocks --enable-source-maps --import=global-jsdom/register --import=tsx --import='./src/setupTest.ts' --test",
     "test:watch": "npm run test -- --watch",
-    "test:watch-no-coverage": "npm run test:watch -- --coverage=false",
+    "test:watch-no-coverage": "npm run test:no-coverage -- --watch",
     "generate-component": "npm start --workspace=component-generator",
     "example:start": "npm start --workspace=example",
     "example:start:with-theme": "npm run start:with-theme --workspace=example",
@@ -127,10 +128,8 @@
     "@formatjs/cli": "^5.0.2",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "@testing-library/jest-dom": "^6.6",
     "@testing-library/react": "^16.1",
     "@testing-library/user-event": "^14.5",
-    "@types/jest": "^29.5.10",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-responsive": "^9.0.0",
@@ -140,7 +139,6 @@
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
     "axios-mock-adapter": "^2.0.0",
-    "babel-jest": "^29.7.0",
     "babel-loader": "^8.2.4",
     "commander": "^9.3.0",
     "eslint": "8.57.1",
@@ -149,57 +147,18 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jsonc": "^2.18.1",
     "eslint-plugin-jsx-a11y": "6.10.2",
+    "global-jsdom": "^27.0.0",
     "husky": "^9.0.11",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^29.7.0",
-    "jest-cli": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.0",
-    "markdown-loader-jest": "^0.1.1",
+    "pretty-format": "^30.2.0",
     "react": "^18",
     "react-test-renderer": "^18",
     "regenerator-runtime": "^0.14.0",
     "semantic-release": "^20.1.3",
     "stylelint": "^15.11.0",
-    "ts-jest": "^29.1.2",
+    "tsx": "^4.21.0",
     "typescript": "^4.7.4"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "transform": {
-      "^.+\\.md?$": "markdown-loader-jest",
-      "^.+\\.jsx?$": "babel-jest",
-      "^icons/index.js$": "babel-jest",
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "setupFilesAfterEnv": [
-      "./src/setupTest.ts"
-    ],
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|scss)$": "identity-obj-proxy"
-    },
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx,ts,tsx}"
-    ],
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "src/setupTest.ts",
-      "src/index.js",
-      "/tests/",
-      "/www/",
-      "/dist/"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/www/",
-      "/dist/",
-      "/dependent-usage-analyzer/",
-      "/component-generator/"
-    ],
-    "transformIgnorePatterns": [
-      "/node_modules/(?!(@openedx/paragon)/).*/"
-    ]
   },
   "browserslist": [
     "extends @edx/browserslist-config"

--- a/src/Alert/Alert.test.tsx
+++ b/src/Alert/Alert.test.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-import renderer, { act } from 'react-test-renderer';
-import { render, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { Context as ResponsiveContext } from 'react-responsive';
+import {
+  assert,
+  describe,
+  mock,
+  it,
+  render,
+  renderer,
+  screen,
+  userEvent,
+  within,
+} from '../testUtils';
 import { Info } from '../../icons';
 import breakpoints from '../utils/breakpoints';
 import Button from '../Button';
@@ -51,66 +59,63 @@ describe('Alert component type checking', () => {
 });
 
 describe('<Alert />', () => {
-  it('renders without any props', () => {
+  it('renders without any props', (t) => {
     const tree = renderer.create((
       <AlertWrapper>Alert</AlertWrapper>
     )).toJSON();
-    expect(tree).toMatchSnapshot();
+    t.assert.snapshot(tree);
   });
-  it('renders with icon prop', () => {
+  it('renders with icon prop', (t) => {
     const tree = renderer.create((
       <AlertWrapper icon={Info}>Alert</AlertWrapper>
     )).toJSON();
-    expect(tree).toMatchSnapshot();
+    t.assert.snapshot(tree);
   });
-  it('renders with dismissible prop', () => {
+  it('renders with dismissible prop', (t) => {
     const tree = renderer.create((
       <AlertWrapper dismissible>Alert</AlertWrapper>
     )).toJSON();
-    expect(tree).toMatchSnapshot();
+    t.assert.snapshot(tree);
   });
   it('handles dismissible onClose', async () => {
-    const mockOnClose = jest.fn();
+    const mockOnClose = mock.fn();
     render(<AlertWrapper onClose={mockOnClose} dismissible>Alert</AlertWrapper>);
     const button = screen.getByRole('button');
     await userEvent.click(button);
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    assert.wasCalled(mockOnClose);
   });
-  it('renders with button prop', () => {
+  it('renders with button prop', (t) => {
     const tree = renderer.create((
       <AlertWrapper actions={[<Button>Hello</Button>]}>Alert</AlertWrapper>
     )).toJSON();
-    expect(tree).toMatchSnapshot();
+    t.assert.snapshot(tree);
   });
   it('handles button onClick', async () => {
-    const mockOnClick = jest.fn();
+    const mockOnClick = mock.fn();
     render(<AlertWrapper actions={[<Button onClick={mockOnClick}>Hello</Button>]}>Alert</AlertWrapper>);
     const button = screen.getByRole('button');
     await userEvent.click(button);
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
+    assert.wasCalled(mockOnClick);
   });
-  it('renders with button and dismissible props', () => {
+  it('renders with button and dismissible props', (t) => {
     const tree = renderer.create((
       <AlertWrapper actions={[<Button>Hello</Button>]} dismissible>Alert</AlertWrapper>
     )).toJSON();
-    expect(tree).toMatchSnapshot();
+    t.assert.snapshot(tree);
   });
-  it('renders with stacked prop', () => {
+  it('renders with stacked prop', (t) => {
     const tree = renderer.create((
       <AlertWrapper stacked actions={[<Button>Hello</Button>]} dismissible>Alert</AlertWrapper>
     )).toJSON();
-    expect(tree).toMatchSnapshot();
+    t.assert.snapshot(tree);
   });
-  it('switches to stacked variant at extra small breakpoint', () => {
-    let tree;
-    act(() => {
-      tree = renderer.create((
-        <ResponsiveContext.Provider value={{ width: breakpoints.extraSmall.maxWidth }}>
-          <AlertWrapper dismissible>Alert</AlertWrapper>
-        </ResponsiveContext.Provider>
-      )).toJSON();
-    });
-    expect(tree).toMatchSnapshot();
+  it('switches to stacked variant at extra small breakpoint', (t) => {
+    const tree = renderer.create((
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraSmall.maxWidth }}>
+        <AlertWrapper dismissible>Alert</AlertWrapper>
+      </ResponsiveContext.Provider>
+    )).toJSON();
+    t.assert.snapshot(tree);
   });
   it('renders with headings and links', async () => {
     render(
@@ -121,8 +126,9 @@ describe('<Alert />', () => {
     );
     const alertDiv = screen.getByRole('alert');
     const heading = within(alertDiv).getByText(/This is the heading/);
-    expect(heading).toHaveClass('alert-heading', 'h4');
+    assert.containsClass(heading, 'alert-heading');
+    assert.containsClass(heading, 'h4');
     const link = within(alertDiv).getByRole('link', { name: 'here is a link' });
-    expect(link).toHaveClass('alert-link');
+    assert.containsClass(link, 'alert-link');
   });
 });

--- a/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -1,6 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<Alert /> renders with button and dismissible props 1`] = `
+exports[`<Alert /> > renders with button and dismissible props 1`] = `
 <div
   className="fade alert-content alert show"
   role="alert"
@@ -39,7 +37,7 @@ exports[`<Alert /> renders with button and dismissible props 1`] = `
 </div>
 `;
 
-exports[`<Alert /> renders with button prop 1`] = `
+exports[`<Alert /> > renders with button prop 1`] = `
 <div
   className="fade alert-content alert show"
   role="alert"
@@ -70,7 +68,7 @@ exports[`<Alert /> renders with button prop 1`] = `
 </div>
 `;
 
-exports[`<Alert /> renders with dismissible prop 1`] = `
+exports[`<Alert /> > renders with dismissible prop 1`] = `
 <div
   className="fade alert-content alert show"
   role="alert"
@@ -102,7 +100,7 @@ exports[`<Alert /> renders with dismissible prop 1`] = `
 </div>
 `;
 
-exports[`<Alert /> renders with icon prop 1`] = `
+exports[`<Alert /> > renders with icon prop 1`] = `
 <div
   className="fade alert-content alert show"
   role="alert"
@@ -138,7 +136,7 @@ exports[`<Alert /> renders with icon prop 1`] = `
 </div>
 `;
 
-exports[`<Alert /> renders with stacked prop 1`] = `
+exports[`<Alert /> > renders with stacked prop 1`] = `
 <div
   className="fade alert-content alert show"
   role="alert"
@@ -177,7 +175,7 @@ exports[`<Alert /> renders with stacked prop 1`] = `
 </div>
 `;
 
-exports[`<Alert /> renders without any props 1`] = `
+exports[`<Alert /> > renders without any props 1`] = `
 <div
   className="fade alert-content alert show"
   role="alert"
@@ -194,4 +192,34 @@ exports[`<Alert /> renders without any props 1`] = `
 </div>
 `;
 
-exports[`<Alert /> switches to stacked variant at extra small breakpoint 1`] = `null`;
+exports[`<Alert /> > switches to stacked variant at extra small breakpoint 1`] = `
+<div
+  className="fade alert-content alert show"
+  role="alert"
+>
+  <div
+    className="pgn__alert-message-wrapper"
+  >
+    <div
+      className="alert-message-content"
+    >
+      Alert
+    </div>
+    <div
+      className="pgn__alert-actions pgn__action-row"
+    >
+      <span
+        className="pgn__action-row-spacer"
+      />
+      <button
+        className="btn btn-tertiary btn-sm"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Dismiss
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/Breadcrumb.test.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import assert from 'node:assert/strict';
+import { describe, mock, it } from 'node:test';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -24,8 +25,8 @@ const baseProps = {
 describe('<Breadcrumb />', () => {
   it('renders with just links', () => {
     render(<Breadcrumb {...baseProps} />);
-    expect(screen.queryAllByRole('list').length).toBe(1);
-    expect(screen.queryAllByRole('listitem').length).toBe(baseProps.links.length);
+    assert.equal(screen.queryAllByRole('list').length, 1);
+    assert.equal(screen.queryAllByRole('listitem').length, baseProps.links.length);
   });
 
   it('renders with links and active label', () => {
@@ -34,9 +35,9 @@ describe('<Breadcrumb />', () => {
     const list = screen.queryAllByRole('list');
     const listItems = screen.queryAllByRole('listitem');
 
-    expect(list.length).toBe(1);
-    expect(listItems.length).toBe(baseProps.links.length + 1);
-    expect(listItems[listItems.length - 1].textContent).toBe(label);
+    assert.equal(list.length, 1);
+    assert.equal(listItems.length, baseProps.links.length + 1);
+    assert.equal(listItems[listItems.length - 1].textContent, label);
   });
 
   it('renders custom spacer', () => {
@@ -44,29 +45,29 @@ describe('<Breadcrumb />', () => {
       <Breadcrumb {...baseProps} spacer={<span>/</span>} />,
     );
     const listItems = screen.queryAllByRole('listitem');
-    expect(listItems.length).toBe(baseProps.links.length);
-    expect(screen.getAllByRole('presentation').length).toBe(2);
+    assert.equal(listItems.length, baseProps.links.length);
+    assert.equal(screen.getAllByRole('presentation').length, 2);
   });
 
   it('fires the passed in click handler', async () => {
     const user = userEvent.setup();
-    const clickHandler = jest.fn();
+    const clickHandler = mock.fn();
     render(<Breadcrumb {...baseProps} clickHandler={clickHandler} />);
 
     const listItems = screen.queryAllByRole('listitem');
     const links = screen.queryAllByRole('link');
-    expect(listItems.length).toBe(baseProps.links.length);
+    assert.equal(listItems.length, baseProps.links.length);
 
     await user.click(links[0]);
-    expect(clickHandler).toHaveBeenCalled();
+    assert.equal(clickHandler.mock.callCount(), 1);
   });
 
   it('renders in mobile view', () => {
     render(<Breadcrumb {...baseProps} isMobile />);
     const list = screen.getByRole('list');
     const listItems = screen.getAllByRole('listitem');
-    expect(listItems.length).toBe(1);
-    expect(list.className).toContain('is-mobile');
+    assert.equal(listItems.length, 1);
+    assert.match(list.className, /is-mobile/);
   });
 
   it('renders links as custom elements', () => {
@@ -74,10 +75,10 @@ describe('<Breadcrumb />', () => {
     const list = screen.getByRole('list');
 
     const anchors = list.querySelectorAll('a');
-    expect(anchors.length).toBe(0);
+    assert.equal(anchors.length, 0);
 
     const customLinks = list.querySelectorAll('div');
-    expect(customLinks.length).toBe(3);
+    assert.equal(customLinks.length, 3);
   });
 
   it('passes down link props to link elements', () => {
@@ -91,8 +92,8 @@ describe('<Breadcrumb />', () => {
     render(<Breadcrumb links={[linkProps]} />);
 
     const links = screen.getByRole('link');
-    expect(links.className).toContain('my-link');
-    expect(links.getAttribute('target')).toBe('_blank');
-    expect(links.getAttribute('href')).toBe('/link-1');
+    assert.match(links.className, /my-link/);
+    assert.equal(links.getAttribute('target'), '_blank');
+    assert.equal(links.getAttribute('href'), '/link-1');
   });
 });

--- a/src/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/Breadcrumb.test.tsx
@@ -1,7 +1,12 @@
-import assert from 'node:assert/strict';
-import { describe, mock, it } from 'node:test';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import {
+  assert,
+  describe,
+  mock,
+  it,
+  render,
+  screen,
+  userEvent,
+} from '../testUtils';
 
 import Breadcrumb from '.';
 
@@ -67,7 +72,7 @@ describe('<Breadcrumb />', () => {
     const list = screen.getByRole('list');
     const listItems = screen.getAllByRole('listitem');
     assert.equal(listItems.length, 1);
-    assert.match(list.className, /is-mobile/);
+    assert.containsClass(list, 'is-mobile');
   });
 
   it('renders links as custom elements', () => {
@@ -92,7 +97,7 @@ describe('<Breadcrumb />', () => {
     render(<Breadcrumb links={[linkProps]} />);
 
     const links = screen.getByRole('link');
-    assert.match(links.className, /my-link/);
+    assert.containsClass(links, 'my-link');
     assert.equal(links.getAttribute('target'), '_blank');
     assert.equal(links.getAttribute('href'), '/link-1');
   });

--- a/src/Bubble/Bubble.test.tsx
+++ b/src/Bubble/Bubble.test.tsx
@@ -1,36 +1,41 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
-import { render, screen } from '@testing-library/react';
+import {
+  assert,
+  describe,
+  it,
+  render,
+  renderer,
+  screen,
+} from '../testUtils';
 import Bubble from '.';
 
 describe('<Bubble />', () => {
   describe('correct rendering', () => {
-    it('successfully renders', () => {
+    it('successfully renders', (t) => {
       const tree = renderer.create(<Bubble>1</Bubble>).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
     it('renders with variant', () => {
       render(<Bubble variant="error">1</Bubble>);
       const bubble = screen.getByText('1');
-      expect(bubble.className).toContain('pgn__bubble-error');
+      assert.containsClass(bubble, 'pgn__bubble-error');
     });
 
     it('renders with default variant', () => {
       render(<Bubble>1</Bubble>);
       const bubble = screen.getByText('1');
-      expect(bubble.className).toContain('pgn__bubble-primary');
+      assert.containsClass(bubble, 'pgn__bubble-primary');
     });
 
     it('renders with disabled variant', () => {
       render(<Bubble disabled>1</Bubble>);
       const bubble = screen.getByText('1');
-      expect(bubble.className).toContain('disabled');
+      assert.containsClass(bubble, 'disabled');
     });
 
     it('renders with expandable variant', () => {
       render(<Bubble expandable>1</Bubble>);
       const bubble = screen.getByText('1');
-      expect(bubble.className).toContain('expandable');
+      assert.containsClass(bubble, 'expandable');
     });
   });
 });

--- a/src/Bubble/__snapshots__/Bubble.test.tsx.snap
+++ b/src/Bubble/__snapshots__/Bubble.test.tsx.snap
@@ -1,6 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<Bubble /> correct rendering successfully renders 1`] = `
+exports[`<Bubble /> > correct rendering > successfully renders 1`] = `
 <div
   className="pgn__bubble pgn__bubble-primary"
 >

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { IntlProvider } from 'react-intl';
+import assert from 'node:assert/strict';
+import { describe, mock, it } from 'node:test';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderer from 'react-test-renderer';
+import { IntlProvider } from 'react-intl';
 
 import { Close } from '../../icons';
 import Button from '.';
@@ -10,91 +11,93 @@ import Hyperlink from '../Hyperlink';
 
 describe('<Button />', () => {
   describe('correct rendering', () => {
-    it('renders without props', () => {
+    it('renders without props', (t) => {
       const tree = renderer.create((
         <Button>Button</Button>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
+
     it('renders with correct class when variant is added', () => {
       render(<Button variant="brand">Button</Button>);
       const button = screen.getByRole('button');
-      expect(button.className).toContain('btn-brand');
+      assert.match(button.className, /btn-brand/);
     });
 
-    it('renders with props iconBefore and size', () => {
+    it('renders with props iconBefore and size', (t) => {
       const tree = renderer.create((
         <Button iconBefore={Close} size="md">Button</Button>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
 
-    it('renders with props iconAfter and size', () => {
+    it('renders with props iconAfter and size', (t) => {
       const tree = renderer.create((
         <Button iconAfter={Close} size="sm">Button</Button>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
 
-    it('renders with props iconBefore', () => {
+    it('renders with props iconBefore', (t) => {
       const tree = renderer.create((
         <Button iconBefore={Close}>Button</Button>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
 
-    it('renders with props iconAfter', () => {
+    it('renders with props iconAfter', (t) => {
       const tree = renderer.create((
         <Button iconAfter={Close}>Button</Button>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
 
-    it('renders with props iconBefore and iconAfter', () => {
+    it('renders with props iconBefore and iconAfter', (t) => {
       const tree = renderer.create((
         <Button iconBefore={Close} iconAfter={Close}>Button</Button>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
 
     describe('renders as a link', () => {
-      test('with href', () => {
+      it('with href', (t) => {
         const tree = renderer.create((
           <Button href="https://edx.org">Button</Button>
         )).toJSON();
-        expect(tree).toMatchSnapshot();
+        t.assert.snapshot(tree);
       });
 
-      test('disable with href', () => {
+      it('disable with href', (t) => {
         const tree = renderer.create((
           <Button as="a" href="https://edx.org" disabled>Button</Button>
         )).toJSON();
-        expect(tree).toMatchSnapshot();
+        t.assert.snapshot(tree);
       });
 
-      test('cannot click if disabled', async () => {
-        const onClick = jest.fn();
+      it('cannot click if disabled', async () => {
+        const onClick = mock.fn();
         render(<Button as="a" href="https://edx.org" disabled onClick={onClick}>Button</Button>);
         const link = screen.getByRole('link');
         await userEvent.click(link);
-        expect(onClick).not.toHaveBeenCalled();
+        // Mock should not be called:
+        assert.equal(onClick.mock.callCount(), 0);
       });
 
-      test('invalid disabled if without href', async () => {
-        const onClick = jest.fn();
+      it('invalid disabled if without href', async () => {
+        const onClick = mock.fn();
         const { rerender } = render(<Button as="a" disabled onClick={onClick}>Button</Button>);
         const link = screen.getByText('Button');
         await userEvent.click(link);
-        expect(onClick).toHaveBeenCalled();
-        onClick.mockClear();
+        assert.equal(onClick.mock.callCount(), 1);
+        onClick.mock.resetCalls();
 
         rerender(<Button as="a" href="" disabled onClick={onClick}>Button</Button>);
         const emptyHrefLink = screen.getByRole('link', { name: 'Button' });
         await userEvent.click(emptyHrefLink);
-        expect(onClick).toHaveBeenCalled();
+        assert.equal(onClick.mock.callCount(), 1);
       });
 
-      test('test button as hyperlink', () => {
+      it('test button as hyperlink', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const ref = (_current: HTMLAnchorElement) => {}; // Check typing of a ref - should not show type errors.
         render(
@@ -102,18 +105,18 @@ describe('<Button />', () => {
             <Button as={Hyperlink} ref={ref} destination="https://www.poop.com/💩">Button</Button>
           </IntlProvider>,
         );
-        expect(screen.getByRole('link').getAttribute('href')).toEqual('https://www.poop.com/💩');
+        assert.equal(screen.getByRole('link').getAttribute('href'), 'https://www.poop.com/💩');
       });
     });
 
-    test('with size="inline"', () => {
+    it('with size="inline"', (t) => {
       const tree = renderer.create((
         <p>
           <span className="mr-1">2 items selected.</span>
           <Button variant="link" size="inline">Clear</Button>
         </p>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
   });
 });

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -1,9 +1,14 @@
-import assert from 'node:assert/strict';
-import { describe, mock, it } from 'node:test';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import renderer from 'react-test-renderer';
 import { IntlProvider } from 'react-intl';
+import {
+  assert,
+  describe,
+  mock,
+  it,
+  render,
+  renderer,
+  screen,
+  userEvent,
+} from '../testUtils';
 
 import { Close } from '../../icons';
 import Button from '.';
@@ -21,7 +26,7 @@ describe('<Button />', () => {
     it('renders with correct class when variant is added', () => {
       render(<Button variant="brand">Button</Button>);
       const button = screen.getByRole('button');
-      assert.match(button.className, /btn-brand/);
+      assert.containsClass(button, 'btn-brand');
     });
 
     it('renders with props iconBefore and size', (t) => {
@@ -80,7 +85,7 @@ describe('<Button />', () => {
         const link = screen.getByRole('link');
         await userEvent.click(link);
         // Mock should not be called:
-        assert.equal(onClick.mock.callCount(), 0);
+        assert.wasNotCalled(onClick);
       });
 
       it('invalid disabled if without href', async () => {
@@ -88,13 +93,13 @@ describe('<Button />', () => {
         const { rerender } = render(<Button as="a" disabled onClick={onClick}>Button</Button>);
         const link = screen.getByText('Button');
         await userEvent.click(link);
-        assert.equal(onClick.mock.callCount(), 1);
+        assert.wasCalled(onClick);
         onClick.mock.resetCalls();
 
         rerender(<Button as="a" href="" disabled onClick={onClick}>Button</Button>);
         const emptyHrefLink = screen.getByRole('link', { name: 'Button' });
         await userEvent.click(emptyHrefLink);
-        assert.equal(onClick.mock.callCount(), 1);
+        assert.wasCalled(onClick);
       });
 
       it('test button as hyperlink', () => {

--- a/src/Button/ButtonGroup.test.tsx
+++ b/src/Button/ButtonGroup.test.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import { describe, it } from 'node:test';
 import renderer from 'react-test-renderer';
 
 import Button, { ButtonGroup } from './index';
 
 describe('<ButtonGroup />', () => {
   describe('correct rendering', () => {
-    it('renders without props', () => {
+    it('renders without props', (t) => {
       const tree = renderer.create((
         <ButtonGroup />
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
 
-    it('renders with children', () => {
+    it('renders with children', (t) => {
       const tree = renderer.create((
         <ButtonGroup size="lg">
           <Button variant="primary">Left</Button>
@@ -20,7 +20,7 @@ describe('<ButtonGroup />', () => {
           <Button variant="primary">Right</Button>
         </ButtonGroup>
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
   });
 });

--- a/src/Button/ButtonToolbar.test.tsx
+++ b/src/Button/ButtonToolbar.test.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import { describe, it } from 'node:test';
 import renderer from 'react-test-renderer';
 
 import { ButtonToolbar } from './index';
 
 describe('<ButtonToolbar />', () => {
   describe('correct rendering', () => {
-    it('renders without props', () => {
+    it('renders without props', (t) => {
       const tree = renderer.create((
         <ButtonToolbar />
       )).toJSON();
-      expect(tree).toMatchSnapshot();
+      t.assert.snapshot(tree);
     });
   });
 });

--- a/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/Button/__snapshots__/Button.test.tsx.snap
@@ -1,6 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<Button /> correct rendering renders as a link disable with href 1`] = `
+exports[`<Button /> > correct rendering > renders as a link > disable with href 1`] = `
 <a
   aria-disabled={true}
   className="btn btn-primary disabled"
@@ -13,7 +11,7 @@ exports[`<Button /> correct rendering renders as a link disable with href 1`] = 
 </a>
 `;
 
-exports[`<Button /> correct rendering renders as a link with href 1`] = `
+exports[`<Button /> > correct rendering > renders as a link > with href 1`] = `
 <a
   className="btn btn-primary"
   href="https://edx.org"
@@ -24,7 +22,7 @@ exports[`<Button /> correct rendering renders as a link with href 1`] = `
 </a>
 `;
 
-exports[`<Button /> correct rendering renders with props iconAfter 1`] = `
+exports[`<Button /> > correct rendering > renders with props iconAfter 1`] = `
 <button
   className="btn btn-primary"
   disabled={false}
@@ -53,7 +51,7 @@ exports[`<Button /> correct rendering renders with props iconAfter 1`] = `
 </button>
 `;
 
-exports[`<Button /> correct rendering renders with props iconAfter and size 1`] = `
+exports[`<Button /> > correct rendering > renders with props iconAfter and size 1`] = `
 <button
   className="btn btn-primary btn-sm"
   disabled={false}
@@ -82,7 +80,7 @@ exports[`<Button /> correct rendering renders with props iconAfter and size 1`] 
 </button>
 `;
 
-exports[`<Button /> correct rendering renders with props iconBefore 1`] = `
+exports[`<Button /> > correct rendering > renders with props iconBefore 1`] = `
 <button
   className="btn btn-primary"
   disabled={false}
@@ -111,7 +109,7 @@ exports[`<Button /> correct rendering renders with props iconBefore 1`] = `
 </button>
 `;
 
-exports[`<Button /> correct rendering renders with props iconBefore and iconAfter 1`] = `
+exports[`<Button /> > correct rendering > renders with props iconBefore and iconAfter 1`] = `
 <button
   className="btn btn-primary"
   disabled={false}
@@ -159,7 +157,7 @@ exports[`<Button /> correct rendering renders with props iconBefore and iconAfte
 </button>
 `;
 
-exports[`<Button /> correct rendering renders with props iconBefore and size 1`] = `
+exports[`<Button /> > correct rendering > renders with props iconBefore and size 1`] = `
 <button
   className="btn btn-primary btn-md"
   disabled={false}
@@ -188,7 +186,7 @@ exports[`<Button /> correct rendering renders with props iconBefore and size 1`]
 </button>
 `;
 
-exports[`<Button /> correct rendering renders without props 1`] = `
+exports[`<Button /> > correct rendering > renders without props 1`] = `
 <button
   className="btn btn-primary"
   disabled={false}
@@ -198,7 +196,7 @@ exports[`<Button /> correct rendering renders without props 1`] = `
 </button>
 `;
 
-exports[`<Button /> correct rendering with size="inline" 1`] = `
+exports[`<Button /> > correct rendering > with size=\"inline\" 1`] = `
 <p>
   <span
     className="mr-1"

--- a/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
@@ -1,6 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<ButtonGroup /> correct rendering renders with children 1`] = `
+exports[`<ButtonGroup /> > correct rendering > renders with children 1`] = `
 <div
   className="btn-group btn-group-lg"
   role="group"
@@ -29,7 +27,7 @@ exports[`<ButtonGroup /> correct rendering renders with children 1`] = `
 </div>
 `;
 
-exports[`<ButtonGroup /> correct rendering renders without props 1`] = `
+exports[`<ButtonGroup /> > correct rendering > renders without props 1`] = `
 <div
   className="btn-group btn-group-md"
   role="group"

--- a/src/Button/__snapshots__/ButtonToolbar.test.tsx.snap
+++ b/src/Button/__snapshots__/ButtonToolbar.test.tsx.snap
@@ -1,6 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<ButtonToolbar /> correct rendering renders without props 1`] = `
+exports[`<ButtonToolbar /> > correct rendering > renders without props 1`] = `
 <div
   className="btn-toolbar"
   role="toolbar"

--- a/src/setupTest.ts
+++ b/src/setupTest.ts
@@ -1,7 +1,32 @@
-import 'regenerator-runtime/runtime';
+import { afterEach, snapshot } from 'node:test';
+import { basename, dirname } from 'node:path';
+import { format as prettyFormat, plugins as formatPlugins } from 'pretty-format';
+import { cleanup } from '@testing-library/react';
 
-import '@testing-library/jest-dom';
+/** Set snapshot filenames for backwards compatibility with Jest */
+snapshot.setResolveSnapshotPath((path) => (path ? `${dirname(path)}/__snapshots__/${basename(path)}.snap` : ''));
 
+/** Serialized deprecated 'react-test-renderer' trees as HTML strings */
+snapshot.setDefaultSnapshotSerializers([
+  (value) => {
+    if (typeof value === 'object' && ['type', 'props', 'children'].every(k => k in value)) {
+      // This is the output of react-test-render's render().toJSON() method. Serialize it as HTML.
+      return prettyFormat(value, {
+        plugins: [formatPlugins.ReactTestComponent],
+        printFunctionName: false,
+      });
+    }
+    return JSON.stringify(value, null, 2);
+  },
+]);
+
+afterEach(() => {
+  // Unmount all react components after each test.
+  // Otherwise each call to render() just adds new ones to the same DOM and the tests conflict.
+  cleanup();
+});
+
+// Mock ResizeObserver since JSDom doesn't provide it:
 class ResizeObserver {
   observe() {
     // do nothing

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,0 +1,67 @@
+/**
+ * For convenience, all the common imports used for testing are grouped into
+ * this file. Using this file will also ensure that you are using "strict"
+ * assertions, which you should always be using.
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+import strictAsserts from 'node:assert/strict';
+import renderer from 'react-test-renderer';
+import userEvent from '@testing-library/user-event';
+import { Mock } from 'node:test';
+
+export { describe, mock, it } from 'node:test';
+export { renderer, userEvent };
+export { render, screen, within } from '@testing-library/react';
+
+// Custom assertion functions.
+// Note: TypeScript requires that custom assertions have very explicit typing,
+// hence the weird layout of this file.
+
+/** Assert that the given HTML element include the specified CSS class */
+function containsClass(element: HTMLElement, className: string): void {
+  strictAsserts.ok(
+    element.classList.contains(className),
+    `expected className "${element.className}" to contain "${className}"`,
+  );
+}
+
+/** Assert that the given mock was called (N times) */
+function wasCalled(mockFn: Mock<Function>, timesCalled = 1): void {
+  strictAsserts.equal(
+    mockFn.mock.callCount(),
+    timesCalled,
+    `Expected mock to have been called ${timesCalled} time(s), but it was called ${mockFn.mock.callCount()} time(s).`,
+  );
+}
+
+/** Assert that the given mock was NOT called */
+function wasNotCalled(mockFn: Mock<Function>): void {
+  wasCalled(mockFn, 0);
+}
+
+/** node.js assertions with custom extensions */
+export const assert: Pick<typeof strictAsserts,
+'equal' |
+'notEqual' |
+'deepEqual' |
+'notDeepEqual' |
+'ok' |
+// 'strictEqual' | -> equal is already strictEqual
+'ifError' |
+'throws' |
+'doesNotThrow' |
+'match' |
+'doesNotMatch' |
+'rejects' |
+'doesNotReject'
+// 'partialDeepStrictEqual' will be a useful new one in Node 25
+> & {
+  containsClass: typeof containsClass,
+  wasCalled: typeof wasCalled,
+  wasNotCalled: typeof wasNotCalled,
+} = {
+  ...strictAsserts,
+  containsClass,
+  wasCalled,
+  wasNotCalled,
+};


### PR DESCRIPTION
This PR demonstrates changing a few tests to run using [Node's Test Runner](https://nodejs.org/api/test.html) instead of jest. 

Running the tests with Node's native test runner is much faster than running them with Jest, but does not support some of the non-standard imports we're currently using like importing SCSS and SVG files into Paragon. I've tried getting them to work using things like `@nodejs-loaders/media` to support importing SVG files, and that does work but it conflicts with the `tsx` loader that we need to support TSX/JSX syntax. So I'm not sure we can use this approach to testing without major refactoring.

It also doesn't support Jest test syntax so many test cases have to be changed, although in a systematic way. (e.g. `expect(tree).toMatchSnapshot();` -> `t.assert.snapshot(tree);`). This is a big disadvantage [compared to Vitest](https://github.com/openedx/paragon/pull/4043).

Time taken to run `npm test -- src/Button/Button*.test.tsx`:

| | Time with coverage | Time (no cov) |
|-|-|-|
| `node:test` | 4.76s | 3.29s |
| Vitest | 5.48s | 4.16s |
| Jest | 41.80s | 10.40s |
