### PR TITLE
fix(ActionRow): align DOM and visual order in stacked mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ www/public
 
 # Local Netlify folder
 .netlify
+.claude/

--- a/src/ActionRow/ActionRow.test.tsx
+++ b/src/ActionRow/ActionRow.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ActionRow from '.';
+
+describe('<ActionRow />', () => {
+  describe('stacked mode', () => {
+    it('renders children in reverse DOM order so primary action leads focus', () => {
+      const { getAllByRole } = render(
+        <ActionRow isStacked>
+          <button type="button">Secondary</button>
+          <button type="button">Primary</button>
+        </ActionRow>,
+      );
+      const buttons = getAllByRole('button');
+      expect(buttons[0]).toHaveTextContent('Primary');
+      expect(buttons[1]).toHaveTextContent('Secondary');
+    });
+  });
+
+  describe('horizontal mode', () => {
+    it('renders children in original DOM order', () => {
+      const { getAllByRole } = render(
+        <ActionRow>
+          <button type="button">Secondary</button>
+          <button type="button">Primary</button>
+        </ActionRow>,
+      );
+      const buttons = getAllByRole('button');
+      expect(buttons[0]).toHaveTextContent('Secondary');
+      expect(buttons[1]).toHaveTextContent('Primary');
+    });
+  });
+});

--- a/src/ActionRow/README.md
+++ b/src/ActionRow/README.md
@@ -16,7 +16,7 @@ notes: |
 A layout utility for the common use case of aligning buttons, links or text
 in a row in a control bar or nav.
 
-ActionRow assumes that its last child is the primary action and lays out actions so that the last item is in a primary location. If horizontal, the primary action sits on the right. If stacked, the primary action sits at the top of the stack (this is done via `flex-direction: column-reverse;`).
+ActionRow assumes that its last child is the primary action and lays out actions so that the last item is in a primary location. If horizontal, the primary action sits on the right. If stacked, the primary action sits at the top of the stack — the component reverses the DOM order of children so that keyboard focus order matches the visual order (primary action is reached first).
 
 ## Basic Usage
 

--- a/src/ActionRow/_index.scss
+++ b/src/ActionRow/_index.scss
@@ -17,7 +17,7 @@
   display: flex;
   flex-grow: 1;
   align-items: center;
-  flex-direction: column-reverse;
+  flex-direction: column;
   justify-content: center;
 
   & > * {
@@ -25,7 +25,7 @@
   }
 
   & > * + * {
-    margin-bottom: var(--pgn-spacing-action-row-gap-y);
+    margin-top: var(--pgn-spacing-action-row-gap-y);
   }
 }
 

--- a/src/ActionRow/index.tsx
+++ b/src/ActionRow/index.tsx
@@ -18,6 +18,12 @@ function ActionRow({
   children,
   ...props
 }: ActionRowProps) {
+  // Reverse DOM order when stacked so the primary action (last child) is first
+  // in the tab sequence, matching its visual position at the top of the stack.
+  const orderedChildren = isStacked
+    ? React.Children.toArray(children).reverse()
+    : children;
+
   return React.createElement(
     as,
     {
@@ -27,7 +33,7 @@ function ActionRow({
         'pgn__action-row-stacked': isStacked,
       }),
     },
-    children,
+    orderedChildren,
   );
 }
 


### PR DESCRIPTION
In isStacked mode, flex-direction: column-reverse placed the primary action (last DOM child) at the visual top but keyboard focus still reached it last, violating WCAG 1.3.2 Meaningful Sequence and 2.4.3 Focus Order.

Fix (Option A): reverse children in DOM order when isStacked is true and change the SCSS to flex-direction: column. The primary action is now first in both DOM and visual order — a sighted keyboard user tabs to it first, matching what they see.

Consumers continue passing the primary action as the last child (consistent with horizontal mode); the component handles reversal internally.

## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
