### PR TITLE
fix: Use node's child_process, not abandoned npm package

### DIFF
--- a/component-generator/utils.js
+++ b/component-generator/utils.js
@@ -1,7 +1,7 @@
 const { InvalidOptionArgumentError } = require('commander');
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { exec } = require('node:child_process');
 require('dotenv').config();
 
 /**

--- a/generate-changelog.js
+++ b/generate-changelog.js
@@ -1,5 +1,5 @@
 const { program } = require('commander');
-const { execSync } = require('child_process');
+const { execSync } = require('node:child_process');
 const fs = require('fs');
 
 program

--- a/lib/__tests__/build-scss.test.js
+++ b/lib/__tests__/build-scss.test.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { spawn } = require('child_process');
+const { spawn } = require('node:child_process');
 const os = require('os');
 const sass = require('sass');
 

--- a/lib/__tests__/install-theme.test.js
+++ b/lib/__tests__/install-theme.test.js
@@ -1,10 +1,10 @@
 const inquirer = require('inquirer');
-const childProcess = require('child_process');
+const childProcess = require('node:child_process');
 
 const themeCommand = require('../install-theme');
 
 jest.mock('inquirer');
-jest.mock('child_process');
+jest.mock('node:child_process');
 
 describe('install-theme', () => {
   beforeEach(() => {

--- a/lib/install-theme.js
+++ b/lib/install-theme.js
@@ -1,5 +1,5 @@
 const inquirer = require('inquirer');
-const childProcess = require('child_process');
+const childProcess = require('node:child_process');
 
 /**
  * Prompts the user to enter the @edx/brand package they want to install.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "axios": "^1.0.0",
     "bootstrap": "^4.6.2",
     "chalk": "^4.1.2",
-    "child_process": "^1.0.2",
     "chroma-js": "^3.0.0",
     "classnames": "^2.3.1",
     "cli-progress": "^3.12.0",


### PR DESCRIPTION
## Description

Paragon currently declares a dependency on `child_process` v1.0.2, but that [npm package doesn't even exist anymore](https://www.npmjs.com/package/child_process) although NPM preserves the 10 year old version that we're using.

This PR changes Paragon CLI/build scripts to use Node's built-in `node:child_process` instead.

### Deploy Preview

Pending

## Merge Checklist

n/a for this type of PR