### PR TITLE
fix(tokens): update code-color token to meet WCAG AA contrast

### DIFF
--- a/styles/css/themes/light/variables.css
+++ b/styles/css/themes/light/variables.css
@@ -614,7 +614,6 @@
   --pgn-color-btn-disabled-border-inverse-outline-success: inherit;
   --pgn-color-btn-disabled-border-inverse-warning: #00000000;
   --pgn-color-card-base: inherit;
-  --pgn-color-code-base: #E83E8CFF;
   --pgn-color-form-control-label-base: inherit;
   --pgn-color-icon-button-bg-base: #00000000;
   --pgn-color-menu-item-bg: #00000000;
@@ -1231,6 +1230,7 @@
   --pgn-color-chip-border-focus-selected-light: var(--pgn-color-dark-500);
   --pgn-color-chip-label-base: var(--pgn-color-primary-700);
   --pgn-color-chip-label-dark: var(--pgn-color-chip-outline-dark);
+  --pgn-color-code-base: var(--pgn-color-brand-500);
   --pgn-color-data-table-bg-base: var(--pgn-color-bg-base);
   --pgn-color-data-table-border: var(--pgn-color-light-300);
   --pgn-color-dropdown-text: var(--pgn-color-body-base);

--- a/tokens/src/themes/light/components/Code.json
+++ b/tokens/src/themes/light/components/Code.json
@@ -2,7 +2,7 @@
   "color": {
     "$type": "color",
     "code": {
-      "base": { "source": "$code-color", "$value": "#E83E8C" },
+      "base": { "source": "$code-color", "$value": "{color.brand.500}" },
       "kbd": {
         "base": { "source": "$kbd-color", "$value": "{color.white}" },
         "bg": { "source": "$kbd-bg", "$value": "{color.gray.700}" }


### PR DESCRIPTION
The light theme code-color token (#E83E8C) failed WCAG 1.4.3 contrast requirements, achieving 3.81:1 on white and 3.56:1 on off-white backgrounds — both below the 4.5:1 minimum for normal-weight text.

Updated color.code.base to reference {color.brand.500} rather than a raw hex value. This resolves the contrast failure (#9D0054, ~9:1 on white) and aligns with the established pattern of component tokens referencing palette tokens (e.g. success → green, info → teal). It also ensures that theme overrides to brand-500 automatically propagate to inline code text color.

Compiled output: --pgn-color-code-base: var(--pgn-color-brand-500)

Identified via WCAG 2.2 AA audit using static source analysis and automated page scanning (OpenEdX_ActionRowComp.pdf, 01 May 26).

AI assistance: Code change, contrast analysis, and token architecture review developed with Claude (claude-sonnet-4-6). Conversation informed the audit findings, color selection, and token pipeline tracing.

## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
