### PR TITLE
chore: pin GitHub Actions workflows to full commit SHAs

### DIFF
--- a/.github/workflows/analyze-dependents.yml
+++ b/.github/workflows/analyze-dependents.yml
@@ -11,182 +11,182 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout openedx/credentials-themes
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/credentials-themes
         path: dependent-usage-analyzer/.projects/credentials-themes
     - name: Checkout openedx/credentials
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/credentials
         path: dependent-usage-analyzer/.projects/credentials
     - name: Checkout openedx/edx-enterprise
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/edx-enterprise
         path: dependent-usage-analyzer/.projects/edx-enterprise
     - name: Checkout openedx/edx-ora2
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/edx-ora2
         path: dependent-usage-analyzer/.projects/edx-ora2
     - name: Checkout openedx/edx-platform
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/edx-platform
         path: dependent-usage-analyzer/.projects/edx-platform
     - name: Checkout openedx/frontend-app-account
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-account
         path: dependent-usage-analyzer/.projects/frontend-app-account
     - name: Checkout openedx/frontend-app-admin-portal
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-admin-portal
         path: dependent-usage-analyzer/.projects/frontend-app-admin-portal
     - name: Checkout openedx/frontend-app-authn
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-authn
         path: dependent-usage-analyzer/.projects/frontend-app-authn
     - name: Checkout openedx/frontend-app-communications
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-communications
         path: dependent-usage-analyzer/.projects/frontend-app-communications
     - name: Checkout openedx/frontend-app-course-authoring
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-course-authoring
         path: dependent-usage-analyzer/.projects/frontend-app-course-authoring
     - name: Checkout openedx/frontend-app-discussions
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-discussions
         path: dependent-usage-analyzer/.projects/frontend-app-discussions
     - name: Checkout openedx/frontend-app-ecommerce
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-ecommerce
         path: dependent-usage-analyzer/.projects/frontend-app-ecommerce
     - name: Checkout openedx/frontend-app-enterprise-public-catalog
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-enterprise-public-catalog
         path: dependent-usage-analyzer/.projects/frontend-app-enterprise-public-catalog
     - name: Checkout openedx/frontend-app-gradebook
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-gradebook
         path: dependent-usage-analyzer/.projects/frontend-app-gradebook
     - name: Checkout openedx/frontend-app-learner-portal-enterprise
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-learner-portal-enterprise
         path: dependent-usage-analyzer/.projects/frontend-app-learner-portal-enterprise
     - name: Checkout openedx/frontend-app-learner-portal-programs
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-learner-portal-programs
         path: dependent-usage-analyzer/.projects/frontend-app-learner-portal-programs
     - name: Checkout openedx/frontend-app-learner-record
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-learner-record
         path: dependent-usage-analyzer/.projects/frontend-app-learner-record
     - name: Checkout openedx/frontend-app-learning
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-learning
         path: dependent-usage-analyzer/.projects/frontend-app-learning
     - name: Checkout openedx/frontend-app-library-authoring
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-library-authoring
         path: dependent-usage-analyzer/.projects/frontend-app-library-authoring
     - name: Checkout openedx/frontend-app-ora-grading
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-ora-grading
         path: dependent-usage-analyzer/.projects/frontend-app-ora-grading
     - name: Checkout openedx/frontend-app-payment
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-payment
         path: dependent-usage-analyzer/.projects/frontend-app-payment
     - name: Checkout openedx/frontend-app-profile
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-profile
         path: dependent-usage-analyzer/.projects/frontend-app-profile
     - name: Checkout openedx/frontend-app-program-console
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-program-console
         path: dependent-usage-analyzer/.projects/frontend-app-program-console
     - name: Checkout openedx/frontend-app-publisher
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-publisher
         path: dependent-usage-analyzer/.projects/frontend-app-publisher
     - name: Checkout openedx/frontend-app-support-tools
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-support-tools
         path: dependent-usage-analyzer/.projects/frontend-app-support-tools
     - name: Checkout openedx/frontend-component-cookie-policy-banner
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-component-cookie-policy-banner
         path: dependent-usage-analyzer/.projects/frontend-component-cookie-policy-banner
     - name: Checkout edx/frontend-component-header-edx
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: edx/frontend-component-header-edx
         path: dependent-usage-analyzer/.projects/frontend-component-header-edx
     - name: Checkout openedx/frontend-component-header
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-component-header
         path: dependent-usage-analyzer/.projects/frontend-component-header
     - name: Checkout openedx/frontend-enterprise
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-enterprise
         path: dependent-usage-analyzer/.projects/frontend-enterprise
     - name: Checkout openedx/frontend-learner-portal-base
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-learner-portal-base
         path: dependent-usage-analyzer/.projects/frontend-learner-portal-base
     - name: Checkout openedx/frontend-lib-special-exams
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-lib-special-exams
         path: dependent-usage-analyzer/.projects/frontend-lib-special-exams
     - name: Checkout openedx/frontend-platform
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-platform
         path: dependent-usage-analyzer/.projects/frontend-platform
     - name: Checkout openedx/frontend-template-application
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-template-application
         path: dependent-usage-analyzer/.projects/frontend-template-application
     - name: Checkout openedx/studio-frontend
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/studio-frontend
         path: dependent-usage-analyzer/.projects/studio-frontend
     - name: Checkout openedx/frontend-app-communications
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-communications
         path: dependent-usage-analyzer/.projects/frontend-app-communications
     - name: Checkout openedx/frontend-app-learner-dashboard
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: openedx/frontend-app-learner-dashboard
         path: dependent-usage-analyzer/.projects/frontend-app-learner-dashboard
@@ -194,11 +194,11 @@ jobs:
       working-directory: dependent-usage-analyzer
       run: ls -la .projects
     - name: Create zip archive of dependent project checkouts
-      uses: montudor/action-zip@v1
+      uses: montudor/action-zip@a8e75c9faefcd80fac3baf53ef40b9b119d5b702 # v1
       with:
         args: zip -qq -r dependent-usage-analyzer/dependent-projects.zip dependent-usage-analyzer/.projects
     - name: Upload dependent projects checkouts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dependent-project-checkouts
         path: dependent-usage-analyzer/dependent-projects.zip
@@ -208,23 +208,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Nodejs Env
       run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Nodejs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VER }}
     - name: Install dependencies
       run: npm ci
       working-directory: dependent-usage-analyzer
     - name: Download dependent project checkouts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: dependent-project-checkouts
         path: dependent-usage-analyzer
     - name: Unzip archive of dependent project checkouts
-      uses: montudor/action-zip@v1
+      uses: montudor/action-zip@a8e75c9faefcd80fac3baf53ef40b9b119d5b702 # v1
       with:
         args: unzip -qq dependent-usage-analyzer/dependent-projects.zip -d dependent-usage-analyzer/dependent-projects
     - name: Move dependent project checkouts
@@ -236,7 +236,7 @@ jobs:
       run: npm run analyze .projects -- --out "${GITHUB_WORKSPACE}/dependent-usage.json"
       working-directory: dependent-usage-analyzer
     - name: Upload analysis output
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dependent-usage-json
         path: dependent-usage.json
@@ -246,22 +246,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
           fetch-depth: 0
     - name: Setup Nodejs Env
       run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Nodejs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VER }}
     - name: Download analysis output
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: dependent-usage-json
     - name: Create pull request for dependent project usages
       id: cpr
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
         token: ${{ secrets.requirements_bot_github_token }}
         commit-message: "docs: update dependent-usage.json"
@@ -271,12 +271,12 @@ jobs:
         branch: dependent-usage-analyzer/update-dependent-usage-json
         base: next
     - name: Auto-approve pull request for dependent project usages
-      uses: hmarr/auto-approve-action@v4
+      uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
       with:
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Auto-merge pull request for dependent project usages
-      uses: pascalgn/automerge-action@v0.16.4
+      uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MERGE_METHOD: squash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Setup Nodejs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
     - name: Install dependencies
@@ -40,6 +40,6 @@ jobs:
     - name: Build Docs
       run: make build-docs
     - name: Coverage
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Setup Nodejs Env
       run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.NODE_VER }}
     - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
       id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
     - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
     - name: Build Docs
       run: npm run build-docs
     - name: Coverage
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Release

--- a/.github/workflows/sync-22-23.yml
+++ b/.github/workflows/sync-22-23.yml
@@ -11,14 +11,14 @@ jobs:
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Create Pull Request
         id: cpr
-        uses: tretuna/sync-branches@1.4.0
+        uses: tretuna/sync-branches@ea58ab6e406fd3ad016a064b31270bbb41127f41 # 1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_BRANCH: release-22.x

--- a/.github/workflows/sync-23-next.yml
+++ b/.github/workflows/sync-23-next.yml
@@ -11,25 +11,25 @@ jobs:
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Create Pull Request
         id: cpr
-        uses: tretuna/sync-branches@1.4.0
+        uses: tretuna/sync-branches@ea58ab6e406fd3ad016a064b31270bbb41127f41 # 1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_BRANCH: release-23.x
           TO_BRANCH: next
       - name: Auto-approve pull request for sync
-        uses: hmarr/auto-approve-action@v4
+        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
         with:
           pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}
           github-token: ${{ secrets.requirements_bot_github_token }}
       - name: Enable Pull Request Automerge
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
           token: ${{ secrets.requirements_bot_github_token }}
           pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}


### PR DESCRIPTION
Pins all `uses:` action refs to their full commit SHA with the version tag preserved as a comment. Part of org-wide SHA-pinning migration: openedx/.github#165