### PR TITLE
feat: add support for :host pseudo-class in style-dictionary output

### DIFF
--- a/tokens/style-dictionary.js
+++ b/tokens/style-dictionary.js
@@ -158,7 +158,7 @@ const createCustomCSSVariables = async ({ formatterArgs }) => {
     usesDtcg: true,
   });
   const header = await fileHeader({ file, formatting });
-  return `${header}:root {\n${variables}\n}\n`;
+  return `${header}:root, :host {\n${variables}\n}\n`;
 };
 
 /**


### PR DESCRIPTION
## Description

This PR updates the generated CSS variables from design tokens to emit variables under both `:root` and `:host`.

Previously, design token CSS variables were generated only under `:root`, which makes them globally available at the document level. This works well for normal application usage, but it does not fully support stylesheets that are loaded inside a Shadow DOM.

The primary use case for this change is to support isolated XBlocks that render inside a Shadow DOM. By including `:host` alongside `:root`, the XBlock can load these stylesheets with the theme remaining isolated to the XBlock without spilling over to the rest of the page. 

### Deploy Preview

NA. This should have no visual impact. 

## Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [x] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
