### PR TITLE
fix(www): load default brand theme from v1 of brand package

### DIFF
--- a/www/src/utils/themeUtils.ts
+++ b/www/src/utils/themeUtils.ts
@@ -3,8 +3,8 @@ import { type Theme, type ThemeConfig, type ThemeWithUrls } from '../types/types
 export const DEFAULT_THEME: ThemeConfig = {
   name: 'Open edX (Default)',
   urls: [
-    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/core.min.css',
-    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@2/dist/light.min.css',
+    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@1/dist/core.min.css',
+    'https://cdn.jsdelivr.net/npm/@openedx/brand-openedx@1/dist/light.min.css',
   ],
   isDefault: true,
 };


### PR DESCRIPTION
## Description

Points the docs site's default theme at **v1** of `@openedx/brand-openedx` instead of v2.

The frontend-apps reverted to v1 of the brand package (see [openedx/frontend-app-learning#1906](https://github.com/openedx/frontend-app-learning/pull/1906)), so the docs site should match to stay visually consistent with what the apps actually render.

v1.3.0 ships the same `dist/core.min.css` + `dist/light.min.css` paths as v2, so this is a straight version-specifier swap with no other changes needed.

## Notes

This came up while debugging why deploy previews appeared to load nothing from `useCustomThemes.ts` — that turned out to be unrelated (stale PR branches predating #4236). This change is purely about which brand-package version the default theme loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)