### PR TITLE
chore(www): migrate analytics-node to @segment/analytics-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6695,6 +6695,27 @@
         "win32"
       ]
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@material-icons/svg": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/@material-icons/svg/-/svg-1.0.33.tgz",
@@ -9640,13 +9661,66 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
+      "integrity": "sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==",
+      "license": "MIT",
       "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-3.0.0.tgz",
+      "integrity": "sha512-Qer+cXr/QH24QTau+NOcw47vuvfvze0xfZORTTKfAyG33thb5FRQvdg3txjGAf0TQKm0+l8qW1V+4jb9nlfAQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.2",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@segment/analytics-node/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@semantic-release/changelog": {
@@ -13390,44 +13464,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/analytics-node/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/analytics-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/anser": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
@@ -14055,15 +14091,6 @@
       },
       "peerDependencies": {
         "axios": ">= 0.17.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -15627,15 +15654,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chevrotain": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.2.0.tgz",
@@ -16446,15 +16464,6 @@
       "resolved": "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz",
       "integrity": "sha512-69pIRJs9fCCHRqCz3390YF2LV1Lu6iEMZ5zuVqqUn+G20V9BNXlMs0cWawWeW9g4Ynmg29JmkG6R7/lUJoGd1Q=="
     },
-    "node_modules/component-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.2.tgz",
-      "integrity": "sha512-99VUHREHiN5cLeHm3YLq312p6v+HUEcwtLCAtelvUDI6+SH5g5Cr85oNR2S1o6ywzL0ykMbuwLzM2ANocjEOIA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/component-xor": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/component-xor/-/component-xor-0.0.4.tgz",
@@ -17041,15 +17050,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -18919,6 +18919,15 @@
       },
       "peerDependencies": {
         "webpack": "^4 || ^5"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -28062,15 +28071,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-root": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
@@ -29537,11 +29537,14 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "license": "MIT"
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/jquery": {
       "version": "3.7.1",
@@ -30588,6 +30591,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.map": {
@@ -31047,23 +31051,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
-    "node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
     },
     "node_modules/mdast-util-definitions": {
       "version": "4.0.0",
@@ -42267,12 +42254,6 @@
       "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "license": "ISC"
     },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "license": "MIT"
-    },
     "node_modules/renderkid": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
@@ -49367,7 +49348,7 @@
         "@mdx-js/mdx": "^2",
         "@mdx-js/react": "^2",
         "@openedx/brand-openedx": "^1.2.2",
-        "analytics-node": "^6.0.0",
+        "@segment/analytics-node": "^3.0.0",
         "axios": "^1.13.5",
         "classnames": "^2.3.1",
         "gatsby": "^5.14",

--- a/www/netlify/functions/sendAnalyticsData.js
+++ b/www/netlify/functions/sendAnalyticsData.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4 } = require('uuid');
-const Analytics = require('analytics-node');
+const { Analytics } = require('@segment/analytics-node');
 
-const analytics = new Analytics(process.env.SEGMENT_KEY);
+const analytics = new Analytics({ writeKey: process.env.SEGMENT_KEY });
 
 exports.handler = async function eventHandler(event) {
   // Only allow POST

--- a/www/netlify/functions/trackGenerateComponent.js
+++ b/www/netlify/functions/trackGenerateComponent.js
@@ -1,8 +1,8 @@
 const { v4: uuidv4 } = require('uuid');
-const Analytics = require('analytics-node');
+const { Analytics } = require('@segment/analytics-node');
 const { COMPONENT_GENERATED_EVENT } = require('../../segment-events');
 
-const analytics = new Analytics(process.env.SEGMENT_KEY);
+const analytics = new Analytics({ writeKey: process.env.SEGMENT_KEY });
 
 exports.handler = async function eventHandler(event) {
   // Only allow POST

--- a/www/package.json
+++ b/www/package.json
@@ -8,7 +8,7 @@
     "@mdx-js/mdx": "^2",
     "@mdx-js/react": "^2",
     "@openedx/brand-openedx": "^1.2.2",
-    "analytics-node": "^6.0.0",
+    "@segment/analytics-node": "^3.0.0",
     "axios": "^1.13.5",
     "classnames": "^2.3.1",
     "gatsby": "^5.14",


### PR DESCRIPTION
## Summary

- Migrates deprecated `analytics-node` to `@segment/analytics-node` in the docs site Netlify functions
- Removes the last source of axios 0.x (`0.27.2`) from the dependency tree
- Migration guide: https://www.twilio.com/docs/segment/connections/sources/catalog/libraries/server/node/migration
- Follow up: https://github.com/openedx/paragon/issues/4220

## Test plan

- [x] `npm ls axios` shows no 0.x versions
- [x] Docs site builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary><h3>Plan</h3></summary>

# Migrate `analytics-node` to `@segment/analytics-node`

## Context

Paragon is moving to axios 1.x. `analytics-node@6.2.0` is the last remaining source of axios 0.x (`0.27.2`) in the dependency tree. The `analytics-node` package is deprecated — Segment replaced it with `@segment/analytics-node` (no axios dependency — uses `jose`, `tslib`, `buffer`, and Segment core packages). Only two Netlify functions in `www/` use it. The browser-side analytics (`gatsby-plugin-segment-js`, `global.analytics.track()`) is unaffected.

Migration guide: https://www.twilio.com/docs/segment/connections/sources/catalog/libraries/server/node/migration

## Files to modify

1. **`www/package.json`** — Replace `"analytics-node": "^6.0.0"` with `"@segment/analytics-node": "^1.0.0"` (or latest)
2. **`www/netlify/functions/trackGenerateComponent.js`** — Update import and initialization
3. **`www/netlify/functions/sendAnalyticsData.js`** — Update import and initialization

## Changes per file

### Netlify functions (both files follow the same pattern)

**Before:**
```js
const Analytics = require('analytics-node');
const analytics = new Analytics(process.env.SEGMENT_KEY);
```

**After:**
```js
const { Analytics } = require('@segment/analytics-node');
const analytics = new Analytics({ writeKey: process.env.SEGMENT_KEY });
```

The `analytics.track()` calls stay the same — both files already pass `{ anonymousId, event, properties }` which is unchanged in the new API.

### www/package.json

Remove `analytics-node`, add `@segment/analytics-node`.

## What's NOT changing

- `gatsby-plugin-segment-js` — browser-side SDK, separate package, unrelated
- `segment-events/` constants and utils — no changes needed
- `global.analytics.track()` calls in components — browser SDK, not affected
- `SettingsContext.tsx` fallback — still works as-is

## Verification

1. `npm install` — confirm `axios@0.27.2` is gone from `npm ls axios`
2. `npm run build-docs` — confirm the www site builds

</details>