### PR TITLE
fix: change bg color and text color for contrast checker pass

### DIFF
--- a/src/Container/README.md
+++ b/src/Container/README.md
@@ -19,27 +19,27 @@ The base container to contain, pad, and center content in the viewport. This com
 ```jsx live
 <div style={{ overflowX: 'auto' }}>
     <div style={{ width: '1500px', border: 'solid 3px red' }}>
-        <Container className="bg-danger-300 my-4">
+        <Container className="bg-danger-700 text-white my-4">
           The content in this container doesn't have a max width
         </Container>
         
-        <Container size="xl" className="bg-danger-300 my-4">
+        <Container size="xl" className="bg-danger-700 text-white my-4">
           The content in this container won't exceed the extra large width.
         </Container>
         
-        <Container size="lg" className="bg-danger-300 mb-4">
+        <Container size="lg" className="bg-danger-700 text-white mb-4">
           The content in this container won't exceed the large width.
         </Container>
         
-        <Container size="md" className="bg-danger-300 mb-4">
+        <Container size="md" className="bg-danger-700 text-white mb-4">
           The content in this container won't exceed the medium width.
         </Container>
         
-        <Container size="sm" className="bg-danger-300 mb-4">
+        <Container size="sm" className="bg-danger-700 text-white mb-4">
           The content in this container won't exceed the small width.
         </Container>
         
-        <Container size="xs" className="bg-danger-300 mb-4">
+        <Container size="xs" className="bg-danger-700 text-white mb-4">
           The content in this container won't exceed the extra small width.
         </Container>
     </div>

--- a/src/Container/README.md
+++ b/src/Container/README.md
@@ -18,7 +18,7 @@ The base container to contain, pad, and center content in the viewport. This com
 
 ```jsx live
 <div style={{ overflowX: 'auto' }}>
-    <div style={{ width: '1500px', border: 'solid 3px red' }}>
+    <div style={{ width: '1500px', border: 'solid 3px var(--pgn-color-danger-700)' }}>
         <Container className="bg-danger-700 text-white my-4">
           The content in this container doesn't have a max width
         </Container>


### PR DESCRIPTION
## Description

The text and background colors used in the Container component example meet all relevant accessibility contrast requirements (WCAG AA or higher).

### Issue
https://github.com/openedx/paragon/issues/2933

### Changes

**Before**

<img width="1018" height="490" alt="Знімок екрана 2025-12-16 о 18 02 48" src="https://github.com/user-attachments/assets/6398bca2-bb0e-4aad-83d9-b3bfd33a5efc" />

**After**

<img width="1058" height="439" alt="Знімок екрана 2025-12-16 о 18 01 48" src="https://github.com/user-attachments/assets/57288f7d-9699-4c5c-9885-3aea44a8843f" />

### Contrast checker result

<img width="824" height="806" alt="Знімок екрана 2025-12-16 о 18 03 44" src="https://github.com/user-attachments/assets/2d9e7f6e-369e-4ef2-af27-2e4481eed371" />