### PR TITLE
refactor: convert Scrollable to TypeScript

### DIFF
--- a/src/Scrollable/index.tsx
+++ b/src/Scrollable/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import useIsVisible from '../hooks/useIsVisibleHook';
@@ -7,20 +6,27 @@ import useIsVisible from '../hooks/useIsVisibleHook';
 export const CLASSNAME_SCROLL_TOP = 'pgn__scrollable-body-scroll-top';
 export const CLASSNAME_SCROLL_BOTTOM = 'pgn__scrollable-body-scroll-bottom';
 
-function Scrollable({ children, ...props }) {
+export interface ScrollableProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Specifies the content of the `Scrollable`. */
+  children: React.ReactNode;
+  /** Additional classnames for this component. */
+  className?: string;
+}
+
+function Scrollable({ children, className, ...props }: ScrollableProps) {
   const [isScrolledToTop, topSentinelRef] = useIsVisible();
   const [isScrolledToBottom, bottomSentinelRef] = useIsVisible();
   const [valueNow, setValueNow] = useState(0);
-  const className = classNames(
+  const scrollableClassName = classNames(
     'pgn__scrollable-body',
-    props.className,
+    className,
     {
       [CLASSNAME_SCROLL_TOP]: isScrolledToTop,
       [CLASSNAME_SCROLL_BOTTOM]: isScrolledToBottom,
     },
   );
 
-  const handleScroll = (e) => {
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const maxScrollHeight = e.currentTarget.scrollHeight - e.currentTarget.clientHeight;
     setValueNow(Math.ceil((100 * e.currentTarget.scrollTop) / maxScrollHeight));
   };
@@ -28,33 +34,24 @@ function Scrollable({ children, ...props }) {
   return (
     <div
       {...props}
-      className={className}
+      className={scrollableClassName}
       role="scrollbar"
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={valueNow}
       aria-controls="scrollbar"
-      tabIndex="0"
+      tabIndex={0}
       onScroll={handleScroll}
     >
-      <div ref={topSentinelRef} />
+      <div ref={topSentinelRef as React.RefObject<HTMLDivElement>} />
       <div className="pgn__scrollable-body-content">
         {children}
       </div>
-      <div ref={bottomSentinelRef} />
+      <div ref={bottomSentinelRef as React.RefObject<HTMLDivElement>} />
     </div>
   );
 }
 
-Scrollable.propTypes = {
-  /** Specifies the content of the `Scrollable`. */
-  children: PropTypes.node.isRequired,
-  /** Additional classnames for this component. */
-  className: PropTypes.string,
-};
-
-Scrollable.defaultProps = {
-  className: undefined,
-};
+Scrollable.displayName = 'Scrollable';
 
 export default Scrollable;

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export { default as ModalDialog } from './Modal/ModalDialog';
 export { default as ModalLayer } from './Modal/ModalLayer';
 export { default as Overlay, OverlayTrigger } from './Overlay';
 export { default as Portal } from './Modal/Portal';
+export { default as Scrollable } from './Scrollable';
 export { default as Spinner } from './Spinner';
 export { default as Stack } from './Stack';
 export { default as Toast, TOAST_CLOSE_LABEL_TEXT, TOAST_DELAY } from './Toast';
@@ -83,8 +84,6 @@ export { default as Layout, Col, Row } from './Layout';
 export { default as Collapse } from './Collapse';
 // @ts-ignore: has yet to be converted to TypeScript
 export { default as Collapsible } from './Collapsible';
-// @ts-ignore: has yet to be converted to TypeScript
-export { default as Scrollable } from './Scrollable';
 export {
   default as Dropdown,
   DropdownToggle,


### PR DESCRIPTION
## Description

Converts the Scrollable component from JSX to TypeScript.

Part of issue https://github.com/openedx/paragon/issues/3739.

### Changes

- Converted `src/Scrollable/index.jsx` to `index.tsx`
- Created `ScrollableProps` interface with JSDoc comments for prop documentation
- Removed deprecated `propTypes` and `defaultProps`
- Added `displayName` for docs generation
- Updated `src/index.ts` to remove `@ts-ignore` and move Scrollable to typed exports section

### Deploy Preview

https://deploy-preview-4135--paragon-openedx-v23.netlify.app/components/scrollable/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.

Co-authored-by: Amazon Q <no-reply@amazon.com>
