### PR TITLE
docs: improve help text for --defaultThemeVariants CLI flag

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -195,8 +195,7 @@ const COMMANDS = {
         description: `Specifies which theme variants are marked as defaults in the generated theme-urls.json.
           Consuming applications (Open edX micro-frontends) use theme-urls.json to determine
           which theme CSS files to load; variants listed here are loaded automatically without
-          requiring explicit configuration. Variants not listed as defaults are still built and
-          available but must be explicitly selected by the consuming application.
+          requiring explicit configuration.
           You can provide multiple default theme variants by passing multiple values, for
           example: \`--defaultThemeVariants light dark\`
         `,

--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -192,7 +192,11 @@ const COMMANDS = {
       },
       {
         name: '--defaultThemeVariants',
-        description: `Specifies default theme variants. Defaults to a single 'light' theme variant.
+        description: `Specifies which theme variants are marked as defaults in the generated theme-urls.json.
+          Consuming applications (Open edX micro-frontends) use theme-urls.json to determine
+          which theme CSS files to load; variants listed here are loaded automatically without
+          requiring explicit configuration. Variants not listed as defaults are still built and
+          available but must be explicitly selected by the consuming application.
           You can provide multiple default theme variants by passing multiple values, for
           example: \`--defaultThemeVariants light dark\`
         `,

--- a/lib/__tests__/help.test.js
+++ b/lib/__tests__/help.test.js
@@ -142,7 +142,7 @@ describe('helpCommand', () => {
       expect.stringContaining('Consuming applications (Open edX micro-frontends) use theme-urls.json'),
     );
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Variants not listed as defaults are still built and'),
+      expect.stringContaining('variants listed here are loaded automatically without'),
     );
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('You can provide multiple default theme variants'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('example: `--defaultThemeVariants light dark`'));

--- a/lib/__tests__/help.test.js
+++ b/lib/__tests__/help.test.js
@@ -135,7 +135,15 @@ describe('helpCommand', () => {
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining(`${chalk.yellow.bold('--defaultThemeVariants')} ${chalk.grey('Default: light')}`),
     );
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Specifies default theme variants'));
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Specifies which theme variants are marked as defaults in the generated theme-urls.json.'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Consuming applications (Open edX micro-frontends) use theme-urls.json'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Variants not listed as defaults are still built and'),
+    );
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('You can provide multiple default theme variants'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('example: `--defaultThemeVariants light dark`'));
     /* eslint-enable no-console */


### PR DESCRIPTION
## Description

Rewrites the `--defaultThemeVariants` help text for the `build-scss` CLI command to explain what the flag actually does, why you'd use it, and what happens to non-default variants                                                         

**Issue:** https://github.com/openedx/paragon/issues/3953

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
