### PR TITLE
fix: build token crash in some cases

### DIFF
--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -311,10 +311,9 @@ const initializeStyleDictionary = async ({ themes }) => {
     format: async ({ dictionary, file, options = {} }) => {
       const { fileHeader } = await getStyleDictionaryUtils();
       const { formatting } = options;
-      const { breakpoint } = dictionary.tokens.size;
 
       let customMediaVariables = '';
-      const breakpoints = Object.values(breakpoint || {});
+      const breakpoints = Object.values(dictionary.tokens?.size?.breakpoint || {});
 
       for (let i = 0; i < breakpoints.length; i++) {
         const [currentBreakpoint, nextBreakpoint] = [breakpoints[i], breakpoints[i + 1]];


### PR DESCRIPTION
## Description

When building a theme where there are no core size tokens, and when using source-tokens-only, the token build step fails since dictionary.tokens doesn't have a 'size' key.

### Testing instructions

- Create a minimal token setup, a folder called `tokens` inside which there should be a folder called `core` inside which you can create a JSON or TOML file for core design tokens.
- Add any token in this file other than a size token, i.e. even something like the following
  ```json
   {
      "token": { "$value": "11" }
   }
  ```
- Run `npx @openedx/paragon@23.21.2 build-tokens --source ./tokens  --source-tokens-only`
- It will fail with the error `An error occurred: TypeError: Cannot destructure property 'breakpoint' of 'dictionary.tokens.size' as it is undefined.`
- If you add a size token to the file the error will go away. Something as simple as `"size": { "test": { "$value": "11px" } }`
- If you test with the version of paragon in this PR it will not throw the error but build correctly.
### Deploy Preview

NA

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.



private-ref: https://tasks.opencraft.com/browse/BB-10703