### PR TITLE
feat(www): load default Open edX brand theme from CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7112,12 +7112,6 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
-    "node_modules/@openedx/brand-openedx": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
-      "license": "GPL-3.0-or-later"
-    },
     "node_modules/@openedx/frontend-build": {
       "version": "14.6.4",
       "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.6.4.tgz",
@@ -48756,7 +48750,6 @@
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@mdx-js/mdx": "^2",
         "@mdx-js/react": "^2",
-        "@openedx/brand-openedx": "^1.2.2",
         "@segment/analytics-node": "^3.0.0",
         "axios": "^1.13.5",
         "classnames": "^2.3.1",

--- a/www/gatsby-browser.jsx
+++ b/www/gatsby-browser.jsx
@@ -2,7 +2,6 @@ const React = require('react');
 const { SettingsContextProvider } = require('./src/context/SettingsContext');
 const { InsightsContextProvider } = require('./src/context/InsightsContext');
 const { encodeThemesToQueryParam } = require('../lib/queryParamEncoding');
-const { hasUrls } = require('./src/utils/themeUtils');
 
 // wrap whole app in settings context
 exports.wrapRootElement = ({ element }) => (
@@ -34,7 +33,7 @@ exports.onRouteUpdate = ({ location: { hash, pathname, href } }) => {
       const activeIdx = savedSettings.activeThemeIndex;
 
       // Only preserve themes if we have custom themes (more than just the default theme)
-      const hasCustomThemes = themes.some(hasUrls);
+      const hasCustomThemes = themes.some(t => !t.isDefault);
 
       if (hasCustomThemes) {
         const url = new URL(window.location.href);
@@ -42,7 +41,7 @@ exports.onRouteUpdate = ({ location: { hash, pathname, href } }) => {
 
         // Only update if themes param is missing
         if (!currentThemesParam) {
-          const encoded = encodeThemesToQueryParam(themes, activeIdx || 0);
+          const encoded = encodeThemesToQueryParam(themes.filter(t => !t.isDefault), activeIdx || 0);
 
           url.searchParams.set('themes', encoded);
 

--- a/www/package.json
+++ b/www/package.json
@@ -7,7 +7,6 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@mdx-js/mdx": "^2",
     "@mdx-js/react": "^2",
-    "@openedx/brand-openedx": "^1.2.2",
     "@segment/analytics-node": "^3.0.0",
     "axios": "^1.13.5",
     "classnames": "^2.3.1",

--- a/www/src/components/ThemeOptions.tsx
+++ b/www/src/components/ThemeOptions.tsx
@@ -6,7 +6,6 @@ import {
 } from '~paragon-react';
 import { Plus } from '~paragon-icons';
 import { type Theme } from '../types/types';
-import { hasUrls } from '../utils/themeUtils';
 
 interface ThemeOptionsProps {
   themes: Theme[];
@@ -38,39 +37,36 @@ const ThemeOptions: React.FC<ThemeOptionsProps> = ({
       onChange={onThemeChange}
       ref={radioRefs}
     >
-      {themes.map((theme, index) => {
-        const isCustom = hasUrls(theme);
-        return (
-          <div key={theme.name}>
-            <Form.Radio
-              value={index.toString()}
-              ref={(el) => {
-                radioRefs.current[index] = el;
-              }}
-            >
-              <Stack gap={1}>
-                <span>{theme.name}</span>
-                {isCustom && (
-                  <div>
-                    <Button
-                      variant="link"
-                      size="sm"
-                      className="p-0"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        onEditTheme(index);
-                      }}
-                    >
-                      Edit
-                    </Button>
-                  </div>
-                )}
-              </Stack>
-            </Form.Radio>
-          </div>
-        );
-      })}
+      {themes.map((theme, index) => (
+        <div key={theme.name}>
+          <Form.Radio
+            value={index.toString()}
+            ref={(el) => {
+              radioRefs.current[index] = el;
+            }}
+          >
+            <Stack gap={1}>
+              <span>{theme.name}</span>
+              {!theme.isDefault && (
+                <div>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="p-0"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onEditTheme(index);
+                    }}
+                  >
+                    Edit
+                  </Button>
+                </div>
+              )}
+            </Stack>
+          </Form.Radio>
+        </div>
+      ))}
     </Form.RadioSet>
     <Stack gap={2}>
       <div>

--- a/www/src/hooks/useCustomThemes.ts
+++ b/www/src/hooks/useCustomThemes.ts
@@ -3,6 +3,7 @@ import { type ThemeConfig } from '../types/types';
 import { UpdateSettingsFunction } from './useSettings';
 
 import { encodeThemesToQueryParam } from '../utils/queryParamEncoding';
+import { DEFAULT_THEME } from '../utils/themeUtils';
 
 /**
  * Hook to manage theme state including default and custom themes
@@ -33,10 +34,10 @@ export const useCustomThemes = (
     const url = new URL(window.location.href);
 
     // Only set URL params if we have custom themes (more than just the default theme)
-    const hasCustomThemes = themes.length > 1 || (themes.length === 1 && themes[0].urls && themes[0].urls.length > 0);
+    const hasCustomThemes = themes.some(t => !t.isDefault);
 
     if (hasCustomThemes) {
-      const encoded = encodeThemesToQueryParam(themes, activeIndex);
+      const encoded = encodeThemesToQueryParam(themes.filter(t => !t.isDefault), activeIndex);
       url.searchParams.set('themes', encoded);
     } else {
       url.searchParams.delete('themes');
@@ -59,7 +60,7 @@ export const useCustomThemes = (
 
     // Ensure we have at least the default theme
     if (themesArr.length === 0) {
-      themesArr = [{ name: 'Open edX (Default)', urls: [] }];
+      themesArr = [DEFAULT_THEME];
       activeIdx = 0;
     }
 
@@ -112,7 +113,7 @@ export const useCustomThemes = (
 
       // Ensure we have at least the default theme
       if (newThemes.length === 0) {
-        newThemes.push({ name: 'Open edX (Default)', urls: [] });
+        newThemes.push(DEFAULT_THEME);
       }
 
       // Adjust active index if needed
@@ -145,7 +146,7 @@ export const useCustomThemes = (
 
     // Update settings atomically - reset to just the default theme
     updateSettings({
-      themes: [{ name: 'Open edX (Default)', urls: [] }],
+      themes: [DEFAULT_THEME],
       activeThemeIndex: 0,
     });
   };

--- a/www/src/hooks/useSettings.ts
+++ b/www/src/hooks/useSettings.ts
@@ -3,6 +3,7 @@ import { type ContainerSize } from '~paragon-react';
 import { SETTINGS_EVENTS, sendUserAnalyticsEvent } from '../../segment-events';
 import { type ThemeConfig } from '../types/types';
 import { decodeThemesFromQueryParam } from '../utils/queryParamEncoding';
+import { DEFAULT_THEME } from '../utils/themeUtils';
 
 export interface Settings {
   direction?: string;
@@ -30,9 +31,7 @@ const defaultSettings: Settings = {
   direction: 'ltr',
   language: 'en',
   containerWidth: 'md' as ContainerSize,
-  themes: [
-    { name: 'Open edX (Default)', urls: [] },
-  ],
+  themes: [DEFAULT_THEME],
   activeThemeIndex: 0,
 };
 
@@ -103,13 +102,14 @@ export const useSettings = (): UseSettings => {
       ...urlSettings,
     };
 
-    const themes = finalSettings.themes || [];
-    const activeIndex = finalSettings.activeThemeIndex;
+    // Normalize themes: filter out entries without URLs (e.g. old default themes
+    // from shared links or localStorage), and ensure DEFAULT_THEME is always first.
+    const loadedThemes = Array.isArray(finalSettings.themes) ? finalSettings.themes : [];
+    const customThemes = loadedThemes.filter(t => !t.isDefault && t.urls?.length > 0);
+    finalSettings.themes = [DEFAULT_THEME, ...customThemes];
 
-    if (!Array.isArray(finalSettings.themes) || finalSettings.themes.length === 0) {
-      finalSettings.themes = defaultSettings.themes;
-      finalSettings.activeThemeIndex = 0;
-    } else if (activeIndex == null || activeIndex < 0 || activeIndex >= themes.length) {
+    const activeIndex = finalSettings.activeThemeIndex;
+    if (activeIndex == null || activeIndex < 0 || activeIndex >= finalSettings.themes.length) {
       finalSettings.activeThemeIndex = 0;
     }
 
@@ -120,12 +120,12 @@ export const useSettings = (): UseSettings => {
       document.body.setAttribute('dir', finalSettings.direction);
     }
 
-    // If themes were loaded from URL, save them to localStorage
+    // If themes were loaded from URL, save normalized themes to localStorage
     if (urlSettings) {
       const settingsToSave = {
         ...storageSettings,
-        themes: urlSettings.themes,
-        activeThemeIndex: urlSettings.activeThemeIndex,
+        themes: finalSettings.themes,
+        activeThemeIndex: finalSettings.activeThemeIndex,
       };
       global.localStorage.setItem('pgn__settings', JSON.stringify(settingsToSave));
     }

--- a/www/src/hooks/useThemeContext.ts
+++ b/www/src/hooks/useThemeContext.ts
@@ -1,7 +1,6 @@
 import { useContext } from 'react';
 import { SettingsContext } from '../context/SettingsContext';
 import { type ThemeConfig } from '../types/types';
-import { hasUrls } from '../utils/themeUtils';
 
 export const useThemeContext = () => {
   const context = useContext(SettingsContext);
@@ -27,7 +26,7 @@ export const useThemeContext = () => {
     handleSettingsChange('activeThemeIndex', index);
   };
 
-  const hasCustomThemes = themes.some(hasUrls);
+  const hasCustomThemes = themes.some(t => !t.isDefault);
 
   return {
     // State

--- a/www/src/types/types.ts
+++ b/www/src/types/types.ts
@@ -51,6 +51,8 @@ export interface Theme {
   name: string;
   /** Array of CSS URLs to load for this theme */
   urls?: string[];
+  /** Whether this is the built-in default theme */
+  isDefault?: boolean;
   /** Optional metadata about the theme */
   metadata?: {
     /** Indicates if the user provided a custom name for this theme */
@@ -67,6 +69,8 @@ export type ThemeConfig = {
   name: string;
   /** Array of CSS URLs to load for this theme (required) */
   urls: string[];
+  /** Whether this is the built-in default theme */
+  isDefault?: boolean;
   /** Optional metadata about the theme */
   metadata?: Theme['metadata'];
 };

--- a/www/src/utils/themeUtils.ts
+++ b/www/src/utils/themeUtils.ts
@@ -1,5 +1,14 @@
 import { type Theme, type ThemeConfig, type ThemeWithUrls } from '../types/types';
 
+export const DEFAULT_THEME: ThemeConfig = {
+  name: 'Open edX (Default)',
+  urls: [
+    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/core.min.css',
+    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/light.min.css',
+  ],
+  isDefault: true,
+};
+
 /**
  * Converts existing theme to ThemeConfig (edit mode)
  * @param theme - Existing theme to convert


### PR DESCRIPTION
## Summary

- Load the default Open edX brand theme from `@openedx/brand-openedx@2` via jsDelivr CDN (`core.min.css` and `light.min.css`)
- Add `isDefault` flag to `ThemeConfig` to distinguish the built-in default from user-added custom themes
- Normalize themes on load for backwards compatibility with old shared links and localStorage entries
- Remove unused `@openedx/brand-openedx` dependency from `www/package.json`

## Context

The `@openedx/brand-openedx` v1.x package was purely a placeholder — its SCSS files contain only comments with no actual styles. With v2.x, the package now ships real pre-compiled theme CSS. The default theme in the theme switcher (introduced in #3663) had `urls: []`, so no brand styles were being loaded.

## Test plan

- [x] Run `npm start` from the repo root and confirm the docs site loads with the branded Open edX theme
- [x] Confirm the Edit button does NOT appear next to the default theme
- [x] Confirm the "Reset custom themes" button only appears when a user-added theme exists
- [x] Confirm switching away from and back to the default theme works
- [x] Confirm the "Reset" functionality restores the CDN-based default theme
- [x] Confirm the `?themes` query param is NOT set when only the default theme is active
- [x] Confirm old shared links (with the URL-less default) still work correctly

<details>
<summary><h3>Plan</h3></summary>

# Update docs site default theme to use brand CDN URLs

## Context

The `@openedx/brand-openedx` v1.x package was purely a placeholder — its SCSS files (`_variables.scss`, `_overrides.scss`, `_fonts.scss`) contain only comments with no actual styles. With v2.x, the package now ships real pre-compiled theme CSS (`core.css`, `light.css`). The docs site needs to load these styles to display proper Open edX branding.

Currently the default theme in the theme switcher (introduced in PR #3663) has `urls: []`, and the `@openedx/brand-openedx@^1.2.2` dependency in `www/package.json` is unused.

## Alternative Considered

Wire up the installed `@openedx/brand-openedx` dependency directly via SCSS. The v1 package (`^1.2.2`) only has SCSS partials (`paragon/_variables.scss`, `_overrides.scss`, `_fonts.scss`) — no pre-compiled CSS. This would require bumping to v2, reworking the SCSS build pipeline in `build-themes.js` and `openedx-theme.scss`, and copying built CSS to `public/static/`. Significantly more complex for the same result.

## Chosen Approach: CDN URLs

Use `https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/` CSS files as the default theme URLs. Minimal code change, no build pipeline changes needed.

### CDN URLs

```
https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/core.min.css
https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/light.min.css
```

## Changes

### 1. Extract default theme constant — `www/src/utils/themeUtils.ts`
Define a shared `DEFAULT_THEME` constant with the CDN URLs, so the default theme is defined in one place:
```ts
export const DEFAULT_THEME: ThemeConfig = {
  name: 'Open edX (Default)',
  urls: [
    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/core.min.css',
    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/light.min.css',
  ],
};
```

Add an `isDefault` boolean flag to the `ThemeConfig` type to explicitly mark the default theme. Custom theme checks become `!theme.isDefault` / `themes.some(t => !t.isDefault)`.

### 2. `www/src/hooks/useSettings.ts` (line 34)
Import `DEFAULT_THEME` and use it in `defaultSettings.themes`.

### 3. `www/src/hooks/useCustomThemes.ts`
- Import `DEFAULT_THEME`.
- **Lines 61-62** (`handleThemesChange`): use `DEFAULT_THEME` instead of `{ name: 'Open edX (Default)', urls: [] }`.
- **Lines 114-115** (`removeTheme`): same.
- **Line 148** (`resetThemes`): same.
- **Line 36** (`updateURLParams`): update `hasCustomThemes` to `themes.some(t => !t.isDefault)`.

### 4. `www/src/types/types.ts`
Add `isDefault?: boolean` to the `ThemeConfig` type (and related types as needed).

### 5. `www/src/hooks/useThemeContext.ts` (line 30)
Update `hasCustomThemes` from `themes.some(hasUrls)` to `themes.some(t => !t.isDefault)`.

### 6. `www/src/components/ThemeOptions.tsx` (line 42)
Update `isCustom` from `hasUrls(theme)` to `!theme.isDefault`. This controls whether the Edit button appears — the default theme should not be editable.

### 7. `www/package.json` (line 10)
Remove the unused `@openedx/brand-openedx` dependency (`"@openedx/brand-openedx": "^1.2.2"`). The CDN approach replaces this entirely.

## Verification

1. Run `npm start` from the repo root and confirm the docs site loads with the branded Open edX theme
2. Confirm the Edit button does NOT appear next to the default theme
3. Confirm the "Reset custom themes" button only appears when a user-added theme exists
4. Confirm switching away from and back to the default theme works
5. Confirm the "Reset" functionality restores the CDN-based default theme
6. Confirm the `?themes` query param is NOT set when only the default theme is active

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)