### PR TITLE
feat: enable compatibility with react-intl v10.1.20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use `paragon help` to see more information.
 
 ## Internationalization
 
-Paragon supports internationalization for its components out of the box with the support of [react-intl](https://formatjs.io/docs/react-intl/). You may view translated strings for each component on the documentation website by switching languages in the settings.
+Paragon supports internationalization for its components out of the box with the support of [react-intl](https://formatjs.io/docs/react-intl/). ``react-intl`` 5.x, 6.x, or 10.1.20+ may be used. You may view translated strings for each component on the documentation website by switching languages in the settings.
 
 Due to Paragon's dependence on ``react-intl``, that means that your whole app needs to be wrapped in its provider, e.g.:
 
@@ -265,59 +265,30 @@ When developing a new component you should generally follow three rules:
       />
       ```
 
-   - For places where the display string has to be a plain JavaScript string use ``formatMessage``, this would require access to ``intl`` object from ``react-intl``, e.g.
+   - For places where the display string has to be a plain JavaScript string use ``formatMessage``, this would require access to ``intl`` object from ``react-intl``, which is provided by the ``useIntl`` hook (the ``injectIntl`` HOC must not be used, as it was removed in ``react-intl`` 10)
 
-      - For class components use ``injectIntl`` HOC
+      ```javascript
+      import { useIntl } from 'react-intl';
 
-          ```javascript
-          import { injectIntl } from 'react-intl';
+      const MyFunctionComponent = ({ altText }) => {
+        const intl = useIntl();
+        const intlAltText = altText || intl.formatMessage({
+          id: 'pgn.MyComponent.altText',
+          defaultMessage: 'Close',
+          description: 'Close label for Toast component',
+        });
 
-          class MyClassComponent extends React.Component {
-            render() {
-              const { altText, intl } = this.props;
-              const intlAltText = altText || intl.formatMessage({
-                id: 'pgn.MyComponent.altText',
-                defaultMessage: 'Close',
-                description: 'Close label for Toast component',
-              });
+        return (
+          <IconButton
+            alt={intlAltText}
+            onClick={() => {}}
+            variant="primary"
+          />
+        )
+      }
 
-              return (
-                <IconButton
-                  alt={intlCloseLabel}
-                  onClick={() => {}}
-                  variant="primary"
-                />
-              )
-            }
-          }
-
-          export default injectIntl(MyClassComponent);
-          ```
-
-      - For functional components use ``useIntl`` hook
-
-          ```javascript
-          import { useIntl } from 'react-intl';
-
-          const MyFunctionComponent = ({ altText }) => {
-            const intls = useIntl();
-            const intlAltText = altText || intl.formatMessage({
-              id: 'pgn.MyComponent.altText',
-              defaultMessage: 'Close',
-              description: 'Close label for Toast component',
-            });
-
-            return (
-              <IconButton
-                alt={intlCloseLabel}
-                onClick={() => {}}
-                variant="primary"
-              />
-            )
-          }
-
-          export default MyFunctionComponent;
-          ```
+      export default MyFunctionComponent;
+      ```
 
    **Notes on the format above**:
    - `id` is required and must be a dot-separated string of the format `pgn.<componentName>.<subcomponentName>.<propName>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "markdown-loader-jest": "^0.1.1",
         "react": "^18",
+        "react-intl": "^10.1.20",
         "react-test-renderer": "^18",
         "regenerator-runtime": "^0.14.0",
         "semantic-release": "^25.0.0",
@@ -118,7 +119,7 @@
       "peerDependencies": {
         "react": "^16.8.6 || ^17 || ^18",
         "react-dom": "^16.8.6 || ^17 || ^18",
-        "react-intl": "^5.25.1 || ^6.4.0"
+        "react-intl": "^5.25.1 || ^6.4.0 || ^10.1.20"
       }
     },
     "component-generator": {
@@ -220,6 +221,47 @@
         }
       }
     },
+    "example/node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
+      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/intl-localematcher": "0.5.8",
+        "tslib": "2"
+      }
+    },
+    "example/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
+      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-skeleton-parser": "1.8.8",
+        "tslib": "2"
+      }
+    },
+    "example/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
+      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "tslib": "2"
+      }
+    },
+    "example/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
+      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
     "example/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -266,6 +308,33 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
+      }
+    },
+    "example/node_modules/react-intl": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
+      "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "@formatjs/intl": "2.10.15",
+        "@formatjs/intl-displaynames": "6.8.5",
+        "@formatjs/intl-listformat": "7.7.5",
+        "@types/hoist-non-react-statics": "3",
+        "@types/react": "16 || 17 || 18",
+        "hoist-non-react-statics": "3",
+        "intl-messageformat": "10.7.7",
+        "tslib": "2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || 17 || 18",
+        "typescript": "^4.7 || 5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "example/node_modules/react-redux": {
@@ -38941,71 +39010,60 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
-      "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "version": "10.1.20",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-10.1.20.tgz",
+      "integrity": "sha512-dvD9F7CqjlB/cIWakFzScGVPDmhWk34cFWY0etWuVNc07Zmc56OKjQwqu9q74evbttSto5wFXchZtvdRXy/Tkg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl": "2.10.15",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "@types/hoist-non-react-statics": "3",
-        "@types/react": "16 || 17 || 18",
-        "hoist-non-react-statics": "3",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
+        "@formatjs/icu-messageformat-parser": "3.5.16",
+        "@formatjs/intl": "4.1.18",
+        "intl-messageformat": "11.2.13"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || 17 || 18",
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
       }
     },
-    "node_modules/react-intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
+    "node_modules/react-intl/node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.16.tgz",
+      "integrity": "sha512-kl6b/4D56gjGZi4ZewSmvXbalHwjOUI5ogEHPZqw42goeXTTrL7/yuPzvdrvr0QigDtvaOeb+UeMf62jks43Yg==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
+    },
+    "node_modules/react-intl/node_modules/@formatjs/intl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.18.tgz",
+      "integrity": "sha512-d+AFsn+luyMAUTQImPJEK76bhEvzFKRG/1PCf1Q6sCH3ojHyHgJJkfvUFElpbDkihtm4uedK7/zoG24EL285nw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.16",
+        "intl-messageformat": "11.2.13"
       }
     },
-    "node_modules/react-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
+    "node_modules/react-intl/node_modules/intl-messageformat": {
+      "version": "11.2.13",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.13.tgz",
+      "integrity": "sha512-JaPaE6TIX+TAS5XLhDUh41geLw4QfBHX4s5pW8Km+L9fVC8HzB9yOuhbh4EMR/F1+8C6b9qk4763Cv+LdOG1kg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.16"
       }
     },
     "node_modules/react-is": {
@@ -48835,7 +48893,7 @@
         "react-focus-on": "^3.6.0",
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.58.1",
-        "react-intl": "^6.4",
+        "react-intl": "^10.1.20",
         "react-live": "^2.4.1",
         "react-markdown": "^9.0.1",
         "rehype-autolink-headings": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "peerDependencies": {
     "react": "^16.8.6 || ^17 || ^18",
     "react-dom": "^16.8.6 || ^17 || ^18",
-    "react-intl": "^5.25.1 || ^6.4.0"
+    "react-intl": "^5.25.1 || ^6.4.0 || ^10.1.20"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",
@@ -156,6 +156,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "markdown-loader-jest": "^0.1.1",
     "react": "^18",
+    "react-intl": "^10.1.20",
     "react-test-renderer": "^18",
     "regenerator-runtime": "^0.14.0",
     "semantic-release": "^25.0.0",
@@ -197,7 +198,7 @@
       "/component-generator/"
     ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!(@openedx/paragon)/).*/"
+      "/node_modules/(?!(@openedx/paragon|react-intl|@formatjs|intl-messageformat)/).*/"
     ]
   },
   "browserslist": [

--- a/www/package.json
+++ b/www/package.json
@@ -32,7 +32,7 @@
     "react-focus-on": "^3.6.0",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.58.1",
-    "react-intl": "^6.4",
+    "react-intl": "^10.1.20",
     "react-live": "^2.4.1",
     "react-markdown": "^9.0.1",
     "rehype-autolink-headings": "^5.1.0",


### PR DESCRIPTION
## Description

This makes Paragon compatible with `react-intl` **10.1.20+** in addition to the existing support for react-intl v5 and v6.

The main motivating factor is that [`react-intl` v5 and v6 declare an annoying dependency on `typescript` v4/v5](https://github.com/formatjs/formatjs/blob/10db1843ba2801270cfba7ea74552813f476ef4b/packages/react-intl/package.json#L148), and since Paragon requires v5 or v6, Paragon is blocking upgrades of TypeScript above v5.

Regarding the parts of the `react-intl` API that Paragon uses, there have been no major/breaking changes between v5 and v10, so compatibility is not much of an issue. The main change is that `injectIntl` is gone in `react-intl` v10, but Paragon was no longer using it anyways. MFEs that haven't finished removing `injectIntl` yet can continue to use react-intl v6 until they are upgraded.

### Other versions

`react-intl` v10 between v10.0.0 and v10.1.20 require React 19, so they're excluded, but v10.1.20+ support React 18.

`react-intl` v9 was broken and v7/v8 work at runtime but have `typescript` dependencies that prevent their installation in this repo. I don't think it's worth trying to support them.

### Deploy Preview

https://deploy-preview-4412--paragon-openedx-v23.netlify.app/

## Merge Checklist

n/a for this sort of PR.