### PR TITLE
feat: add atlasTranslations to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "/lib"
   ],
   "sideEffects": false,
+  "atlasTranslations": {
+    "path": "translations/paragon/src/i18n/messages"
+  },
   "scripts": {
     "build": "make build",
     "build-docs": "make build-docs",


### PR DESCRIPTION
* Part of https://github.com/openedx/frontend-base/issues/176

Adds an `atlasTranslations` field to `package.json` so that sites using `openedx translations:pull` (frontend-base PR #205) can resolve and pull Paragon's translations transitively.

```json
"atlasTranslations": {
  "path": "translations/paragon/src/i18n/messages"
}
```

No `dependencies` field is needed — Paragon has no further `atlasTranslations` deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)