### PR TITLE
chore(ci): update semantic release workflow to use OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,19 @@ on:
     branches:
     - next
     - release-*
+
+permissions:
+  contents: read # for checkout
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -35,5 +44,4 @@ jobs:
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_NPM_TOKEN }}
-      run: npx semantic-release@22
+      run: npx semantic-release@25


### PR DESCRIPTION
## Description

* Update `semantic-release` version used from `22` to `25` (we had it pinned at `22` to ensure it would work with node 18 - that is no longer needed)
* Remove `NPM_TOKEN` from workflow as those are deprecated
* Add `permissions` sections to match [the example from the `semantic-release` documentation](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#githubworkflowsreleaseyml-configuration-for-node-projects)
