### PR TITLE
docs: improve help text for source-tokens-only

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -83,7 +83,7 @@ const COMMANDS = {
       },
       {
         name: '--source-tokens-only',
-        description: 'Include only source design tokens in the build.',
+        description: 'If provided, only tokens from --source will be included in the output; Paragon tokens will be used for references but not included in the output.',
         defaultValue: false,
       },
       {

--- a/lib/__tests__/help.test.js
+++ b/lib/__tests__/help.test.js
@@ -228,7 +228,7 @@ describe('helpCommand', () => {
       expect.stringContaining(`${chalk.yellow.bold('--source-tokens-only')} ${chalk.grey('Default: false')}`),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Include only source design tokens in the build.'),
+      expect.stringContaining('If provided, only tokens from --source will be included in the output; Paragon tokens will be used for references but not included in the output.'),
     );
 
     expect(console.log).toHaveBeenCalledWith(


### PR DESCRIPTION
## Description

Clarifies the `--source-tokens-only` CLI flag description in `paragon-scripts.js` to better explain its behavior.

**Issue:** https://github.com/openedx/paragon/issues/3952

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
