### PR TITLE
fix: output flat KV format for Transifex translation extraction

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,0 @@
-[main]
-host = https://www.transifex.com
-
-[o:open-edx:p:edx-platform:r:paragon]
-file_filter = src/i18n/messages/<lang>.json
-source_file = src/i18n/transifex_input.json
-source_lang = en
-type        = STRUCTURED_JSON

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,6 @@ build:
 	rm -rf dist/setupTest.js
 	./bin/paragon-scripts.js build-scss
 
-export TRANSIFEX_RESOURCE = paragon
-transifex_langs = "ar,ca,es_419,fr,he,id,ko_KR,pl,pt_BR,ru,th,uk,zh_CN,es_AR,es_ES,pt_PT,tr_TR,it_IT"
-i18n = ./src/i18n
-transifex_input = $(i18n)/transifex_input.json
-
 NPM_TESTS=build i18n_extract lint test
 
 .PHONY: test
@@ -57,22 +52,6 @@ i18n.extract:
 	npm run-script i18n_extract
 
 extract_translations: | requirements i18n.extract
-
-# Despite the name, we actually need this target to detect changes in the incoming translated message files as well.
-detect_changed_source_translations:
-	# Checking for changed translations...
-	git diff --exit-code $(i18n)
-
-# Pushes translations to Transifex.  You must run make extract_translations first.
-push_translations:
-	# Pushing strings to Transifex...
-	tx push -s
-
-# Pulls translations from Transifex.
-pull_translations: | requirements
-	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
-	# compile files with translated strings to KEYVALUEJSON format which react-intl understands...
-	npm run-script i18n_compile
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "example:start": "npm start --workspace=example",
     "example:start:with-theme": "npm run start:with-theme --workspace=example",
     "generate-changelog": "node generate-changelog.js",
-    "i18n_compile": "formatjs compile-folder --format transifex ./src/i18n/messages ./src/i18n/messages",
     "i18n_extract": "formatjs extract 'src/**/*.{jsx,js,tsx,ts}' --out-file ./src/i18n/transifex_input.json --ignore='**/*.d.ts' --format ./src/i18n/transifex-formatter.js",
     "type-check": "tsc --noEmit && tsc --project www --noEmit",
     "type-check:watch": "npm run type-check -- --watch",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "example:start:with-theme": "npm run start:with-theme --workspace=example",
     "generate-changelog": "node generate-changelog.js",
     "i18n_compile": "formatjs compile-folder --format transifex ./src/i18n/messages ./src/i18n/messages",
-    "i18n_extract": "formatjs extract 'src/**/*.{jsx,js,tsx,ts}' --out-file ./src/i18n/transifex_input.json --ignore='**/*.d.ts' --format transifex",
+    "i18n_extract": "formatjs extract 'src/**/*.{jsx,js,tsx,ts}' --out-file ./src/i18n/transifex_input.json --ignore='**/*.d.ts' --format ./src/i18n/transifex-formatter.js",
     "type-check": "tsc --noEmit && tsc --project www --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "build-types": "tsc --emitDeclarationOnly",

--- a/src/i18n/transifex-formatter.js
+++ b/src/i18n/transifex-formatter.js
@@ -1,0 +1,3 @@
+exports.format = (messages) => Object.fromEntries(
+  Object.entries(messages).map(([id, { defaultMessage }]) => [id, defaultMessage])
+);


### PR DESCRIPTION
## Summary

All other frontend repos in openedx-translations produce a flat `{"key": "value"}` JSON format for `transifex_input.json`, but Paragon was using `--format transifex` which outputs a nested `{"key": {"string": "value"}}` format. This PR fixes that and removes the legacy Transifex CLI workflow that's been superseded by openedx-translations.

- Add `src/i18n/transifex-formatter.js` — a small custom formatter that outputs flat KV, matching the format used by all other frontend repos
- Update `i18n_extract` script to use the new formatter instead of `--format transifex`
- Remove `i18n_compile` script (was only used by the legacy `tx` CLI workflow)
- Remove `pull_translations`, `push_translations`, and `detect_changed_source_translations` Makefile targets along with their associated variables
- Remove `.tx/config` (Transifex CLI config)

This also establishes a clean pattern for frontend-base MFE conversions, which similarly won't have access to `frontend-platform` or `frontend-build`.

## Test plan

- [ ] Run `make extract_translations` and verify `src/i18n/transifex_input.json` is in flat KV format

<details>
<summary><h3>Log</h3></summary>

# Paragon i18n Format Fix — Investigation & Changes Log

## Problem

All non-Paragon frontend repos in openedx-translations produce a flat KV format for `transifex_input.json`:
```json
{"message.id": "Default message string"}
```

Paragon was using `--format transifex` in its `i18n_extract` script, which produces a nested object format:
```json
{"message.id": {"string": "Default message string", "developer_comment": "..."}}
```

## Investigation

### Verified the format difference

Cloned openedx-translations and checked all `src/i18n/transifex_input.json` files (excluding node_modules). All 25 non-Paragon repos output flat KV. Paragon was the only one using nested-object format.

### Traced the MFE pipeline

MFEs (e.g. frontend-app-authn) use a two-step pipeline via `make extract_translations`:

1. `i18n.extract` — runs `fedx-scripts formatjs extract` (from frontend-build), which uses a custom `formatter.js` that outputs an **array** of `{id, defaultMessage, description}` objects to `./temp/babel-plugin-formatjs/Default.messages.json`
2. `i18n.concat` — runs `transifex-utils.js` (from frontend-platform at `src/i18n/scripts/transifex-utils.js`), which reads that array and writes flat KV to `src/i18n/transifex_input.json`

Paragon skips both steps and uses `formatjs extract --format transifex` directly, which is why it produces the nested format.

### Key files referenced

- `openedx/frontend-build` — `lib/formatter.js`, `bin/fedx-scripts.js`
- `openedx/frontend-platform` — `src/i18n/scripts/transifex-utils.js`
- `openedx/frontend-app-authn` — `Makefile`, `package.json`
- `openedx/openedx-translations` — `.github/workflows/extract-translation-source-files.yml`

### Why the custom formatter approach is the right pattern

Paragon doesn't depend on frontend-platform or frontend-build. A self-contained custom formatter with no external dependencies is the right approach — and also establishes a clean pattern for frontend-base MFE conversions, which similarly won't have access to those packages.

### Note on atlas

MFEs use `atlas pull` (e.g. in authn's `pull_translations` Makefile target) to pull fresh translations from openedx-translations for their own messages and their deps (including paragon). Paragon's own `src/i18n/messages/` are stale (3+ years) and nothing currently updates them — follow-up issue needed.

## Changes Made (branch: `fix-i18n-flat-kv-format`)

### Commit 1: feat: use custom formatter to output flat KV format for Transifex
- Added `src/i18n/transifex-formatter.js`:
  ```js
  exports.format = (messages) => Object.fromEntries(
    Object.entries(messages).map(([id, { defaultMessage }]) => [id, defaultMessage])
  );
  ```
- Updated `i18n_extract` in `package.json` to use `--format ./src/i18n/transifex-formatter.js` instead of `--format transifex`

### Commit 2: chore: remove i18n_compile script
- Removed `i18n_compile` from `package.json` — was only used by the legacy `tx` CLI `pull_translations` workflow

### Commit 3: chore: remove legacy tx CLI translation targets from Makefile
- Removed `pull_translations`, `push_translations`, `detect_changed_source_translations` targets
- Removed `TRANSIFEX_RESOURCE`, `transifex_langs`, `transifex_input`, `i18n` variables (all unused after removals)

### Commit 4: chore: remove .tx Transifex CLI config
- Deleted `.tx/config` — Transifex CLI config, no longer needed

## Follow-up

- Paragon's `src/i18n/messages/` translations are stale and nothing in the release workflow updates them. The atlas flow used by MFEs handles pulling paragon translations at build/deploy time, but Paragon's own bundled translations need a solution.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)