### PR TITLE
docs: correct help text for replace-variables

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -133,12 +133,12 @@ const COMMANDS = {
     options: [
       {
         name: '-s, --source',
-        description: 'Type of replacement: usage or definition. If set to "definition" the command will only update SCSS variables definitions with CSS variables, if set to "usage" - all occurrences of SCSS variables will we replaced',
+        description: 'The path to the source directory containing variable mappings.',
         defaultValue: '\'\'',
       },
       {
         name: '-t, --replacementType',
-        description: 'Type of replacement: usage or definition. If set to "definition" the command will only update SCSS variables definitions with CSS variables, if set to "usage" - all occurrences of SCSS variables will we replaced',
+        description: 'Type of replacement: usage or definition. If set to "definition" the command will only update SCSS variables definitions with CSS variables, if set to "usage" - all occurrences of SCSS variables will be replaced.',
         choices: '[usage|definition]',
         defaultValue: 'definition',
       },

--- a/lib/__tests__/help.test.js
+++ b/lib/__tests__/help.test.js
@@ -184,7 +184,7 @@ describe('helpCommand', () => {
       expect.stringContaining(`${chalk.yellow.bold('-s, --source')} ${chalk.grey('Default: \'\'')}`),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Type of replacement: usage or definition'),
+      expect.stringContaining('The path to the source directory containing variable mappings.'),
     );
 
     expect(console.log).toHaveBeenCalledWith(
@@ -192,7 +192,9 @@ describe('helpCommand', () => {
         `${chalk.yellow.bold('-t, --replacementType')} ${chalk.grey('[usage|definition], Default: definition')}`,
       ),
     );
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Type of replacement: usage or definition'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining(
+      'Type of replacement: usage or definition. If set to "definition" the command will only update SCSS variables definitions with CSS variables, if set to "usage" - all occurrences of SCSS variables will be replaced.',
+    ));
 
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining(

--- a/lib/replace-variables.js
+++ b/lib/replace-variables.js
@@ -8,7 +8,7 @@ const mapSCSStoCSS = require('../tokens/map-scss-to-css');
  * @param {string[]} commandArgs - Command line arguments for replacing variables.
  * @param {string} [commandArgs.filePath] - The path to the file in which variables should be replaced.
  * @param {string} [commandArgs.source] - The path to the source directory containing variable mappings.
- * @param {string} [commandArgs.replacementType] - The type of replacement ('usage' or 'all').
+ * @param {string} [commandArgs.replacementType] - The type of replacement ('usage' or 'definition').
  * @param {string} [commandArgs.direction] - The direction of replacement ('forward' or 'backward').
  */
 async function replaceVariablesCommand(commandArgs) {


### PR DESCRIPTION
## Description

- Fix incorrect and duplicated help text for the replace-variables CLI command's -s, --source option, which was copy-pasted from `--replacementType` instead of describing the source path
- Fix typo in `--replacementType` description ("will we replaced" → "will be replaced")
- Fix incorrect JSDoc in `lib/replace-variables.js` ('usage' or 'all' → 'usage' or 'definition')

**Issue:** https://github.com/openedx/paragon/issues/3951

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
