### PR TITLE
fix(datatable): improve sortable header accessibility

### DIFF
--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -35,6 +35,8 @@ interface TableHeaderCellProps {
   getSortByToggleProps?: (...args: any[]) => Record<string, any>;
   /** Indicates whether a column is sortable */
   canSort?: boolean;
+  /** Indicates the column's sort priority */
+  sortedIndex?: number;
   /** Class(es) to be applied to header cells */
   headerClassName?: string;
 }
@@ -46,13 +48,14 @@ function TableHeaderCell({
   getSortByToggleProps = () => ({}),
   isSorted = false,
   isSortedDesc = false,
+  sortedIndex = 0,
   headerClassName,
 }: TableHeaderCellProps) {
   const headerProps = getHeaderProps();
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
   // Per WAI-ARIA APG sortable table guidance, only the actively sorted header should expose aria-sort.
   let ariaSort: React.AriaAttributes['aria-sort'];
-  if (isSorted) {
+  if (isSorted && sortedIndex === 0) {
     ariaSort = isSortedDesc ? 'descending' : 'ascending';
   }
   const headerContentClassName = classNames('pgn__data-table-header-content', headerClassName);

--- a/src/DataTable/TableHeaderCell.tsx
+++ b/src/DataTable/TableHeaderCell.tsx
@@ -31,7 +31,7 @@ interface TableHeaderCellProps {
   render: (type: 'Header') => React.ReactNode;
   /** Indicates whether the column is sorted in descending order */
   isSortedDesc?: boolean;
-  /** Gets props related to sorting that will be passed to th */
+  /** Gets props related to sorting that will be passed to the sort button */
   getSortByToggleProps?: (...args: any[]) => Record<string, any>;
   /** Indicates whether a column is sortable */
   canSort?: boolean;
@@ -48,14 +48,44 @@ function TableHeaderCell({
   isSortedDesc = false,
   headerClassName,
 }: TableHeaderCellProps) {
+  const headerProps = getHeaderProps();
   const toggleProps = canSort && getSortByToggleProps ? getSortByToggleProps() : {};
+  // Per WAI-ARIA APG sortable table guidance, only the actively sorted header should expose aria-sort.
+  let ariaSort: React.AriaAttributes['aria-sort'];
+  if (isSorted) {
+    ariaSort = isSortedDesc ? 'descending' : 'ascending';
+  }
+  const headerContentClassName = classNames('pgn__data-table-header-content', headerClassName);
 
   return (
-    <th {...getHeaderProps(toggleProps)}>
-      <span className={classNames('d-flex align-items-center', headerClassName)}>
-        <span>{render('Header')}</span>
-        {canSort && <SortIndicator isSorted={isSorted} isSortedDesc={isSortedDesc || false} />}
-      </span>
+    <th
+      {...headerProps}
+      scope="col"
+      aria-sort={ariaSort}
+      className={classNames(
+        headerProps.className,
+        { 'pgn__data-table-sortable-header': canSort },
+      )}
+    >
+      {canSort ? (
+        <button
+          {...toggleProps}
+          type="button"
+          className={classNames(
+            'pgn__data-table-sort-button',
+            toggleProps.className,
+          )}
+        >
+          <span className={headerContentClassName}>
+            <span>{render('Header')}</span>
+            <SortIndicator isSorted={isSorted} isSortedDesc={isSortedDesc || false} />
+          </span>
+        </button>
+      ) : (
+        <span className={headerContentClassName}>
+          <span>{render('Header')}</span>
+        </span>
+      )}
     </th>
   );
 }

--- a/src/DataTable/index.scss
+++ b/src/DataTable/index.scss
@@ -146,6 +146,36 @@
     background-color: var(--pgn-color-light-300);
     padding: var(--pgn-spacing-data-table-padding-cell);
     text-align: start;
+
+    // The button owns sortable header padding so the full visible header remains the sort hit target.
+    &.pgn__data-table-sortable-header {
+      padding: 0;
+      position: relative;
+    }
+  }
+
+  .pgn__data-table-header-content {
+    display: flex;
+    align-items: center;
+  }
+
+  .pgn__data-table-sort-button {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    padding: var(--pgn-spacing-data-table-padding-cell);
+    text-align: inherit;
+    width: 100%;
+    box-sizing: border-box;
+
+    // Extend pointer hit testing to the full sortable th when row height is set by another header cell.
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
   }
 
   td {

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render, screen, waitFor, within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as reactTable from 'react-table';
 import { IntlProvider } from 'react-intl';
@@ -143,6 +145,36 @@ describe('<DataTable />', () => {
     render(<DataTableWrapper {...props} />);
     expect(screen.getAllByRole('columnheader')).toHaveLength(props.columns.length);
     expect(screen.getAllByRole('row')).toHaveLength(props.data.length + 1); // (need + 1 to include header row)
+  });
+
+  it('sorts rows when activating a sortable header button', async () => {
+    const getNameColumnValues = () => screen.getAllByRole('row')
+      .slice(1)
+      .map(row => within(row).getAllByRole('cell')[0].textContent);
+
+    render(<DataTableWrapper {...props} isSortable />);
+
+    expect(getNameColumnValues()).toEqual([
+      'Lil Bub',
+      'Grumpy Cat',
+      'Smoothie',
+      'Maru',
+      'Keyboard Cat',
+      'Long Cat',
+      'Zeno',
+    ]);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+
+    await waitFor(() => expect(getNameColumnValues()).toEqual([
+      'Grumpy Cat',
+      'Keyboard Cat',
+      'Lil Bub',
+      'Long Cat',
+      'Maru',
+      'Smoothie',
+      'Zeno',
+    ]));
   });
 
   it('displays a table footer', () => {

--- a/src/DataTable/tests/DataTable.test.jsx
+++ b/src/DataTable/tests/DataTable.test.jsx
@@ -177,6 +177,23 @@ describe('<DataTable />', () => {
     ]));
   });
 
+  it('only sets aria-sort on the primary sorted header when multi-sorting', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<DataTableWrapper {...props} isSortable />);
+
+    await user.click(screen.getByRole('button', { name: 'Name' }));
+    await user.keyboard('{Shift>}');
+    await user.click(screen.getByRole('button', { name: 'Famous For' }));
+    await user.keyboard('{/Shift}');
+
+    const nameHeader = screen.getByRole('button', { name: 'Name' }).closest('th');
+    const famousForHeader = screen.getByRole('button', { name: 'Famous For' }).closest('th');
+
+    await waitFor(() => expect(container.querySelectorAll('th[aria-sort]')).toHaveLength(1));
+    expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+    expect(famousForHeader).not.toHaveAttribute('aria-sort');
+  });
+
   it('displays a table footer', () => {
     render(<DataTableWrapper {...props} />);
     expect(screen.getByTestId('table-footer')).toBeInTheDocument();

--- a/src/DataTable/tests/TableHeaderCell.test.jsx
+++ b/src/DataTable/tests/TableHeaderCell.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import TableHeaderCell from '../TableHeaderCell';
 
-const sortByToggleProps = { foo: 'bar' };
+const sortByToggleProps = { 'data-sort-prop': 'bar' };
 const props = {
   getHeaderProps: () => ({ className: 'red' }),
   render: () => 'Title',
@@ -20,20 +21,40 @@ function FakeTable({ ...rest }) {
 
 describe('<TableHeaderCell />', () => {
   describe('unsorted', () => {
-    render(<FakeTable {...props} />);
-    const cell = screen.getByRole('columnheader');
-    const innerCell = cell.firstChild;
-
     it('renders a table header cell', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
       expect(cell).toBeInTheDocument();
     });
 
     it('adds props to the cell', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
       expect(cell.className).toBe('red');
     });
 
+    it('adds column scope to the cell', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveAttribute('scope', 'col');
+    });
+
     it('adds the headerClassName to inner span', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
+      const innerCell = cell.firstChild;
       expect(innerCell.className).toContain(props.headerClassName);
+    });
+
+    it('does not render a button for non-sortable headers', () => {
+      render(<FakeTable {...props} />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('does not add sortable header styling to non-sortable headers', () => {
+      render(<FakeTable {...props} />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).not.toHaveClass('pgn__data-table-sortable-header');
     });
   });
 
@@ -56,10 +77,70 @@ describe('<TableHeaderCell />', () => {
       expect(sortIndicator).toBeInTheDocument();
     });
 
-    it('adds the toggle props to the header props if toggle props are available', () => {
+    it('renders the sort toggle as a button', () => {
+      render(<FakeTable {...props} canSort />);
+      expect(screen.getByRole('button', { name: 'Title' })).toBeInTheDocument();
+    });
+
+    it('adds sortable header styling to preserve the sort button hit target', () => {
+      render(<FakeTable {...props} canSort />);
+      const cell = screen.getByRole('columnheader');
+      const button = screen.getByRole('button', { name: 'Title' });
+      expect(cell).toHaveClass('pgn__data-table-sortable-header');
+      expect(button).toHaveClass('pgn__data-table-sort-button');
+    });
+
+    it('adds headerClassName to sortable header content', () => {
+      render(<FakeTable {...props} canSort />);
+      const button = screen.getByRole('button', { name: 'Title' });
+      expect(button).not.toHaveClass(props.headerClassName);
+      expect(button.firstChild).toHaveClass(props.headerClassName);
+    });
+
+    it('adds ascending sort state to the header cell when sorted ascending', () => {
+      render(<FakeTable {...props} canSort isSorted />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('adds descending sort state to the header cell when sorted descending', () => {
+      render(<FakeTable {...props} canSort isSorted isSortedDesc />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('does not add inactive sort state to unsorted header cells', () => {
+      render(<FakeTable {...props} canSort />);
+      const cell = screen.getByRole('columnheader');
+      expect(cell).not.toHaveAttribute('aria-sort');
+    });
+
+    it('adds the toggle props to the sort button if toggle props are available', () => {
+      render(<FakeTable {...props} canSort />);
+      const button = screen.getByRole('button', { name: 'Title' });
+      expect(button).toHaveAttribute('data-sort-prop', sortByToggleProps['data-sort-prop']);
+    });
+
+    it('does not pass toggle props to the header props', () => {
       const headerPropsSpy = jest.fn().mockReturnValueOnce({});
       render(<FakeTable {...props} canSort getHeaderProps={headerPropsSpy} />);
-      expect(headerPropsSpy).toHaveBeenCalledWith(sortByToggleProps);
+      expect(headerPropsSpy).toHaveBeenCalledWith();
+    });
+
+    it('makes sortable headers keyboard reachable and operable', async () => {
+      const user = userEvent.setup();
+      const handleSort = jest.fn();
+      render(<FakeTable {...props} canSort getSortByToggleProps={() => ({ onClick: handleSort })} />);
+      const button = screen.getByRole('button', { name: 'Title' });
+
+      await user.tab();
+      expect(button).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+      expect(handleSort).toHaveBeenCalledTimes(1);
+
+      await user.keyboard(' ');
+      expect(handleSort).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Description

This PR improves DataTable sortable header accessibility.

Keyboard operation; Sortable headers now render a native button inside the existing `<th>`, with React Table sort toggle props on the button. This makes sortable headers reachable with Tab and operable with Enter and Space.

Sort state: Sorted headers now expose sort direction with `aria-sort` on the primary sorted header only. Inactive sortable headers and secondary multi-sort headers omit `aria-sort`.

Column scope declaration: DataTable header cells also render `scope="col"`, and scoped DataTable styles keep the sort button aligned with the existing header layout and click target.

### Out of Scope

- Table captions, table labels, and explanatory text for sortable columns.
- The test output includes a pre-existing React warning about spreading a key prop. DataTable uses helpers that  return key with other props; React wants key passed as its own JSX attribute. This PR does not change the existing pattern because fixing would increase the scope to touch header, row, and cell code throughout DataTable. I think cleaning up the key warning belongs in a separate PR; this PR is scoped to just the a11y fixes.
- The tests also show pre-existing React defaultProps warnings. These are not introduced by this PR and are out of scope.

## Change Log

- Render sortable DataTable headers as native buttons.
- Move React Table sort toggle props from the `<th>` to the sort button.
- Add `aria-sort` for the primary sorted column and omit it for inactive or secondary sorted columns.
- Add `scope="col"` to DataTable header cells.
- Add DataTable styles for sortable header button layout and click area.
- Add tests for sort state, column scope, sortable button behavior, keyboard operation, DataTable sorting, and multi-sort `aria-sort` behavior.

## Notes

- Visual sort indicators still render for sorted columns, including secondary multi-sort columns. Only the primary sorted column exposes `aria-sort`.
- The React `key` spread warning is existing behavior from React Table prop getters and is unchanged by this PR.
- Accessibility review is recommended because this changes table header semantics and keyboard behavior.

## Tests Done

- `npm test -- --runTestsByPath src/DataTable/tests/DataTable.test.jsx src/DataTable/tests/TableHeaderCell.test.jsx --coverage=false`
- `git diff --check`

### Deploy Preview

https://deploy-preview-4345--paragon-openedx-v23.netlify.app/components/datatable/#frontend-filtering-and-sorting

## Merge Checklist

- [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
  - No intended visual change; Netlify deploy preview review is pending.
- [x] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
  - Added scoped `pgn__` DataTable classes under the existing `.pgn__data-table` styles.
- [x] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
  - No documented public props were added.
- [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
  - Not run.
- [ ] Were your changes tested in the `example` app?
  - Not run.
- [x] Is there adequate test coverage for your changes?
  - Focused `TableHeaderCell` tests and DataTable regression tests cover the changed behavior.
- [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.
  - Accessibility review is recommended because this changes table header semantics and keyboard behavior.

## Post-merge Checklist

- [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
- [ ] If useful, share the contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).

## AI Assistance

AI tools were used to aid in diagnosis, planning, implementation, and review. All work was checked and reviewed.
