### PR TITLE
feat: Breadcumb 'className' appends instead of replaces, fix other types

### DIFF
--- a/src/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/Breadcrumb.test.tsx
@@ -95,4 +95,29 @@ describe('<Breadcrumb />', () => {
     expect(links.getAttribute('target')).toBe('_blank');
     expect(links.getAttribute('href')).toBe('/link-1');
   });
+
+  it('renders with a custom CSS class', () => {
+    render(<Breadcrumb {...baseProps} ariaLabel="Breadcrumbs" className="foobar" />);
+    const nav = screen.getByLabelText('Breadcrumbs');
+    expect(nav.classList).toContain('foobar');
+    expect(nav.classList).toContain('pgn__breadcrumb');
+    expect(nav.classList).toContain('pgn__breadcrumb-light');
+  });
+
+  it('can access data-xxxxx attributes on the links in clickHandler', async () => {
+    const user = userEvent.setup();
+    const clickHandler = jest.fn();
+    render(
+      <Breadcrumb
+        ariaLabel="Location"
+        links={[
+          { label: 'Link1', href: '/link1', 'data-parent-index': 17 },
+        ]}
+        clickHandler={({ currentTarget }) => clickHandler(currentTarget.dataset.parentIndex)}
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'Link1' });
+    await user.click(link);
+    expect(clickHandler).toHaveBeenCalledWith('17');
+  });
 });

--- a/src/Breadcrumb/index.tsx
+++ b/src/Breadcrumb/index.tsx
@@ -5,7 +5,7 @@ import BreadcrumbLink from './BreadcrumbLink';
 import { ChevronRight } from '../../icons';
 import Icon from '../Icon';
 
-interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> { // There is no 'HTMLNavElement'
+interface BreadcrumbProps {
   /** An array of objects describing links to be rendered. The contents of an object depend on the value of `linkAs`
    * prop as these objects will get passed down as props to the underlying component defined by `linkAs` prop.
    */
@@ -34,7 +34,7 @@ interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> { // There i
 
 function Breadcrumb({
   links, activeLabel, spacer, clickHandler, className,
-  variant = 'light', isMobile = false, ariaLabel = 'breadcrumb', linkAs = 'a', ...props
+  variant = 'light', isMobile = false, ariaLabel = 'breadcrumb', linkAs = 'a',
 }: BreadcrumbProps) {
   const linkCount = links.length;
   const displayLinks = isMobile ? [links[linkCount - 1]] : links;
@@ -43,7 +43,6 @@ function Breadcrumb({
     <nav
       aria-label={ariaLabel}
       className={classNames('pgn__breadcrumb', `pgn__breadcrumb-${variant}`, className)}
-      {...props}
     >
       <ol className={classNames('list-inline', { 'is-mobile': isMobile })}>
         {displayLinks.map((link, i) => (

--- a/src/Breadcrumb/index.tsx
+++ b/src/Breadcrumb/index.tsx
@@ -5,7 +5,7 @@ import BreadcrumbLink from './BreadcrumbLink';
 import { ChevronRight } from '../../icons';
 import Icon from '../Icon';
 
-interface BreadcrumbProps {
+interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> { // There is no 'HTMLNavElement'
   /** An array of objects describing links to be rendered. The contents of an object depend on the value of `linkAs`
    * prop as these objects will get passed down as props to the underlying component defined by `linkAs` prop.
    */
@@ -19,7 +19,7 @@ interface BreadcrumbProps {
   spacer?: React.ReactElement;
   /** allows to add a custom function to be called `onClick` of a breadcrumb link.
    * The use case for this is for adding custom analytics to the component. */
-  clickHandler?: (event: React.MouseEvent, link: any) => void;
+  clickHandler?: (event: React.MouseEvent<HTMLAnchorElement>, link: any) => void;
   /** The `Breadcrumbs` style variant to use. */
   variant?: 'light' | 'dark';
   /** The `Breadcrumbs` mobile variant view. */
@@ -28,10 +28,12 @@ interface BreadcrumbProps {
    * [react-router's Link](https://reactrouter.com/en/main/components/link).
    */
   linkAs?: React.ElementType;
+  /** Optional class name(s) to append to the base `<nav>` element. */
+  className?: string;
 }
 
 function Breadcrumb({
-  links, activeLabel, spacer, clickHandler,
+  links, activeLabel, spacer, clickHandler, className,
   variant = 'light', isMobile = false, ariaLabel = 'breadcrumb', linkAs = 'a', ...props
 }: BreadcrumbProps) {
   const linkCount = links.length;
@@ -40,7 +42,7 @@ function Breadcrumb({
   return (
     <nav
       aria-label={ariaLabel}
-      className={classNames('pgn__breadcrumb', `pgn__breadcrumb-${variant}`)}
+      className={classNames('pgn__breadcrumb', `pgn__breadcrumb-${variant}`, className)}
       {...props}
     >
       <ol className={classNames('list-inline', { 'is-mobile': isMobile })}>


### PR DESCRIPTION
## Description

Currently, the `Breadcrumb` component will accept a `className` prop, but it replaces the default Paragon classes (`pgn__breadcrumb` etc.) instead of appending to them. This PR makes it so custom classes are appended, which is more consistent with the other Paragon components. It also fixes the typing so `className` is allowed by TypeScript, which wasn't the case after the initial TypeScript version of `Breadcrumb` was recently implemented.

It also makes a minor update to the `clickHandler` typing so that `event.currentTarget` is an `HTMLAnchorElement` instead of a generic `Element`; this allows event handlers to access more attributes on the clicked link element such as `data-` attributes (useful for analytics or metadata). This is based on usage in the Authoring MFE.

### Deploy Preview

https://deploy-preview-4077--paragon-openedx-v23.netlify.app/components/breadcrumb/

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable. n/a
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [x] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)? n/a
* [ ] Were your changes tested in the `example` app?
* [x] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel. n/a

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
