### PR TITLE
fix(datatable): improve sortable header accessibility

### DIFF
--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -48,7 +48,7 @@ function TableHeaderCell({
   isSortedDesc = false,
   headerClassName,
 }: TableHeaderCellProps) {
-  const headerProps = getHeaderProps();
+  const { key, ...headerProps } = getHeaderProps();
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
   // Per WAI-ARIA APG sortable table guidance, only the actively sorted header should expose aria-sort.
   let ariaSort: React.AriaAttributes['aria-sort'];
@@ -59,6 +59,7 @@ function TableHeaderCell({
 
   return (
     <th
+      key={key}
       {...headerProps}
       scope="col"
       aria-sort={ariaSort}
@@ -73,12 +74,13 @@ function TableHeaderCell({
           type="button"
           className={classNames(
             'pgn__data-table-sort-button',
-            headerContentClassName,
             toggleProps.className,
           )}
         >
-          <span>{render('Header')}</span>
-          <SortIndicator isSorted={isSorted} isSortedDesc={isSortedDesc || false} />
+          <span className={headerContentClassName}>
+            <span>{render('Header')}</span>
+            <SortIndicator isSorted={isSorted} isSortedDesc={isSortedDesc || false} />
+          </span>
         </button>
       ) : (
         <span className={headerContentClassName}>

--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -31,7 +31,7 @@ interface TableHeaderCellProps {
   render: (type: 'Header') => React.ReactNode;
   /** Indicates whether the column is sorted in descending order */
   isSortedDesc?: boolean;
-  /** Gets props related to sorting that will be passed to th */
+  /** Gets props related to sorting that will be passed to the sort button */
   getSortByToggleProps?: (...args: any[]) => Record<string, any>;
   /** Indicates whether a column is sortable */
   canSort?: boolean;
@@ -49,13 +49,31 @@ function TableHeaderCell({
   headerClassName,
 }: TableHeaderCellProps) {
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
+  const ariaSort: React.AriaAttributes['aria-sort'] = isSorted
+    ? (isSortedDesc ? 'descending' : 'ascending')
+    : undefined;
+  const headerContentClassName = classNames('pgn__data-table-header-content', headerClassName);
 
   return (
-    <th {...getHeaderProps(toggleProps)}>
-      <span className={classNames('d-flex align-items-center', headerClassName)}>
-        <span>{render('Header')}</span>
-        {canSort && <SortIndicator isSorted={isSorted} isSortedDesc={isSortedDesc || false} />}
-      </span>
+    <th {...getHeaderProps()} scope="col" aria-sort={ariaSort}>
+      {canSort ? (
+        <button
+          {...toggleProps}
+          type="button"
+          className={classNames(
+            'pgn__data-table-sort-button',
+            headerContentClassName,
+            toggleProps.className,
+          )}
+        >
+          <span>{render('Header')}</span>
+          <SortIndicator isSorted={isSorted} isSortedDesc={isSortedDesc || false} />
+        </button>
+      ) : (
+        <span className={headerContentClassName}>
+          <span>{render('Header')}</span>
+        </span>
+      )}
     </th>
   );
 }

--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -50,6 +50,7 @@ function TableHeaderCell({
 }: TableHeaderCellProps) {
   const headerProps = getHeaderProps();
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
+  // Per W3C guidance, only the actively sorted header should expose aria-sort.
   let ariaSort: React.AriaAttributes['aria-sort'];
   if (isSorted) {
     ariaSort = isSortedDesc ? 'descending' : 'ascending';

--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -50,7 +50,7 @@ function TableHeaderCell({
 }: TableHeaderCellProps) {
   const headerProps = getHeaderProps();
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
-  // Per W3C guidance, only the actively sorted header should expose aria-sort.
+  // Per WAI-ARIA APG sortable table guidance, only the actively sorted header should expose aria-sort.
   let ariaSort: React.AriaAttributes['aria-sort'];
   if (isSorted) {
     ariaSort = isSortedDesc ? 'descending' : 'ascending';

--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -49,9 +49,10 @@ function TableHeaderCell({
   headerClassName,
 }: TableHeaderCellProps) {
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
-  const ariaSort: React.AriaAttributes['aria-sort'] = isSorted
-    ? (isSortedDesc ? 'descending' : 'ascending')
-    : undefined;
+  let ariaSort: React.AriaAttributes['aria-sort'];
+  if (isSorted) {
+    ariaSort = isSortedDesc ? 'descending' : 'ascending';
+  }
   const headerContentClassName = classNames('pgn__data-table-header-content', headerClassName);
 
   return (

--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -48,6 +48,7 @@ function TableHeaderCell({
   isSortedDesc = false,
   headerClassName,
 }: TableHeaderCellProps) {
+  const headerProps = getHeaderProps();
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
   let ariaSort: React.AriaAttributes['aria-sort'];
   if (isSorted) {
@@ -56,7 +57,15 @@ function TableHeaderCell({
   const headerContentClassName = classNames('pgn__data-table-header-content', headerClassName);
 
   return (
-    <th {...getHeaderProps()} scope="col" aria-sort={ariaSort}>
+    <th
+      {...headerProps}
+      scope="col"
+      aria-sort={ariaSort}
+      className={classNames(
+        headerProps.className,
+        { 'pgn__data-table-sortable-header': canSort },
+      )}
+    >
       {canSort ? (
         <button
           {...toggleProps}

--- a/src/DataTable/TableHeaderRow.jsx
+++ b/src/DataTable/TableHeaderRow.jsx
@@ -5,13 +5,21 @@ import TableHeaderCell from './TableHeaderCell';
 function TableHeaderRow({ headerGroups }) {
   return (
     <thead>
-      {headerGroups.map(headerGroup => (
-        <tr {...headerGroup.getHeaderGroupProps()}>
-          {headerGroup.headers.map(column => (
-            <TableHeaderCell {...column} {...column.getHeaderProps()} />
-          ))}
-        </tr>
-      ))}
+      {headerGroups.map((headerGroup) => {
+        const { key: headerGroupKey, ...headerGroupProps } = headerGroup.getHeaderGroupProps();
+
+        return (
+          <tr key={headerGroupKey} {...headerGroupProps}>
+            {headerGroup.headers.map((column) => {
+              const { key: headerKey } = column.getHeaderProps();
+
+              return (
+                <TableHeaderCell key={headerKey} {...column} />
+              );
+            })}
+          </tr>
+        );
+      })}
     </thead>
   );
 }
@@ -19,10 +27,10 @@ function TableHeaderRow({ headerGroups }) {
 TableHeaderRow.propTypes = {
   headerGroups: PropTypes.arrayOf(PropTypes.shape({
     headers: PropTypes.arrayOf(PropTypes.shape({
-      /** Props for the TableHeaderCell component. Must include a key */
+      /** Props for the TableHeaderCell component. Must include a React key */
       getHeaderProps: PropTypes.func.isRequired,
     })).isRequired,
-    /** Returns props for the header tr element */
+    /** Returns props for the header tr element. Must include a React key */
     getHeaderGroupProps: PropTypes.func.isRequired,
   })).isRequired,
 };

--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -147,6 +147,7 @@
     padding: var(--pgn-spacing-data-table-padding-cell);
     text-align: start;
 
+    // The button owns sortable header padding so the full visible header remains the sort hit target.
     &.pgn__data-table-sortable-header {
       padding: 0;
     }

--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -150,6 +150,7 @@
     // The button owns sortable header padding so the full visible header remains the sort hit target.
     &.pgn__data-table-sortable-header {
       padding: 0;
+      position: relative;
     }
   }
 
@@ -168,6 +169,13 @@
     text-align: inherit;
     width: 100%;
     box-sizing: border-box;
+
+    // Extend pointer hit testing to the full sortable th when row height is set by another header cell.
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
   }
 
   td {

--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -146,6 +146,10 @@
     background-color: var(--pgn-color-light-300);
     padding: var(--pgn-spacing-data-table-padding-cell);
     text-align: start;
+
+    &.pgn__data-table-sortable-header {
+      padding: 0;
+    }
   }
 
   .pgn__data-table-header-content {
@@ -159,9 +163,10 @@
     color: inherit;
     cursor: pointer;
     font: inherit;
-    padding: 0;
+    padding: var(--pgn-spacing-data-table-padding-cell);
     text-align: inherit;
     width: 100%;
+    box-sizing: border-box;
   }
 
   td {

--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -148,6 +148,22 @@
     text-align: start;
   }
 
+  .pgn__data-table-header-content {
+    display: flex;
+    align-items: center;
+  }
+
+  .pgn__data-table-sort-button {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
+    text-align: inherit;
+    width: 100%;
+  }
+
   td {
     padding: var(--pgn-spacing-data-table-padding-cell);
     line-height: 24px;

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render, screen, waitFor, within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as reactTable from 'react-table';
 import { IntlProvider } from 'react-intl';
@@ -143,6 +145,36 @@ describe('<DataTable />', () => {
     render(<DataTableWrapper {...props} />);
     expect(screen.getAllByRole('columnheader')).toHaveLength(props.columns.length);
     expect(screen.getAllByRole('row')).toHaveLength(props.data.length + 1); // (need + 1 to include header row)
+  });
+
+  it('sorts rows when activating a sortable header button', async () => {
+    const getNameColumnValues = () => screen.getAllByRole('row')
+      .slice(1)
+      .map(row => within(row).getAllByRole('cell')[0].textContent);
+
+    render(<DataTableWrapper {...props} isSortable />);
+
+    expect(getNameColumnValues()).toEqual([
+      'Lil Bub',
+      'Grumpy Cat',
+      'Smoothie',
+      'Maru',
+      'Keyboard Cat',
+      'Long Cat',
+      'Zeno',
+    ]);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+
+    await waitFor(() => expect(getNameColumnValues()).toEqual([
+      'Grumpy Cat',
+      'Keyboard Cat',
+      'Lil Bub',
+      'Long Cat',
+      'Maru',
+      'Smoothie',
+      'Zeno',
+    ]));
   });
 
   it('displays a table footer', () => {

--- a/src/DataTable/tests/TableHeaderCell.test.jsx
+++ b/src/DataTable/tests/TableHeaderCell.test.jsx
@@ -90,6 +90,13 @@ describe('<TableHeaderCell />', () => {
       expect(button).toHaveClass('pgn__data-table-sort-button');
     });
 
+    it('adds headerClassName to sortable header content', () => {
+      render(<FakeTable {...props} canSort />);
+      const button = screen.getByRole('button', { name: 'Title' });
+      expect(button).not.toHaveClass(props.headerClassName);
+      expect(button.firstChild).toHaveClass(props.headerClassName);
+    });
+
     it('adds ascending sort state to the header cell when sorted ascending', () => {
       render(<FakeTable {...props} canSort isSorted />);
       const cell = screen.getByRole('columnheader');

--- a/src/DataTable/tests/TableHeaderCell.test.jsx
+++ b/src/DataTable/tests/TableHeaderCell.test.jsx
@@ -50,6 +50,12 @@ describe('<TableHeaderCell />', () => {
       render(<FakeTable {...props} />);
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
+
+    it('does not add sortable header styling to non-sortable headers', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).not.toHaveClass('pgn__data-table-sortable-header');
+    });
   });
 
   describe('with sorting', () => {
@@ -74,6 +80,14 @@ describe('<TableHeaderCell />', () => {
     it('renders the sort toggle as a button', () => {
       render(<FakeTable {...props} canSort />);
       expect(screen.getByRole('button', { name: 'Title' })).toBeInTheDocument();
+    });
+
+    it('adds sortable header styling to preserve the sort button hit target', () => {
+      render(<FakeTable {...props} canSort />);
+      const cell = screen.getByRole('columnheader');
+      const button = screen.getByRole('button', { name: 'Title' });
+      expect(cell).toHaveClass('pgn__data-table-sortable-header');
+      expect(button).toHaveClass('pgn__data-table-sort-button');
     });
 
     it('adds ascending sort state to the header cell when sorted ascending', () => {

--- a/src/DataTable/tests/TableHeaderCell.test.jsx
+++ b/src/DataTable/tests/TableHeaderCell.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import TableHeaderCell from '../TableHeaderCell';
 
-const sortByToggleProps = { foo: 'bar' };
+const sortByToggleProps = { 'data-sort-prop': 'bar' };
 const props = {
   getHeaderProps: () => ({ className: 'red' }),
   render: () => 'Title',
@@ -20,20 +21,34 @@ function FakeTable({ ...rest }) {
 
 describe('<TableHeaderCell />', () => {
   describe('unsorted', () => {
-    render(<FakeTable {...props} />);
-    const cell = screen.getByRole('columnheader');
-    const innerCell = cell.firstChild;
-
     it('renders a table header cell', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
       expect(cell).toBeInTheDocument();
     });
 
     it('adds props to the cell', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
       expect(cell.className).toBe('red');
     });
 
+    it('adds column scope to the cell', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveAttribute('scope', 'col');
+    });
+
     it('adds the headerClassName to inner span', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
+      const innerCell = cell.firstChild;
       expect(innerCell.className).toContain(props.headerClassName);
+    });
+
+    it('does not render a button for non-sortable headers', () => {
+      render(<FakeTable {...props} />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
   });
 
@@ -56,10 +71,55 @@ describe('<TableHeaderCell />', () => {
       expect(sortIndicator).toBeInTheDocument();
     });
 
-    it('adds the toggle props to the header props if toggle props are available', () => {
+    it('renders the sort toggle as a button', () => {
+      render(<FakeTable {...props} canSort />);
+      expect(screen.getByRole('button', { name: 'Title' })).toBeInTheDocument();
+    });
+
+    it('adds ascending sort state to the header cell when sorted ascending', () => {
+      render(<FakeTable {...props} canSort isSorted />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('adds descending sort state to the header cell when sorted descending', () => {
+      render(<FakeTable {...props} canSort isSorted isSortedDesc />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('does not add inactive sort state to unsorted header cells', () => {
+      render(<FakeTable {...props} canSort />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).not.toHaveAttribute('aria-sort');
+    });
+
+    it('adds the toggle props to the sort button if toggle props are available', () => {
+      render(<FakeTable {...props} canSort />);
+      const button = screen.getByRole('button', { name: 'Title' });
+      expect(button).toHaveAttribute('data-sort-prop', sortByToggleProps['data-sort-prop']);
+    });
+
+    it('does not pass toggle props to the header props', () => {
       const headerPropsSpy = jest.fn().mockReturnValueOnce({});
       render(<FakeTable {...props} canSort getHeaderProps={headerPropsSpy} />);
-      expect(headerPropsSpy).toHaveBeenCalledWith(sortByToggleProps);
+      expect(headerPropsSpy).toHaveBeenCalledWith();
+    });
+
+    it('makes sortable headers keyboard reachable and operable', async () => {
+      const user = userEvent.setup();
+      const handleSort = jest.fn();
+      render(<FakeTable {...props} canSort getSortByToggleProps={() => ({ onClick: handleSort })} />);
+      const button = screen.getByRole('button', { name: 'Title' });
+
+      await user.tab();
+      expect(button).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+      expect(handleSort).toHaveBeenCalledTimes(1);
+
+      await user.keyboard(' ');
+      expect(handleSort).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/DataTable/tests/TableHeaderRow.test.jsx
+++ b/src/DataTable/tests/TableHeaderRow.test.jsx
@@ -31,24 +31,51 @@ const props = {
   }],
 };
 
-describe('<TableHeaderRow />', () => {
+function renderTableHeaderRow() {
   render(<table><TableHeaderRow {...props} /></table>);
-  const head = screen.getByRole('rowgroup');
-  const row = screen.getByRole('row');
-  const cells = screen.getAllByRole('columnheader');
+}
 
+describe('<TableHeaderRow />', () => {
   it('renders a table head and row', () => {
+    renderTableHeaderRow();
+
+    const head = screen.getByRole('rowgroup');
+    const row = screen.getByRole('row');
+
     expect(head).toBeInTheDocument();
     expect(row).toBeInTheDocument();
   });
 
   it('adds props to the row', () => {
+    renderTableHeaderRow();
+
+    const row = screen.getByRole('row');
+
     expect(row.className).toEqual('red');
   });
 
   it('renders cells', () => {
+    renderTableHeaderRow();
+
+    const cells = screen.getAllByRole('columnheader');
+
     expect(cells.length).toEqual(2);
     expect(cells[0]).toHaveTextContent(header1Name);
     expect(cells[1]).toHaveTextContent(header2Name);
+  });
+
+  it('does not spread React keys from react-table prop getters', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      renderTableHeaderRow();
+
+      const keySpreadWarning = consoleError.mock.calls.some(([message]) => (
+        String(message).includes('A props object containing a "key" prop')
+      ));
+      expect(keySpreadWarning).toEqual(false);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
**Note: this draft PR was closed and replaced with a more tightly scoped https://github.com/openedx/paragon/pull/4345**. That implementation removes the React key cleanup.
## Description

This PR improves DataTable sortable header accessibility without changing the public DataTable API.

It addresses three header behavior gaps:

* **Sort state:** sortable headers had visual affordances, but active sort state was not exposed programmatically. Sorted headers now set `aria-sort="ascending"` or `aria-sort="descending"`; inactive/unsorted headers omit `aria-sort`.
* **Keyboard operation:** sort behavior was attached to the `<th>`, so sortable headers were not reachable by Tab. Sortable headers now render a native button inside the existing `<th>`, with React Table sort toggle props on the button for native Tab, Enter, and Space behavior.
* **Column scope:** DataTable header cells did not explicitly declare column scope. `TableHeaderCell` now renders `scope="col"`.

Supporting changes:

* Add scoped DataTable header-content, sortable-header, and sort-button classes so the new native button matches the previous header layout and hit target without Bootstrap utility classes or token overrides.
* Add focused tests for sort state, header scope, sortable button rendering, toggle prop placement, Tab focus, Enter activation, Space activation, real DataTable sorting through the sortable header button, and header-path key handling.

Opportunistic change:
* Clean up React key handling in the DataTable header

### In Scope

* Expose active sort state with `aria-sort` on the sorted header cell.
* Make sortable headers keyboard reachable and operable with native header buttons.
* Make DataTable header scope explicit with `scope="col"`.

### Out of Scope / Future Work

* Table caption, table identity, or shared sortable-header instruction API.
* Pre-existing React `defaultProps` warnings and DataTable row/cell `key`-spread warnings. The header path touched by this PR is cleaned up; remaining warnings existed before this a11y change and should be handled separately.

### Reviewer Notes / Decisions

* `aria-sort` is intentionally set only on the active sorted header cell. Inactive sortable headers omit `aria-sort`, following W3C/APG guidance that the attribute is set on the currently sorted column and moved when sorting changes.
* Sortable headers use a native button instead of adding keyboard handling to the `<th>`. This follows the APG sortable-table pattern and keeps keyboard behavior native.
* Non-sortable headers remain not buttons.
* `scope="col"` is applied to all `TableHeaderCell` `<th>` elements because this component owns DataTable column-header markup.
* React Table header prop getters may return React `key` values. This PR strips those keys out before spreading header prop objects in the touched header path. The list keys are applied at the header group/header cell map boundaries; remaining row/cell key-spread warnings are separate existing DataTable cleanup.

### Verification

* `npm test -- --runTestsByPath src/DataTable/tests/TableHeaderCell.test.jsx --coverage=false` passed.
* `npm test -- --runTestsByPath src/DataTable/tests/Table.test.jsx --coverage=false` passed.
* `npm test -- --runTestsByPath src/DataTable/tests/DataTable.test.jsx --coverage=false` passed.
* `npm test -- --runTestsByPath src/DataTable/tests/TableHeaderRow.test.jsx --coverage=false` passed.
* `npm test -- --runTestsByPath src/DataTable/tests/TableHeaderCell.test.jsx src/DataTable/tests/DataTable.test.jsx --coverage=false` passed.
* `npm test -- --runTestsByPath src/DataTable/tests/TableHeaderRow.test.jsx src/DataTable/tests/TableHeaderCell.test.jsx src/DataTable/tests/DataTable.test.jsx --coverage=false` passed.
* `npm run lint` passed.
* `git diff --check` passed.
* Local Gatsby docs page verification passed at `/components/datatable/`:
  * Visual: header layout, sort icons, alignment, and focus treatment remained acceptable.
  * Keyboard: Tab reached sortable header buttons; Enter and Space toggled sorting; non-sortable headers were skipped.
  * DOM: `scope="col"` appeared on `<th>`; active sorted headers exposed `aria-sort`; unsorted headers omitted `aria-sort`; sortable headers rendered `button type="button"`.

### Deploy Preview
https://deploy-preview-4340--paragon-openedx-v23.netlify.app/components/datatable/

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
  * No intended visual change; local docs visual check passed. Netlify deploy preview review is pending.
* [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
  * Added scoped `pgn__` DataTable classes under the existing `.pgn__data-table` styles; the new CSS does not reference primitive tokens and uses inheritance for button font, color, and text alignment.
* [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
  * No public props or API surface were added.
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
  * Local docs verification passed; all-theme Netlify preview check is pending.
* [ ] Were your changes tested in the `example` app?
  * Not run. DataTable docs were used for local visual, keyboard, and DOM verification.
* [x] Is there adequate test coverage for your changes?
  * Focused `TableHeaderCell` tests were added/updated and targeted DataTable tests passed.
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.
  * A11y review is recommended because this changes table header semantics and keyboard behavior.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] Celebrate! Thanks for your contribution.

## AI Disclosure
Codex was used to help diagnose the issue, catalog the current behavior, suggest an implementation shape, execute the fix, and generate the framework for the PR text based on Open edX guidances in the docs. Each step required manual review.
