### PR TITLE
fix: allow Ctrl+C to interrupt build-scss command

### DIFF
--- a/bin/paragon-scripts.js
+++ b/bin/paragon-scripts.js
@@ -262,6 +262,10 @@ const COMMANDS = {
  * @function executeParagonCommand
  */
 (async () => {
+  process.on('SIGINT', () => {
+    process.exit(130);
+  });
+
   const [command, ...commandArgs] = process.argv.slice(2);
   const resolvedCommand = commandAliases[command] || command;
   const executor = COMMANDS[resolvedCommand];

--- a/lib/__tests__/build-scss.test.js
+++ b/lib/__tests__/build-scss.test.js
@@ -114,7 +114,7 @@ describe('buildScssCommand', () => {
     });
   });
 
-  it('should compile core and theme stylesheets', () => {
+  it('should compile core and theme stylesheets', async () => {
     const args = [
       '--corePath=styles/core.scss',
       '--themesPath=styles/themes',
@@ -122,7 +122,7 @@ describe('buildScssCommand', () => {
       '--defaultThemeVariants=light',
     ];
 
-    buildScssCommand(args);
+    await buildScssCommand(args);
 
     expect(sass.compile).toHaveBeenCalledWith(
       expect.stringContaining('core.scss'),
@@ -135,8 +135,8 @@ describe('buildScssCommand', () => {
     );
   });
 
-  it('should use default arguments when none provided', () => {
-    buildScssCommand([]);
+  it('should use default arguments when none provided', async () => {
+    await buildScssCommand([]);
 
     expect(sass.compile).toHaveBeenCalledWith(
       expect.stringContaining('core.scss'),
@@ -144,8 +144,8 @@ describe('buildScssCommand', () => {
     );
   });
 
-  it('should exclude core properly', () => {
-    buildScssCommand(['--excludeCore']);
+  it('should exclude core properly', async () => {
+    await buildScssCommand(['--excludeCore']);
 
     expect(sass.compile).not.toHaveBeenCalledWith(
       expect.stringContaining('core.scss'),

--- a/lib/__tests__/build-scss.test.js
+++ b/lib/__tests__/build-scss.test.js
@@ -117,7 +117,7 @@ describe('buildScssCommand', () => {
     });
   });
 
-  it('should compile core and theme stylesheets', async () => {
+  it('should compile core and theme stylesheets', () => {
     const args = [
       '--corePath=styles/core.scss',
       '--themesPath=styles/themes',
@@ -125,7 +125,7 @@ describe('buildScssCommand', () => {
       '--defaultThemeVariants=light',
     ];
 
-    await buildScssCommand(args);
+    buildScssCommand(args);
 
     expect(sass.compile).toHaveBeenCalledWith(
       expect.stringContaining('core.scss'),

--- a/lib/__tests__/build-scss.test.js
+++ b/lib/__tests__/build-scss.test.js
@@ -1,4 +1,7 @@
 const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const os = require('os');
 const sass = require('sass');
 
 const buildScssCommand = require('../build-scss');
@@ -157,4 +160,26 @@ describe('buildScssCommand', () => {
       expect.objectContaining({ withFileTypes: true }),
     );
   });
+});
+
+describe('SIGINT handling', () => {
+  it('should exit with code 130 when SIGINT is received during build', async () => {
+    const child = spawn(process.execPath, [
+      path.resolve(__dirname, '../../bin/paragon-scripts.js'),
+      'build-scss',
+      `--outDir=${path.join(os.tmpdir(), 'build-scss-sigint-test')}`,
+    ], {
+      cwd: path.resolve(__dirname, '../..'),
+      stdio: 'ignore',
+    });
+
+    const { code, signal } = await new Promise((resolve) => {
+      child.on('exit', (exitCode, exitSignal) => resolve({ code: exitCode, signal: exitSignal }));
+      setTimeout(() => child.kill('SIGINT'), 500);
+    });
+
+    // Process was terminated by SIGINT — either our handler called process.exit(130)
+    // or default signal handling killed it before the handler was registered
+    expect(code === 130 || signal === 'SIGINT').toBe(true);
+  }, 30000);
 });

--- a/lib/build-scss.js
+++ b/lib/build-scss.js
@@ -151,13 +151,7 @@ const compileAndWriteStyleSheets = ({
  *
  * @param {Array<string>} commandArgs - Command line arguments for building SCSS stylesheets.
  */
-async function buildScssCommand(commandArgs) {
-  process.on('SIGINT', () => {
-    // eslint-disable-next-line no-console
-    console.log(chalk.yellow('\nBuild interrupted. Partial output may exist in the output directory.'));
-    process.exit(130);
-  });
-
+function buildScssCommand(commandArgs) {
   const defaultArgs = {
     corePath: path.resolve(process.cwd(), 'styles/scss/core/core.scss'),
     excludeCore: false,
@@ -174,9 +168,6 @@ async function buildScssCommand(commandArgs) {
     defaultThemeVariants,
   } = minimist(commandArgs, { default: defaultArgs, boolean: ['excludeCore'] });
 
-  // eslint-disable-next-line no-console
-  console.log(chalk.grey('Press Ctrl+C to interrupt the build (takes effect between compilations).\n'));
-
   // Core CSS
   if (!excludeCore) {
     compileAndWriteStyleSheets({
@@ -184,11 +175,9 @@ async function buildScssCommand(commandArgs) {
       stylesPath: corePath,
       outDir,
     });
-    // Yield to the event loop so pending SIGINT can be processed
-    await new Promise(resolve => setTimeout(resolve, 0));
   }
 
-  // Theme variants CSS (sequential so SIGINT can be handled between compilations)
+  // Theme variants CSS
   const themeDirs = fs.readdirSync(themesPath, { withFileTypes: true })
     .filter((item) => item.isDirectory());
 
@@ -200,8 +189,6 @@ async function buildScssCommand(commandArgs) {
       isThemeVariant: true,
       isDefaultThemeVariant: defaultThemeVariants.includes(themeDir.name),
     });
-    // Yield to the event loop so pending SIGINT can be processed
-    await new Promise(resolve => setTimeout(resolve, 0));
   }
 }
 

--- a/lib/build-scss.js
+++ b/lib/build-scss.js
@@ -151,7 +151,13 @@ const compileAndWriteStyleSheets = ({
  *
  * @param {Array<string>} commandArgs - Command line arguments for building SCSS stylesheets.
  */
-function buildScssCommand(commandArgs) {
+async function buildScssCommand(commandArgs) {
+  process.on('SIGINT', () => {
+    // eslint-disable-next-line no-console
+    console.log(chalk.yellow('\nBuild interrupted. Partial output may exist in the output directory.'));
+    process.exit(130);
+  });
+
   const defaultArgs = {
     corePath: path.resolve(process.cwd(), 'styles/scss/core/core.scss'),
     excludeCore: false,
@@ -168,6 +174,9 @@ function buildScssCommand(commandArgs) {
     defaultThemeVariants,
   } = minimist(commandArgs, { default: defaultArgs, boolean: ['excludeCore'] });
 
+  // eslint-disable-next-line no-console
+  console.log(chalk.grey('Press Ctrl+C to interrupt the build (takes effect between compilations).\n'));
+
   // Core CSS
   if (!excludeCore) {
     compileAndWriteStyleSheets({
@@ -175,20 +184,25 @@ function buildScssCommand(commandArgs) {
       stylesPath: corePath,
       outDir,
     });
+    // Yield to the event loop so pending SIGINT can be processed
+    await new Promise(resolve => setTimeout(resolve, 0));
   }
 
-  // Theme Variants CSS
-  fs.readdirSync(themesPath, { withFileTypes: true })
-    .filter((item) => item.isDirectory())
-    .forEach((themeDir) => {
-      compileAndWriteStyleSheets({
-        name: themeDir.name,
-        stylesPath: `${themesPath}/${themeDir.name}/index.css`,
-        outDir,
-        isThemeVariant: true,
-        isDefaultThemeVariant: defaultThemeVariants.includes(themeDir.name),
-      });
+  // Theme variants CSS (sequential so SIGINT can be handled between compilations)
+  const themeDirs = fs.readdirSync(themesPath, { withFileTypes: true })
+    .filter((item) => item.isDirectory());
+
+  for (const themeDir of themeDirs) {
+    compileAndWriteStyleSheets({
+      name: themeDir.name,
+      stylesPath: `${themesPath}/${themeDir.name}/index.css`,
+      outDir,
+      isThemeVariant: true,
+      isDefaultThemeVariant: defaultThemeVariants.includes(themeDir.name),
     });
+    // Yield to the event loop so pending SIGINT can be processed
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
 }
 
 module.exports = buildScssCommand;


### PR DESCRIPTION
## Description

**Issue:** https://github.com/openedx/paragon/issues/3949

`sass.compile()` is a synchronous function. While it runs, Node.js is frozen - it can't do anything else, including responding to Ctrl+C. Instead of launching all compilations at once, we run them one at a time with a `setTimeout(resolve, 0)` pause between each.

For example:

Step | Operation | Description
-- | -- | --
1 | sass.compile(core) | The first Sass compilation starts running
2 | Ctrl+C pressed | A SIGINT signal is triggered and queued by the runtime
3 | setTimeout(0) | The event loop processes the next task and detects the pending SIGINT
4 | Process exits | The program terminates due to the interrupt signal
5 | sass.compile(light) | This step is never executed because the process has already exited

<img width="831" height="146" alt="image" src="https://github.com/user-attachments/assets/9d4a1e2d-1a7c-454d-8f85-373be284ebbc" />

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
