### PR TITLE
fix: include user-defined tokens as app token source

### DIFF
--- a/lib/build-tokens.js
+++ b/lib/build-tokens.js
@@ -199,8 +199,11 @@ async function buildTokensCommand(commandArgs) {
     ...coreConfig,
     include: [
       ...coreConfig.include,
+      ...coreConfig.source,
       path.resolve(__dirname, '../tokens/src/themes/light/**/*.json'),
       path.resolve(__dirname, '../tokens/src/themes/light/**/*.toml'),
+      `${tokensSource}/themes/light/**/*.json`,
+      `${tokensSource}/themes/light/**/*.toml`,
     ],
     source: [
       `${tokensPath}/apps/${appName}/**/*.json`,


### PR DESCRIPTION
## Description
Currently, app tokens are limited by the tokens defined in the Paragon core and light themes, if a new token is defined by a custom theme, app tokens can't reference it.

This change includes the user-defined tokens as sources so custom themes with app tokens can use values from there.

### Deploy Preview

NA

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
