### PR TITLE
fix: drop `:preserveSemverRanges` from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    ":preserveSemverRanges"
+    "config:base"
   ],
   "patch": {
     "automerge": true


### PR DESCRIPTION
## Summary

The `:preserveSemverRanges` preset sets `rangeStrategy: "replace"`, which skips in-range updates entirely — no PR, no lockfile update. This causes dependencies to go stale in the lockfile with no visibility.

Removing it falls back to `rangeStrategy: "auto"`, which for npm:
1. **Widens** peerDependencies
2. **Replaces** the range if the update is outside it
3. **Updates the lockfile** if the update is in-range

## Relevant links

- [`:preserveSemverRanges` preset](https://docs.renovatebot.com/presets-default/#preservesemverranges)
- [`rangeStrategy` docs](https://docs.renovatebot.com/configuration-options/#rangestrategy)
- [OEP-0067: caret ranges for dependencies](https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0067/decisions/frontend/0011-caret-ranges-dependencies.html)

## Test plan

- [ ] Renovate opens PRs for in-range dependency updates (lockfile-only changes)
- [ ] Out-of-range updates still replace the range in `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary><h3>Conversation</h3></summary>

# Paragon Renovate Config Cleanup

## Problem

Renovate config extends `:preserveSemverRanges` which sets `rangeStrategy: "replace"`. With `replace`, renovate only opens a PR when a new version falls **outside** the current range. For caret ranges (e.g., `^7.58.1`), any new minor/patch within the same major is already satisfied, so renovate does nothing — no PR, no lockfile update.

This conflicts with the openedx "use ^" convention (OEP-0067 decision 0011) and leads to dependencies going stale in the lockfile with no visibility.

## Relevant links

- `:preserveSemverRanges` preset: https://docs.renovatebot.com/presets-default/#preservesemverranges
- `rangeStrategy` docs: https://docs.renovatebot.com/configuration-options/#rangestrategy
- OEP-0067 caret ranges decision: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0067/decisions/frontend/0011-caret-ranges-dependencies.html

## Fix

Remove `:preserveSemverRanges` from the `extends` array in `renovate.json`. This falls back to `rangeStrategy: "auto"`, which for npm:

1. **Widens** peerDependencies (e.g., `^1.0.0 || ^2.0.0` → `^1.0.0 || ^2.0.0 || ^3.0.0`)
2. **Replaces** the range if the update is outside it (e.g., `^2.0.0` → `^3.0.0`)
3. **Updates the lockfile** if the update is in-range (e.g., `^7.58.1` stays in `package.json` but lockfile gets `7.72.1`)

This means in-range updates still get PRs (with lockfile changes), preventing stale dependencies and surprise breakage on lockfile regen.

</details>